### PR TITLE
Enable parallel benchmark runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ MODEL ?= haiku
 TASK_FILTER ?=
 N_TASKS ?=
 TASKS ?= tasks
+N_CONCURRENT ?= $(shell sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)
 MODEL_ARGS = $(if $(MODEL),--model '$(MODEL)',)
 TASK_FILTER_ARGS = $(if $(TASK_FILTER),--include-task-name '$(TASK_FILTER)',)
 N_TASKS_ARGS = $(if $(N_TASKS),--n-tasks $(N_TASKS),)
+CONCURRENCY_ARGS = --n-concurrent $(N_CONCURRENT)
 
 help:
 	@printf '%s\n' \
@@ -22,6 +24,7 @@ help:
 		'  make benchmark-agents Run Claude Code benchmark (AGENT_JOB_NAME=...)' \
 		'  make benchmark-model Alias for benchmark' \
 		'  make check-agent-auth Verify Claude Code and quality judge auth is available' \
+		'  make benchmark* N_CONCURRENT=4 Override Harbor trial concurrency' \
 		'  make view        Open Harbor job viewer' \
 		'  make check       Syntax-check shared JS/Python and sync dataset' \
 		'  make check-generated Verify sync/check leave no generated diff' \
@@ -35,10 +38,10 @@ dataset: sync
 	harbor sync $(TASKS)
 
 benchmark: dataset
-	harbor run --path $(TASKS) --agent $(AGENT) $(MODEL_ARGS) $(TASK_FILTER_ARGS) $(N_TASKS_ARGS) --job-name $(JOB_NAME) -y
+	harbor run --path $(TASKS) --agent $(AGENT) $(MODEL_ARGS) $(TASK_FILTER_ARGS) $(N_TASKS_ARGS) $(CONCURRENCY_ARGS) --job-name $(JOB_NAME) -y
 
 benchmark-oracle: dataset
-	harbor run -c job.yaml --job-name $(ORACLE_JOB_NAME) -y
+	harbor run -c job.yaml $(CONCURRENCY_ARGS) --job-name $(ORACLE_JOB_NAME) -y
 
 check-agent-auth:
 	@if env | grep -q '^CLAUDE_FORCE_OAUTH=$$'; then \
@@ -56,7 +59,7 @@ check-agent-auth:
 	fi
 
 benchmark-agents: check-agent-auth dataset
-	harbor run -c job.agents.yaml --job-name $(AGENT_JOB_NAME) -y
+	harbor run -c job.agents.yaml $(CONCURRENCY_ARGS) --job-name $(AGENT_JOB_NAME) -y
 
 benchmark-model: benchmark
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ Run the Claude Code harness matrix:
 make benchmark-agents
 ```
 
+Benchmark Make targets run Harbor with one concurrent trial per detected logical
+CPU by default. Override this if Docker Desktop, memory, API limits, or localnet
+load become the bottleneck:
+
+```bash
+make benchmark-agents N_CONCURRENT=4
+```
+
 Run a different harness/model over all tasks:
 
 ```bash

--- a/job.agents.yaml
+++ b/job.agents.yaml
@@ -2,10 +2,8 @@ job_name: tempo-bench-agents-local
 jobs_dir: jobs
 n_attempts: 3
 timeout_multiplier: 1.0
-orchestrator:
-  type: local
-  n_concurrent_trials: 1
-  quiet: false
+n_concurrent_trials: 4
+quiet: false
 environment:
   type: docker
   force_build: true

--- a/job.yaml
+++ b/job.yaml
@@ -2,10 +2,8 @@ job_name: tempo-bench-local
 jobs_dir: jobs
 n_attempts: 1
 timeout_multiplier: 1.0
-orchestrator:
-  type: local
-  n_concurrent_trials: 1
-  quiet: false
+n_concurrent_trials: 4
+quiet: false
 environment:
   type: docker
   force_build: true


### PR DESCRIPTION
## Summary

- Add an `N_CONCURRENT` Makefile knob for benchmark targets.
- Pass Harbor trial concurrency through benchmark Make targets.
- Move job configs to top-level concurrency fields with a 4-trial default.
- Document how to tune local concurrency.

## Motivation

Local benchmark runs were serialized by default, leaving Docker capacity unused during multi-task runs.

## Key design considerations

- Make targets default to detected logical CPU count for local runs.
- Checked-in job configs keep a conservative 4-trial default for direct config usage.
- Concurrency remains easy to reduce when Docker resources or service limits become the bottleneck.