### PR TITLE
chore: simplify benchmark model CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,26 @@
-.PHONY: help sync dataset benchmark benchmark-agents view check clean-jobs clean
+.PHONY: help sync dataset benchmark benchmark-oracle benchmark-agents benchmark-model view check clean-jobs clean
 
-JOB_NAME ?= tempo-bench-local
+JOB_NAME ?= tempo-bench-model-local
+ORACLE_JOB_NAME ?= tempo-bench-oracle-local
 AGENT_JOB_NAME ?= tempo-bench-agents-local
+AGENT ?= claude-code
+MODEL ?= haiku
+TASK_FILTER ?=
+N_TASKS ?=
 TASKS ?= tasks
+MODEL_ARGS = $(if $(MODEL),--model '$(MODEL)',)
+TASK_FILTER_ARGS = $(if $(TASK_FILTER),--include-task-name '$(TASK_FILTER)',)
+N_TASKS_ARGS = $(if $(N_TASKS),--n-tasks $(N_TASKS),)
 
 help:
 	@printf '%s\n' \
 		'Targets:' \
 		'  make sync        Sync shared verifier/RewardKit/sidecar assets into tasks' \
 		'  make dataset     Refresh Harbor task digests' \
-		'  make benchmark   Run Harbor oracle benchmark (JOB_NAME=...)' \
+		'  make benchmark   Run one harness/model (AGENT=claude-code MODEL=haiku by default)' \
+		'  make benchmark-oracle Run Harbor oracle baseline (ORACLE_JOB_NAME=...)' \
 		'  make benchmark-agents Run Codex and Claude Code benchmark (AGENT_JOB_NAME=...)' \
+		'  make benchmark-model Alias for benchmark' \
 		'  make view        Open Harbor job viewer' \
 		'  make check       Syntax-check shared JS/Python and sync dataset' \
 		'  make clean-jobs  Remove local Harbor job outputs' \
@@ -23,10 +33,15 @@ dataset: sync
 	harbor sync $(TASKS)
 
 benchmark: dataset
-	harbor run -c job.yaml --job-name $(JOB_NAME) -y
+	harbor run --path $(TASKS) --agent $(AGENT) $(MODEL_ARGS) $(TASK_FILTER_ARGS) $(N_TASKS_ARGS) --job-name $(JOB_NAME) -y
+
+benchmark-oracle: dataset
+	harbor run -c job.yaml --job-name $(ORACLE_JOB_NAME) -y
 
 benchmark-agents: dataset
 	harbor run -c job.agents.yaml --job-name $(AGENT_JOB_NAME) -y
+
+benchmark-model: benchmark
 
 view:
 	harbor view jobs

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Docker/Harbor require files inside the task context.
 
 ## Harbor Concepts
 
-- `job.yaml` is the Harbor sanity-check job. It selects the local Docker
-  orchestrator, the `oracle` agent, and the `tasks/` dataset.
+- `job.yaml` is the Harbor oracle baseline job. It selects the local Docker
+  environment, the `oracle` agent, and the `tasks/` dataset.
 - `job.agents.yaml` is the local harness matrix for real agents. It currently
   runs `codex` and `claude-code` over the same dataset.
 - `tasks/dataset.toml` is the Harbor dataset manifest for the future
@@ -157,16 +157,40 @@ Refresh task digests in the dataset:
 make dataset
 ```
 
-Run the oracle solution:
+Run the default model benchmark:
 
 ```bash
 make benchmark
+```
+
+This defaults to:
+
+```bash
+make benchmark AGENT=claude-code MODEL=haiku
+```
+
+Run the oracle baseline:
+
+```bash
+make benchmark-oracle
 ```
 
 Run the Codex and Claude Code harness matrix:
 
 ```bash
 make benchmark-agents
+```
+
+Run a different harness/model over all tasks:
+
+```bash
+make benchmark AGENT=claude-code MODEL=sonnet
+```
+
+Run a single harness/model over matching tasks:
+
+```bash
+make benchmark AGENT=claude-code MODEL=sonnet TASK_FILTER='tempo/transfer-*'
 ```
 
 Open Harbor's viewer:
@@ -196,6 +220,42 @@ This Harbor install lists `codex` and `claude-code` as built-ins. It does not
 list `amp`; to add AMP, wrap it as a Harbor custom agent and set
 `import_path: module.path:ClassName`, or use an ACP registry shorthand if AMP
 ships an ACP adapter.
+
+For ad hoc model runs, use `make benchmark`. It is a thin wrapper over
+`harbor run --path tasks --agent ... --model ...`.
+
+Common examples:
+
+```bash
+# Claude Code with latest Haiku over all tasks
+make benchmark
+
+# Claude Code with Sonnet over all tasks
+make benchmark MODEL=sonnet
+
+# Codex with an explicit model
+make benchmark AGENT=codex MODEL=gpt-5
+
+# Only transfer tasks
+make benchmark TASK_FILTER='tempo/transfer-*'
+
+# One matching task, useful for smoke tests
+make benchmark TASK_FILTER='tempo/set-*' N_TASKS=1
+
+# Custom job name
+make benchmark JOB_NAME=tempo-bench-claude-haiku-smoke N_TASKS=1
+
+# Oracle baseline
+make benchmark-oracle
+```
+
+`TASK_FILTER` is passed to Harbor's `--include-task-name` and supports glob
+patterns. `N_TASKS` limits the task count after filtering. `benchmark-model` is
+kept as an alias for `benchmark`:
+
+```bash
+make benchmark-model AGENT=codex MODEL=gpt-5 TASK_FILTER='tempo/set-*' N_TASKS=1
+```
 
 ## Adding Pieces
 


### PR DESCRIPTION
## Summary

- Make `make benchmark` run a configurable harness/model directly
- Add `make benchmark-oracle` for the oracle baseline
- Document common benchmark CLI examples and task filters

## Motivation

Make it easier to run benchmark tasks from the CLI with a chosen harness and model while keeping the oracle baseline available as a separate command.

## Key design considerations

- Defaults to Claude Code with the Haiku model alias
- Keeps `benchmark-model` as an alias for compatibility
- Uses Harbor's native task filtering and task limit flags