### PR TITLE
Skip quality judge when Anthropic auth is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Docker/Harbor require files inside the task context.
   cutoff-based turn/token efficiency checks with a Claude Haiku LLM judge over
   the submitted TypeScript files. Raw efficiency counts are written to
   `/logs/verifier/efficiency.json`. Quality does not affect Harbor's binary
-  pass/fail reward.
+  pass/fail reward. Local runs without `ANTHROPIC_API_KEY` or
+  `ANTHROPIC_AUTH_TOKEN` skip the LLM quality reward and write
+  `/logs/verifier/quality-skipped.txt`.
 - `tasks/*/tests/tempo-bench-verifier` is a minimal copied verifier package
   containing only the shared core plus the task's selected case. Harbor mounts
   `/tests` without following external package symlinks, so the package must be
@@ -254,8 +256,9 @@ agents:
 `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN`,
 Claude Code exits before writing `/app/package.json` or `/app/src`, and Harbor's
 artifact collection reports Docker copy errors for those missing paths.
-The RewardKit quality judge also requires `ANTHROPIC_API_KEY` or
-`ANTHROPIC_AUTH_TOKEN` in the verifier environment.
+The RewardKit quality judge requires `ANTHROPIC_API_KEY` or
+`ANTHROPIC_AUTH_TOKEN` in the verifier environment. Without one, local verifier
+runs skip the LLM quality reward and still report the binary correctness reward.
 If using `CLAUDE_FORCE_OAUTH`, set it to `1`/`true` or leave it unset; an empty
 value is invalid.
 

--- a/shared/rewardkit/test.sh
+++ b/shared/rewardkit/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/create-stablecoin-with-policy-docs/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy-docs/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:b4a2d212b9382c76fe5a7357bc4b8aa1395ef7dab8d3a3d85edd54e1960cd763"
+digest = "sha256:5e7d223399be8b7d34e6efad0e475b89250e560a44f1740f7b209a842e150bae"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:2d7453ee5424730c32330a4133bd3e491ec0e3c3c6a3bb54a6ead92030d0c992"
+digest = "sha256:a53178715e0a39e38a0ae75fa7b59b544671d021679709e7db18f98a1f2b735f"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:44b14b514e1ff025fd39f2cda666b30509c2300b709f24d16549a9bfcd08f99c"
+digest = "sha256:370e8ae65f1ad499966828a2a399f981f3e5d7d78917807e0fff266b17c28eb7"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:5e113c54d9f1fb0db4e460e5cfbc4883d73130bbda1b48a6bb3c67409c2bb625"
+digest = "sha256:796fcead034f05690b3a07c4d41d550b570e016c22121fbf7defca2ab39d59cb"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:bb00a10bee520d2fc1dfe55e181384001a0ad42ba666d53d5f439bccec42f95d"
+digest = "sha256:a5d39057204f9fa65778f06b16dcb1792972590f39c60384a599bae5a1cbefd4"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:cb6ccae15605eee18f11aa45865531ebcef4a919490a9c9304eddb06d7e7f8e5"
+digest = "sha256:1573dacef82ad8972de9cc7967b1be149f76ac3eed28b3b17e1fd0362288364a"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:65387f02bf74fe9013a215b2fa577e8bb814b1e38d118a244f0cd48258276072"
+digest = "sha256:3b8625b353476253f8cbf3f62a672b0daef76539bd52a14bf068fe601a3e1afb"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:c4900b141da99cde45f1e2c49047efdd5903cefba5d5b2367327cca9531200c6"
+digest = "sha256:45ce2f8f8bb1456612e5b918a9d956f3b89c7722a932b3818c27ced8e27dadd9"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:8eaa5995ee09e5187b72646c60803cd8d82acbef355e0c05b6c7cf18075677dc"
+digest = "sha256:4d090e90de3a110050515b18dfd65742fdbcec00f10e12072d85b0d058aa314e"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:37a0e1a344b64595d29d60d2d5dff05046d4c6bdda8bc1b0672f8ede0062803b"
+digest = "sha256:0d933fe0296c702e316a263a7c68ff3995c4f360c02a1517bc9500c9e9cafad6"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:04e818e64143cddf520dd995fe0699a7382ce8c8acba57fa55b2783bb3163aa3"
+digest = "sha256:24bc39033dee22ad9a656b61a46fccecc13e73f649a800f4d69c39eae457da54"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:e4784fb0e48043c3cc57e9ab21277c3042e1776330c68be34ded0cc7a755bf07"
+digest = "sha256:e9b58f6553fa7c26bba4d8fdb8c77fbb58917fd0408b47151737546526b42187"
 

--- a/tasks/faucet-funded-transfer-docs/tests/test.sh
+++ b/tasks/faucet-funded-transfer-docs/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/faucet-funded-transfer-mcp/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/faucet-funded-transfer/tests/test.sh
+++ b/tasks/faucet-funded-transfer/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/set-fee-token-docs/tests/test.sh
+++ b/tasks/set-fee-token-docs/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/set-fee-token-mcp/tests/test.sh
+++ b/tasks/set-fee-token-mcp/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/set-fee-token/tests/test.sh
+++ b/tasks/set-fee-token/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/stablecoin-dex-swap-docs/tests/test.sh
+++ b/tasks/stablecoin-dex-swap-docs/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/stablecoin-dex-swap-mcp/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/stablecoin-dex-swap/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-docs/tests/test.sh
+++ b/tasks/transfer-with-memo-docs/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/transfer-with-memo-mcp/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo/tests/test.sh
+++ b/tasks/transfer-with-memo/tests/test.sh
@@ -6,7 +6,17 @@ REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
+REWARDKIT_TESTS_DIR="/tests"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+
+if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f /tests/quality/reward.toml ]; then
+  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
+  rm -rf "$REWARDKIT_TESTS_DIR"
+  cp -R /tests "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.' \
+    > /logs/verifier/quality-skipped.txt
+fi
 
 write_binary_reward() {
   python3 - "$DETAILS_FILE" "$REWARD_FILE" <<'PY'
@@ -54,7 +64,7 @@ if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-
   exit 0
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit /tests \
+if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \


### PR DESCRIPTION
## Summary
- Skip the LLM quality reward locally when neither Anthropic API auth variable is configured.
- Keep deterministic correctness rewards running by invoking rewardkit against a temporary tests directory without `quality/reward.toml`.
- Document the local behavior in the README.

## Test plan
- `make check`