### PR TITLE
Add shared RewardKit criteria

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+tasks/*/environment/Dockerfile linguist-generated=true
+tasks/*/environment/rewardkit-package/** linguist-generated=true
+tasks/*/tests/quality/** linguist-generated=true
+tasks/*/tests/tempo-bench-verifier/** linguist-generated=true
+tasks/*/tests/test.sh linguist-generated=true
+tasks/*-docs/tests/correctness/criteria.py linguist-generated=true
+tasks/*-mcp/tests/correctness/criteria.py linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn.lock
 pnpm-lock.yaml
 tasks/**/tests/node_modules/
 tasks/**/tests/package-lock.json
+tasks/**/environment/rewardkit-package/
 
 # Python caches
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ view:
 
 check: dataset
 	find shared/verifier tasks/*/tests/tempo-bench-verifier -path '*/node_modules' -prune -o -type f -name '*.js' -print0 | xargs -0 -n1 node -c
-	python3 -c 'from pathlib import Path; [compile(p.read_text(), str(p), "exec") for root in [Path("shared/rewardkit"), *Path("tasks").glob("*/tests")] for p in root.rglob("*.py") if "node_modules" not in p.parts]'
+	python3 -c 'from pathlib import Path; [compile(p.read_text(), str(p), "exec") for root in [Path("shared/rewardkit"), Path("shared/rewardkit-package"), *Path("tasks").glob("*/tests")] for p in root.rglob("*.py") if "node_modules" not in p.parts]'
 	find shared/rewardkit tasks/*/tests tasks/*/solution -path '*/node_modules' -prune -o -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
 
 check-generated: check

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Docker/Harbor require files inside the task context.
   file into its base Compose config.
 - `tasks/*/environment/Dockerfile` is copied from `shared/docker/main-node/`.
   BuildKit expects the Dockerfile inside the build context, so this cannot be a
-  symlink to a shared file outside the task. Test-only Python packages are not
-  baked into this image; `tests/test.sh` installs the pinned RewardKit package
-  during verification, matching Harbor's quality rubric.
+  symlink to a shared file outside the task. `make sync` also materializes the
+  ignored `tasks/*/environment/rewardkit-package/` build-context copy so the
+  image can bake in the shared Tempo RewardKit helpers.
 - `tasks/*-mcp` declares the official remote `tempo` MCP server in
   `task.toml`. No local docs MCP sidecar is used for the main matrix.
 - `tasks/*/tests/test.sh` is Harbor's verifier entrypoint. It runs RewardKit,
@@ -97,9 +97,13 @@ Docker/Harbor require files inside the task context.
   writes dimension details to `/logs/verifier/reward-details.json`, and writes
   Harbor's primary `/logs/verifier/reward.json` as exactly one binary key:
   `reward`.
-- `tasks/*/tests/correctness` contains all current file, regex, docs/tool-use,
-  build, run, and onchain checks. Harbor's binary `reward` is `1` only when the
-  `correctness` dimension scores `1.0`.
+- `shared/rewardkit-package` defines reusable RewardKit criteria for Tempo
+  TypeScript project shape, source-pattern checks, trajectory checks, and the
+  onchain verifier. The package is installed into the task image as
+  `tempo_bench_rewardkit`.
+- `tasks/*/tests/correctness` registers task-specific source patterns plus the
+  shared build/run/onchain checks. Harbor's binary `reward` is `1` only when
+  the `correctness` dimension scores `1.0`.
 - `tasks/*/tests/quality` contains non-binary quality scoring. It combines
   cutoff-based turn/token efficiency checks with a Claude Haiku LLM judge over
   the submitted TypeScript files. Raw efficiency counts are written to

--- a/scripts/sync-shared.mjs
+++ b/scripts/sync-shared.mjs
@@ -79,6 +79,7 @@ function copyGeneratedTask(source, destination) {
         "environment/docker-compose.yaml",
         "environment/tempo-localnet",
         "environment/tempo-docs-mcp",
+        "environment/rewardkit-package",
         "tests/tempo-bench-verifier",
         "tests/e2e/verify-tempo.sh",
         "tests/correctness/verify-tempo.sh",
@@ -275,31 +276,20 @@ function updateProfileCriteria(taskDir, profile) {
   const criteriaPath = taskCriteriaPath(taskDir);
   let content = fs.readFileSync(criteriaPath, "utf8");
   content = content.replace(
-    /from rewardkit import ([^\n]+)/,
-    (_match, imports) => {
-      const names = new Set(imports.split(",").map((name) => name.trim()).filter(Boolean));
-      names.add("command_succeeds");
-      return `from rewardkit import ${Array.from(names).sort().join(", ")}`;
-    },
+    /\nrk\.tempo_trajectory_matches\([\s\S]*?\n\)\n/g,
+    "\n",
   );
-  content = content.replace(/\ncommand_succeeds\([\s\S]*?name="trajectory_uses_[^"]+",\n\)\n/g, "\n");
 
   if (profile.id === "docs") {
     content += `
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\\\.tempo\\\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )
 `;
   } else if (profile.id === "mcp") {
     content += `
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )
 `;
   }
@@ -452,6 +442,7 @@ function syncRewardKit(taskDir) {
   removePath(path.join(taskDir, "tests/tokens"));
   removePath(path.join(taskDir, "tests/reward"));
   removePath(path.join(taskDir, "tests/criteria"));
+  removePath(path.join(taskDir, "tests/criteria.py"));
   removePath(path.join(taskDir, "tests/e2e"));
   removePath(path.join(taskDir, "tests/correctness"));
   removePath(path.join(taskDir, "tests/quality"));
@@ -625,6 +616,10 @@ for (const taskDir of tasks) {
   copyFile(
     path.join(root, "shared/docker/main-node/Dockerfile"),
     path.join(taskDir, "environment/Dockerfile"),
+  );
+  copyDir(
+    path.join(root, "shared/rewardkit-package"),
+    path.join(taskDir, "environment/rewardkit-package"),
   );
 
   linkDir(

--- a/shared/docker/main-node/Dockerfile
+++ b/shared/docker/main-node/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/shared/rewardkit-package/pyproject.toml
+++ b/shared/rewardkit-package/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "tempo-bench-rewardkit"
+version = "0.1.0"
+description = "Shared RewardKit criteria for Tempo benchmark tasks"
+requires-python = ">=3.11"
+dependencies = [
+  "harbor-rewardkit==0.1.7",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -1,0 +1,14 @@
+from .criteria import (
+    tempo_onchain_verifier,
+    tempo_source_patterns,
+    tempo_trajectory_matches,
+    tempo_typescript_project,
+)
+
+
+__all__ = [
+    "tempo_onchain_verifier",
+    "tempo_source_patterns",
+    "tempo_trajectory_matches",
+    "tempo_typescript_project",
+]

--- a/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -1,0 +1,138 @@
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from rewardkit import criterion
+
+
+LOG_DIR = Path("/logs/verifier")
+
+
+def _write_json(name: str, payload: dict) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    (LOG_DIR / name).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_workspace_file(workspace: Path, relative_path: str) -> str:
+    return (workspace / relative_path).read_text(encoding="utf-8")
+
+
+def _pattern_check(workspace: Path, name: str, file: str, pattern: str) -> dict:
+    try:
+        content = _read_workspace_file(workspace, file)
+        matched = re.search(pattern, content, re.MULTILINE) is not None
+        error = None
+    except Exception as exc:
+        matched = False
+        error = str(exc)
+
+    return {
+        "name": name,
+        "file": file,
+        "pattern": pattern,
+        "passed": matched,
+        "error": error,
+    }
+
+
+@criterion(shared=True)
+def tempo_typescript_project(workspace: Path) -> bool:
+    file_checks = [
+        ("package_json_exists", "package.json"),
+        ("tsconfig_json_exists", "tsconfig.json"),
+        ("src_index_ts_exists", "src/index.ts"),
+    ]
+    pattern_checks = [
+        ("package_has_build_script", "package.json", r'"build"\s*:'),
+        ("package_has_run_script", "package.json", r'"run"\s*:'),
+        ("package_depends_on_viem", "package.json", r'"viem"\s*:'),
+        ("source_uses_environment_variables", "src/index.ts", r"process\.env"),
+        ("source_uses_address_or_hex_types", "src/index.ts", r"\b(Address|Hex)\b"),
+    ]
+
+    results = []
+    for name, relative_path in file_checks:
+        exists = (workspace / relative_path).exists()
+        results.append({
+            "name": name,
+            "file": relative_path,
+            "passed": exists,
+            "error": None if exists else "missing file",
+        })
+
+    results.extend(
+        _pattern_check(workspace, name, file, pattern)
+        for name, file, pattern in pattern_checks
+    )
+
+    _write_json("typescript-project.json", {"checks": results})
+    return all(result["passed"] for result in results)
+
+
+@criterion(shared=True)
+def tempo_source_patterns(workspace: Path, patterns: list[dict]) -> bool:
+    results = [
+        _pattern_check(
+            workspace,
+            str(pattern["name"]),
+            str(pattern.get("file", "src/index.ts")),
+            str(pattern["pattern"]),
+        )
+        for pattern in patterns
+    ]
+
+    _write_json("source-patterns.json", {"checks": results})
+    return all(result["passed"] for result in results)
+
+
+@criterion(shared=True)
+def tempo_onchain_verifier(workspace: Path) -> bool:
+    timeout = int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900"))
+    result = subprocess.run(
+        ["bash", "/tests/correctness/verify-tempo.sh"],
+        cwd=workspace,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+    _write_json(
+        "onchain-criterion.json",
+        {
+            "command": "bash /tests/correctness/verify-tempo.sh",
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        },
+    )
+    return result.returncode == 0
+
+
+@criterion(shared=True)
+def tempo_trajectory_matches(_workspace: Path, pattern: str) -> bool:
+    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+        if candidate.exists():
+            content = candidate.read_text(encoding="utf-8", errors="replace")
+            matched = re.search(pattern, content, re.IGNORECASE | re.MULTILINE) is not None
+            _write_json(
+                "trajectory-match.json",
+                {
+                    "trajectory": str(candidate),
+                    "pattern": pattern,
+                    "passed": matched,
+                },
+            )
+            return matched
+
+    _write_json(
+        "trajectory-match.json",
+        {
+            "trajectory": None,
+            "pattern": pattern,
+            "passed": True,
+        },
+    )
+    return True

--- a/shared/rewardkit/test.sh
+++ b/shared/rewardkit/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/create-stablecoin-with-policy-docs/environment/Dockerfile
+++ b/tasks/create-stablecoin-with-policy-docs/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
@@ -1,31 +1,32 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_creates_stablecoin",
+        "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
+    },
+    {
+        "name": "source_creates_transfer_policy",
+        "pattern": r"policy\.createSync",
+    },
+    {
+        "name": "source_links_transfer_policy",
+        "pattern": r"changeTransferPolicySync|transferPolicy",
+    },
+    {
+        "name": "source_reads_stablecoin_currency",
+        "pattern": r"TEMPO_STABLECOIN_CURRENCY",
+    },
+    {
+        "name": "source_reads_policy_account",
+        "pattern": r"TEMPO_POLICY_ACCOUNT",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency", name="source_creates_stablecoin")
-file_contains_regex("src/index.ts", r"policy\.createSync", name="source_creates_transfer_policy")
-file_contains_regex("src/index.ts", r"changeTransferPolicySync|transferPolicy", name="source_links_transfer_policy")
-file_contains_regex("src/index.ts", r"TEMPO_STABLECOIN_CURRENCY", name="source_reads_stablecoin_currency")
-file_contains_regex("src/index.ts", r"TEMPO_POLICY_ACCOUNT", name="source_reads_policy_account")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\.tempo\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )

--- a/tasks/create-stablecoin-with-policy-docs/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy-docs/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/create-stablecoin-with-policy-mcp/environment/Dockerfile
+++ b/tasks/create-stablecoin-with-policy-mcp/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -1,31 +1,32 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_creates_stablecoin",
+        "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
+    },
+    {
+        "name": "source_creates_transfer_policy",
+        "pattern": r"policy\.createSync",
+    },
+    {
+        "name": "source_links_transfer_policy",
+        "pattern": r"changeTransferPolicySync|transferPolicy",
+    },
+    {
+        "name": "source_reads_stablecoin_currency",
+        "pattern": r"TEMPO_STABLECOIN_CURRENCY",
+    },
+    {
+        "name": "source_reads_policy_account",
+        "pattern": r"TEMPO_POLICY_ACCOUNT",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency", name="source_creates_stablecoin")
-file_contains_regex("src/index.ts", r"policy\.createSync", name="source_creates_transfer_policy")
-file_contains_regex("src/index.ts", r"changeTransferPolicySync|transferPolicy", name="source_links_transfer_policy")
-file_contains_regex("src/index.ts", r"TEMPO_STABLECOIN_CURRENCY", name="source_reads_stablecoin_currency")
-file_contains_regex("src/index.ts", r"TEMPO_POLICY_ACCOUNT", name="source_reads_policy_account")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )

--- a/tasks/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/create-stablecoin-with-policy/environment/Dockerfile
+++ b/tasks/create-stablecoin-with-policy/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -1,24 +1,28 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
-
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency", name="source_creates_stablecoin")
-file_contains_regex("src/index.ts", r"policy\.createSync", name="source_creates_transfer_policy")
-file_contains_regex("src/index.ts", r"changeTransferPolicySync|transferPolicy", name="source_links_transfer_policy")
-file_contains_regex("src/index.ts", r"TEMPO_STABLECOIN_CURRENCY", name="source_reads_stablecoin_currency")
-file_contains_regex("src/index.ts", r"TEMPO_POLICY_ACCOUNT", name="source_reads_policy_account")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_creates_stablecoin",
+        "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
+    },
+    {
+        "name": "source_creates_transfer_policy",
+        "pattern": r"policy\.createSync",
+    },
+    {
+        "name": "source_links_transfer_policy",
+        "pattern": r"changeTransferPolicySync|transferPolicy",
+    },
+    {
+        "name": "source_reads_stablecoin_currency",
+        "pattern": r"TEMPO_STABLECOIN_CURRENCY",
+    },
+    {
+        "name": "source_reads_policy_account",
+        "pattern": r"TEMPO_POLICY_ACCOUNT",
+    },
+])
+rk.tempo_onchain_verifier()

--- a/tasks/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:5e7d223399be8b7d34e6efad0e475b89250e560a44f1740f7b209a842e150bae"
+digest = "sha256:750fcb90e32c9e351dbe6185bc6933d5932dadeb9f9c63c1e0bbdce865f6f15c"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:a53178715e0a39e38a0ae75fa7b59b544671d021679709e7db18f98a1f2b735f"
+digest = "sha256:9868f8f4780caaf70aa7c07641e77cb6ee567b6a413e63c323e4078a72ae870e"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:370e8ae65f1ad499966828a2a399f981f3e5d7d78917807e0fff266b17c28eb7"
+digest = "sha256:bbc5f91fa3cf7239a406f7bff3dd1b0e4f944848ea7b9fc0398cb2333b1fcd0f"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:796fcead034f05690b3a07c4d41d550b570e016c22121fbf7defca2ab39d59cb"
+digest = "sha256:ff8b6040685d351786ca053cd925f99c170e363c1088e89a0bb937690f4d8efb"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:a5d39057204f9fa65778f06b16dcb1792972590f39c60384a599bae5a1cbefd4"
+digest = "sha256:d4c4331cce6b4b66690432aca824eecbec401ca005a80338632d3a57de519f78"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:1573dacef82ad8972de9cc7967b1be149f76ac3eed28b3b17e1fd0362288364a"
+digest = "sha256:440325b4d5f4b289fe53416ca495a322733bdee60d6992bfc63b615c23e801a5"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:3b8625b353476253f8cbf3f62a672b0daef76539bd52a14bf068fe601a3e1afb"
+digest = "sha256:99c4a2cadb23e6cc61ba594d1107493f3dba855722de080c7afc62dbc5211da6"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:45ce2f8f8bb1456612e5b918a9d956f3b89c7722a932b3818c27ced8e27dadd9"
+digest = "sha256:5d22b52aef44926443f6bbb2f909db9718aaf9fede44a08dae4336ad319e7a07"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:4d090e90de3a110050515b18dfd65742fdbcec00f10e12072d85b0d058aa314e"
+digest = "sha256:1664e7edadf3fefcc71165208fefb94eb88c6d5029c32590c158a092a6184677"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:0d933fe0296c702e316a263a7c68ff3995c4f360c02a1517bc9500c9e9cafad6"
+digest = "sha256:9b1291f4fa4ef628a4302cc31f6ae3e13188051af7ad947707db8878bff10ff5"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:24bc39033dee22ad9a656b61a46fccecc13e73f649a800f4d69c39eae457da54"
+digest = "sha256:726c62a7b7ded85633bb73724b32cc94662882816808ec4c757998ea1074083f"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:e9b58f6553fa7c26bba4d8fdb8c77fbb58917fd0408b47151737546526b42187"
+digest = "sha256:98c6d13baf2ab62bcc1e98810f22e87900f59c3f58c8dee6a0be37007827be67"
 

--- a/tasks/faucet-funded-transfer-docs/environment/Dockerfile
+++ b/tasks/faucet-funded-transfer-docs/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
@@ -1,29 +1,24 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_calls_faucet_fund",
+        "pattern": r"faucet\.fundSync|fundSync",
+    },
+    {
+        "name": "source_reads_faucet_private_key",
+        "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
+    },
+    {
+        "name": "source_sends_transfer",
+        "pattern": r"transferSync|transferWithMemo",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"faucet\.fundSync|fundSync", name="source_calls_faucet_fund")
-file_contains_regex("src/index.ts", r"TEMPO_FAUCET_PRIVATE_KEY", name="source_reads_faucet_private_key")
-file_contains_regex("src/index.ts", r"transferSync|transferWithMemo", name="source_sends_transfer")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\.tempo\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )

--- a/tasks/faucet-funded-transfer-docs/tests/test.sh
+++ b/tasks/faucet-funded-transfer-docs/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/faucet-funded-transfer-mcp/environment/Dockerfile
+++ b/tasks/faucet-funded-transfer-mcp/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -1,29 +1,24 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_calls_faucet_fund",
+        "pattern": r"faucet\.fundSync|fundSync",
+    },
+    {
+        "name": "source_reads_faucet_private_key",
+        "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
+    },
+    {
+        "name": "source_sends_transfer",
+        "pattern": r"transferSync|transferWithMemo",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"faucet\.fundSync|fundSync", name="source_calls_faucet_fund")
-file_contains_regex("src/index.ts", r"TEMPO_FAUCET_PRIVATE_KEY", name="source_reads_faucet_private_key")
-file_contains_regex("src/index.ts", r"transferSync|transferWithMemo", name="source_sends_transfer")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )

--- a/tasks/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/faucet-funded-transfer-mcp/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/faucet-funded-transfer/environment/Dockerfile
+++ b/tasks/faucet-funded-transfer/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer/tests/correctness/criteria.py
@@ -1,22 +1,20 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
-
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"faucet\.fundSync|fundSync", name="source_calls_faucet_fund")
-file_contains_regex("src/index.ts", r"TEMPO_FAUCET_PRIVATE_KEY", name="source_reads_faucet_private_key")
-file_contains_regex("src/index.ts", r"transferSync|transferWithMemo", name="source_sends_transfer")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_calls_faucet_fund",
+        "pattern": r"faucet\.fundSync|fundSync",
+    },
+    {
+        "name": "source_reads_faucet_private_key",
+        "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
+    },
+    {
+        "name": "source_sends_transfer",
+        "pattern": r"transferSync|transferWithMemo",
+    },
+])
+rk.tempo_onchain_verifier()

--- a/tasks/faucet-funded-transfer/tests/test.sh
+++ b/tasks/faucet-funded-transfer/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/set-fee-token-docs/environment/Dockerfile
+++ b/tasks/set-fee-token-docs/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/set-fee-token-docs/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-docs/tests/correctness/criteria.py
@@ -1,28 +1,20 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_calls_set_user_token",
+        "pattern": r"setUserToken",
+    },
+    {
+        "name": "source_reads_tempo_fee_token",
+        "pattern": r"TEMPO_FEE_TOKEN",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"setUserToken", name="source_calls_set_user_token")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_TOKEN", name="source_reads_tempo_fee_token")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\.tempo\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )

--- a/tasks/set-fee-token-docs/tests/test.sh
+++ b/tasks/set-fee-token-docs/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/set-fee-token-mcp/environment/Dockerfile
+++ b/tasks/set-fee-token-mcp/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-mcp/tests/correctness/criteria.py
@@ -1,28 +1,20 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_calls_set_user_token",
+        "pattern": r"setUserToken",
+    },
+    {
+        "name": "source_reads_tempo_fee_token",
+        "pattern": r"TEMPO_FEE_TOKEN",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"setUserToken", name="source_calls_set_user_token")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_TOKEN", name="source_reads_tempo_fee_token")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )

--- a/tasks/set-fee-token-mcp/tests/test.sh
+++ b/tasks/set-fee-token-mcp/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/set-fee-token/environment/Dockerfile
+++ b/tasks/set-fee-token/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/set-fee-token/tests/correctness/criteria.py
@@ -1,21 +1,16 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
-
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"setUserToken", name="source_calls_set_user_token")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_TOKEN", name="source_reads_tempo_fee_token")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_calls_set_user_token",
+        "pattern": r"setUserToken",
+    },
+    {
+        "name": "source_reads_tempo_fee_token",
+        "pattern": r"TEMPO_FEE_TOKEN",
+    },
+])
+rk.tempo_onchain_verifier()

--- a/tasks/set-fee-token/tests/test.sh
+++ b/tasks/set-fee-token/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/stablecoin-dex-swap-docs/environment/Dockerfile
+++ b/tasks/stablecoin-dex-swap-docs/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
@@ -1,31 +1,32 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_dex_actions",
+        "pattern": r"Actions\.dex|\.dex\.",
+    },
+    {
+        "name": "source_approves_dex_spending",
+        "pattern": r"approveSync",
+    },
+    {
+        "name": "source_provides_dex_liquidity",
+        "pattern": r"placeSync|provideLiquidity|addLiquidity",
+    },
+    {
+        "name": "source_executes_dex_swap",
+        "pattern": r"sellSync|buySync|swapSync",
+    },
+    {
+        "name": "source_reads_swap_token_env",
+        "pattern": r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"Actions\.dex|\.dex\.", name="source_uses_dex_actions")
-file_contains_regex("src/index.ts", r"approveSync", name="source_approves_dex_spending")
-file_contains_regex("src/index.ts", r"placeSync|provideLiquidity|addLiquidity", name="source_provides_dex_liquidity")
-file_contains_regex("src/index.ts", r"sellSync|buySync|swapSync", name="source_executes_dex_swap")
-file_contains_regex("src/index.ts", r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN", name="source_reads_swap_token_env")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\.tempo\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )

--- a/tasks/stablecoin-dex-swap-docs/tests/test.sh
+++ b/tasks/stablecoin-dex-swap-docs/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/stablecoin-dex-swap-mcp/environment/Dockerfile
+++ b/tasks/stablecoin-dex-swap-mcp/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -1,31 +1,32 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_dex_actions",
+        "pattern": r"Actions\.dex|\.dex\.",
+    },
+    {
+        "name": "source_approves_dex_spending",
+        "pattern": r"approveSync",
+    },
+    {
+        "name": "source_provides_dex_liquidity",
+        "pattern": r"placeSync|provideLiquidity|addLiquidity",
+    },
+    {
+        "name": "source_executes_dex_swap",
+        "pattern": r"sellSync|buySync|swapSync",
+    },
+    {
+        "name": "source_reads_swap_token_env",
+        "pattern": r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"Actions\.dex|\.dex\.", name="source_uses_dex_actions")
-file_contains_regex("src/index.ts", r"approveSync", name="source_approves_dex_spending")
-file_contains_regex("src/index.ts", r"placeSync|provideLiquidity|addLiquidity", name="source_provides_dex_liquidity")
-file_contains_regex("src/index.ts", r"sellSync|buySync|swapSync", name="source_executes_dex_swap")
-file_contains_regex("src/index.ts", r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN", name="source_reads_swap_token_env")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )

--- a/tasks/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/stablecoin-dex-swap-mcp/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/stablecoin-dex-swap/environment/Dockerfile
+++ b/tasks/stablecoin-dex-swap/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -1,24 +1,28 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
-
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"Actions\.dex|\.dex\.", name="source_uses_dex_actions")
-file_contains_regex("src/index.ts", r"approveSync", name="source_approves_dex_spending")
-file_contains_regex("src/index.ts", r"placeSync|provideLiquidity|addLiquidity", name="source_provides_dex_liquidity")
-file_contains_regex("src/index.ts", r"sellSync|buySync|swapSync", name="source_executes_dex_swap")
-file_contains_regex("src/index.ts", r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN", name="source_reads_swap_token_env")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_dex_actions",
+        "pattern": r"Actions\.dex|\.dex\.",
+    },
+    {
+        "name": "source_approves_dex_spending",
+        "pattern": r"approveSync",
+    },
+    {
+        "name": "source_provides_dex_liquidity",
+        "pattern": r"placeSync|provideLiquidity|addLiquidity",
+    },
+    {
+        "name": "source_executes_dex_swap",
+        "pattern": r"sellSync|buySync|swapSync",
+    },
+    {
+        "name": "source_reads_swap_token_env",
+        "pattern": r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN",
+    },
+])
+rk.tempo_onchain_verifier()

--- a/tasks/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/stablecoin-dex-swap/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-docs/environment/Dockerfile
+++ b/tasks/transfer-with-memo-docs/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
@@ -1,29 +1,24 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_transfer_with_memo_semantics",
+        "pattern": r"transferWithMemo|transferSync",
+    },
+    {
+        "name": "source_reads_tempo_memo",
+        "pattern": r"TEMPO_MEMO",
+    },
+    {
+        "name": "source_parses_token_units",
+        "pattern": r"parseUnits",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"transferWithMemo|transferSync", name="source_uses_transfer_with_memo_semantics")
-file_contains_regex("src/index.ts", r"TEMPO_MEMO", name="source_reads_tempo_memo")
-file_contains_regex("src/index.ts", r"parseUnits", name="source_parses_token_units")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\.tempo\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )

--- a/tasks/transfer-with-memo-docs/tests/test.sh
+++ b/tasks/transfer-with-memo-docs/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-fee-payer-docs/environment/Dockerfile
+++ b/tasks/transfer-with-memo-fee-payer-docs/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
@@ -1,32 +1,36 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_transfer_with_memo_semantics",
+        "pattern": r"transferWithMemo|transferSync",
+    },
+    {
+        "name": "source_reads_tempo_memo",
+        "pattern": r"TEMPO_MEMO",
+    },
+    {
+        "name": "source_parses_token_units",
+        "pattern": r"parseUnits",
+    },
+    {
+        "name": "source_reads_fee_payer_private_key",
+        "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
+    },
+    {
+        "name": "source_passes_fee_payer",
+        "pattern": r"feePayer",
+    },
+    {
+        "name": "source_reads_fee_token",
+        "pattern": r"TEMPO_FEE_TOKEN",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"transferWithMemo|transferSync", name="source_uses_transfer_with_memo_semantics")
-file_contains_regex("src/index.ts", r"TEMPO_MEMO", name="source_reads_tempo_memo")
-file_contains_regex("src/index.ts", r"parseUnits", name="source_parses_token_units")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_PAYER_PRIVATE_KEY", name="source_reads_fee_payer_private_key")
-file_contains_regex("src/index.ts", r"feePayer", name="source_passes_fee_payer")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_TOKEN", name="source_reads_fee_token")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'docs\\.tempo\\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_tempo_docs_when_available",
+rk.tempo_trajectory_matches(
+    r"docs\.tempo\.xyz|TEMPO_DOCS_URL|Tempo docs|documentation",
 )

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-fee-payer-mcp/environment/Dockerfile
+++ b/tasks/transfer-with-memo-fee-payer-mcp/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -1,32 +1,36 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_transfer_with_memo_semantics",
+        "pattern": r"transferWithMemo|transferSync",
+    },
+    {
+        "name": "source_reads_tempo_memo",
+        "pattern": r"TEMPO_MEMO",
+    },
+    {
+        "name": "source_parses_token_units",
+        "pattern": r"parseUnits",
+    },
+    {
+        "name": "source_reads_fee_payer_private_key",
+        "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
+    },
+    {
+        "name": "source_passes_fee_payer",
+        "pattern": r"feePayer",
+    },
+    {
+        "name": "source_reads_fee_token",
+        "pattern": r"TEMPO_FEE_TOKEN",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"transferWithMemo|transferSync", name="source_uses_transfer_with_memo_semantics")
-file_contains_regex("src/index.ts", r"TEMPO_MEMO", name="source_reads_tempo_memo")
-file_contains_regex("src/index.ts", r"parseUnits", name="source_parses_token_units")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_PAYER_PRIVATE_KEY", name="source_reads_fee_payer_private_key")
-file_contains_regex("src/index.ts", r"feePayer", name="source_passes_fee_payer")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_TOKEN", name="source_reads_fee_token")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-fee-payer/environment/Dockerfile
+++ b/tasks/transfer-with-memo-fee-payer/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -1,25 +1,32 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
-
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"transferWithMemo|transferSync", name="source_uses_transfer_with_memo_semantics")
-file_contains_regex("src/index.ts", r"TEMPO_MEMO", name="source_reads_tempo_memo")
-file_contains_regex("src/index.ts", r"parseUnits", name="source_parses_token_units")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_PAYER_PRIVATE_KEY", name="source_reads_fee_payer_private_key")
-file_contains_regex("src/index.ts", r"feePayer", name="source_passes_fee_payer")
-file_contains_regex("src/index.ts", r"TEMPO_FEE_TOKEN", name="source_reads_fee_token")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_transfer_with_memo_semantics",
+        "pattern": r"transferWithMemo|transferSync",
+    },
+    {
+        "name": "source_reads_tempo_memo",
+        "pattern": r"TEMPO_MEMO",
+    },
+    {
+        "name": "source_parses_token_units",
+        "pattern": r"parseUnits",
+    },
+    {
+        "name": "source_reads_fee_payer_private_key",
+        "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
+    },
+    {
+        "name": "source_passes_fee_payer",
+        "pattern": r"feePayer",
+    },
+    {
+        "name": "source_reads_fee_token",
+        "pattern": r"TEMPO_FEE_TOKEN",
+    },
+])
+rk.tempo_onchain_verifier()

--- a/tasks/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo-mcp/environment/Dockerfile
+++ b/tasks/transfer-with-memo-mcp/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -1,29 +1,24 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_transfer_with_memo_semantics",
+        "pattern": r"transferWithMemo|transferSync",
+    },
+    {
+        "name": "source_reads_tempo_memo",
+        "pattern": r"TEMPO_MEMO",
+    },
+    {
+        "name": "source_parses_token_units",
+        "pattern": r"parseUnits",
+    },
+])
+rk.tempo_onchain_verifier()
 
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"transferWithMemo|transferSync", name="source_uses_transfer_with_memo_semantics")
-file_contains_regex("src/index.ts", r"TEMPO_MEMO", name="source_reads_tempo_memo")
-file_contains_regex("src/index.ts", r"parseUnits", name="source_parses_token_units")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
-
-command_succeeds(
-    "test ! -f /logs/trajectory.json || "
-    "(grep -Eiq 'tempo|mcp|docs|documentation|search' /logs/trajectory.json)",
-    timeout=5,
-    name="trajectory_uses_mcp_when_available",
+rk.tempo_trajectory_matches(
+    r"tempo|mcp|docs|documentation|search",
 )

--- a/tasks/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/transfer-with-memo-mcp/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \

--- a/tasks/transfer-with-memo/environment/Dockerfile
+++ b/tasks/transfer-with-memo/environment/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update \
     python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
+COPY rewardkit-package /opt/tempo-bench-rewardkit
+
+RUN python3 -m venv /opt/tempo-bench-rewardkit-venv \
+  && /opt/tempo-bench-rewardkit-venv/bin/python -m pip install --no-cache-dir /opt/tempo-bench-rewardkit
+
+ENV TEMPO_BENCH_REWARDKIT_VENV=/opt/tempo-bench-rewardkit-venv
+
 WORKDIR /app

--- a/tasks/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo/tests/correctness/criteria.py
@@ -1,22 +1,20 @@
-import os
+import rewardkit as rk
+import tempo_bench_rewardkit
 
-from rewardkit import command_succeeds, file_contains_regex, file_exists
 
-
-file_exists("package.json", name="package_json_exists")
-file_exists("tsconfig.json", name="tsconfig_json_exists")
-file_exists("src/index.ts", name="src_index_ts_exists")
-file_contains_regex("package.json", r'"build"\s*:', name="package_has_build_script")
-file_contains_regex("package.json", r'"run"\s*:', name="package_has_run_script")
-file_contains_regex("package.json", r'"viem"\s*:', name="package_depends_on_viem")
-file_contains_regex("src/index.ts", r"process\.env", name="source_uses_environment_variables")
-file_contains_regex("src/index.ts", r"\b(Address|Hex)\b", name="source_uses_address_or_hex_types")
-file_contains_regex("src/index.ts", r"transferWithMemo|transferSync", name="source_uses_transfer_with_memo_semantics")
-file_contains_regex("src/index.ts", r"TEMPO_MEMO", name="source_reads_tempo_memo")
-file_contains_regex("src/index.ts", r"parseUnits", name="source_parses_token_units")
-
-command_succeeds(
-    "bash /tests/correctness/verify-tempo.sh",
-    timeout=int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900")),
-    name="tempo_submission_builds_runs_and_emits_onchain_evidence",
-)
+rk.tempo_typescript_project()
+rk.tempo_source_patterns([
+    {
+        "name": "source_uses_transfer_with_memo_semantics",
+        "pattern": r"transferWithMemo|transferSync",
+    },
+    {
+        "name": "source_reads_tempo_memo",
+        "pattern": r"TEMPO_MEMO",
+    },
+    {
+        "name": "source_parses_token_units",
+        "pattern": r"parseUnits",
+    },
+])
+rk.tempo_onchain_verifier()

--- a/tasks/transfer-with-memo/tests/test.sh
+++ b/tasks/transfer-with-memo/tests/test.sh
@@ -3,6 +3,7 @@ set -u
 
 mkdir -p /logs/verifier
 REWARDKIT_VENV="${TEMPO_BENCH_REWARDKIT_VENV:-/tmp/tempo-bench-rewardkit}"
+REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="/logs/verifier/reward.json"
 DETAILS_FILE="/logs/verifier/reward-details.json"
 REWARDKIT_OUTPUT_FILE="/logs/verifier/rewardkit-output.json"
@@ -50,21 +51,23 @@ write_zero_reward() {
   printf '{"reward":0}\n' > "$REWARD_FILE"
 }
 
-if ! python3 -m venv "$REWARDKIT_VENV" \
-  > /logs/verifier/rewardkit-venv.stdout.txt \
-  2> /logs/verifier/rewardkit-venv.stderr.txt; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  if ! python3 -m venv "$REWARDKIT_VENV" \
+    > /logs/verifier/rewardkit-venv.stdout.txt \
+    2> /logs/verifier/rewardkit-venv.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
+
+  if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
+    > /logs/verifier/rewardkit-install.stdout.txt \
+    2> /logs/verifier/rewardkit-install.stderr.txt; then
+    write_zero_reward
+    exit 0
+  fi
 fi
 
-if ! "$REWARDKIT_VENV/bin/python" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
-  > /logs/verifier/rewardkit-install.stdout.txt \
-  2> /logs/verifier/rewardkit-install.stderr.txt; then
-  write_zero_reward
-  exit 0
-fi
-
-if ! "$REWARDKIT_VENV/bin/python" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+if ! "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
   --workspace /app \
   --output "$REWARDKIT_OUTPUT_FILE" \
   > /logs/verifier/rewardkit.stdout.txt \


### PR DESCRIPTION
## Summary
- Add `tempo-bench-rewardkit`, a small shared Python package with reusable RewardKit criteria for Tempo TypeScript project shape, source-pattern checks, trajectory checks, and onchain verifier execution.
- Bake that package into each task image from an ignored generated Docker build-context copy, so task-local correctness files stay small and no `tests/criteria.py` copies are committed.
- Update task correctness files to import/register the package and keep only task-specific source patterns.
- Teach `make sync` to materialize the package build-context copy and refresh the generated task Dockerfiles/test scripts/digests.

## Why
Adding a new benchmark task currently repeats the same project-shape, source-regex, trajectory, and onchain verifier checks across tasks and profiles. This keeps Harbor tasks runnable with their self-contained Docker build contexts while making the shared criteria a real package instead of committed duplicate files.

## Test plan
- `make check`
- `git diff --check origin/main`
- `harbor run --path tasks --agent oracle --include-task-name 'transfer-with-memo-docs' --n-concurrent 1 --job-name tempo-bench-packaged-criteria-oracle-2 --verifier-include-logs '*' --force-build -y`