### PR TITLE
ci: add lint and dataset checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  checks:
+    name: Lint and dataset freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Add uv tool directory to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Install Ruff
+        run: python -m pip install ruff==0.15.0
+
+      - name: Install Harbor
+        run: uv tool install harbor
+
+      - name: Run lint checks
+        run: make lint
+
+      - name: Verify dataset freshness
+        run: make check-dataset

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync dataset benchmark benchmark-oracle check-agent-auth benchmark-agents benchmark-model view check check-generated clean-jobs clean
+.PHONY: help sync dataset benchmark benchmark-oracle check-agent-auth benchmark-agents benchmark-model view lint test check check-dataset check-generated clean-jobs clean
 
 JOB_NAME ?= tempo-bench-model-local
 ORACLE_JOB_NAME ?= tempo-bench-oracle-local
@@ -26,8 +26,11 @@ help:
 		'  make check-agent-auth Verify Claude Code and quality judge auth is available' \
 		'  make benchmark* N_CONCURRENT=4 Override Harbor trial concurrency' \
 		'  make view        Open Harbor job viewer' \
-		'  make check       Syntax-check shared JS/Python and sync dataset' \
-		'  make check-generated Verify sync/check leave no generated diff' \
+		'  make lint        Run Ruff and syntax checks' \
+		'  make test        Build task solution packages' \
+		'  make check       Sync dataset, run lint checks, and build task solutions' \
+		'  make check-dataset Verify dataset digests are fresh' \
+		'  make check-generated Verify sync leaves no generated diff' \
 		'  make clean-jobs  Remove local Harbor job outputs' \
 		'  make clean       Remove generated local caches and job outputs'
 
@@ -66,12 +69,23 @@ benchmark-model: benchmark
 view:
 	harbor view jobs
 
-check: dataset
+lint:
+	ruff format --check .
+	ruff check .
 	find shared/verifier tasks/*/tests/tempo-bench-verifier -path '*/node_modules' -prune -o -type f -name '*.js' -print0 | xargs -0 -n1 node -c
 	python3 -c 'from pathlib import Path; [compile(p.read_text(), str(p), "exec") for root in [Path("shared/rewardkit"), Path("shared/rewardkit-package"), *Path("tasks").glob("*/tests")] for p in root.rglob("*.py") if "node_modules" not in p.parts]'
 	find shared/rewardkit tasks/*/tests tasks/*/solution -path '*/node_modules' -prune -o -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
+	find shared/rewardkit tasks/*/tests tasks/*/solution -path '*/node_modules' -prune -o -type f -name '*.sh' -print0 | xargs -0 shellcheck
 
-check-generated: check
+test:
+	find tasks -path '*/solution/package.json' -print0 | xargs -0 -n1 sh -c 'dir=$$(dirname "$$0"); npm --prefix "$$dir" install --ignore-scripts --no-package-lock && npm --prefix "$$dir" run build'
+
+check: dataset lint test
+
+check-dataset: dataset
+	git diff --exit-code tasks/dataset.toml
+
+check-generated: dataset
 	git diff --exit-code
 
 clean-jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+"tasks/*/tests/correctness/criteria.py" = ["F401"]

--- a/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -5,7 +5,6 @@ from .criteria import (
     tempo_typescript_project,
 )
 
-
 __all__ = [
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from rewardkit import criterion
 
-
 LOG_DIR = Path("/logs/verifier")
 
 
@@ -55,12 +54,14 @@ def tempo_typescript_project(workspace: Path) -> bool:
     results = []
     for name, relative_path in file_checks:
         exists = (workspace / relative_path).exists()
-        results.append({
-            "name": name,
-            "file": relative_path,
-            "passed": exists,
-            "error": None if exists else "missing file",
-        })
+        results.append(
+            {
+                "name": name,
+                "file": relative_path,
+                "passed": exists,
+                "error": None if exists else "missing file",
+            }
+        )
 
     results.extend(
         _pattern_check(workspace, name, file, pattern)
@@ -94,8 +95,7 @@ def tempo_onchain_verifier(workspace: Path) -> bool:
         ["bash", "/tests/correctness/verify-tempo.sh"],
         cwd=workspace,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=timeout,
         check=False,
     )
@@ -113,10 +113,15 @@ def tempo_onchain_verifier(workspace: Path) -> bool:
 
 @criterion(shared=True)
 def tempo_trajectory_matches(_workspace: Path, pattern: str) -> bool:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             content = candidate.read_text(encoding="utf-8", errors="replace")
-            matched = re.search(pattern, content, re.IGNORECASE | re.MULTILINE) is not None
+            matched = (
+                re.search(pattern, content, re.IGNORECASE | re.MULTILINE) is not None
+            )
             _write_json(
                 "trajectory-match.json",
                 {

--- a/shared/rewardkit/quality/check.py
+++ b/shared/rewardkit/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
@@ -1,30 +1,31 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_creates_stablecoin",
-        "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
-    },
-    {
-        "name": "source_creates_transfer_policy",
-        "pattern": r"policy\.createSync",
-    },
-    {
-        "name": "source_links_transfer_policy",
-        "pattern": r"changeTransferPolicySync|transferPolicy",
-    },
-    {
-        "name": "source_reads_stablecoin_currency",
-        "pattern": r"TEMPO_STABLECOIN_CURRENCY",
-    },
-    {
-        "name": "source_reads_policy_account",
-        "pattern": r"TEMPO_POLICY_ACCOUNT",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_creates_stablecoin",
+            "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
+        },
+        {
+            "name": "source_creates_transfer_policy",
+            "pattern": r"policy\.createSync",
+        },
+        {
+            "name": "source_links_transfer_policy",
+            "pattern": r"changeTransferPolicySync|transferPolicy",
+        },
+        {
+            "name": "source_reads_stablecoin_currency",
+            "pattern": r"TEMPO_STABLECOIN_CURRENCY",
+        },
+        {
+            "name": "source_reads_policy_account",
+            "pattern": r"TEMPO_POLICY_ACCOUNT",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/create-stablecoin-with-policy-docs/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -1,30 +1,31 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_creates_stablecoin",
-        "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
-    },
-    {
-        "name": "source_creates_transfer_policy",
-        "pattern": r"policy\.createSync",
-    },
-    {
-        "name": "source_links_transfer_policy",
-        "pattern": r"changeTransferPolicySync|transferPolicy",
-    },
-    {
-        "name": "source_reads_stablecoin_currency",
-        "pattern": r"TEMPO_STABLECOIN_CURRENCY",
-    },
-    {
-        "name": "source_reads_policy_account",
-        "pattern": r"TEMPO_POLICY_ACCOUNT",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_creates_stablecoin",
+            "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
+        },
+        {
+            "name": "source_creates_transfer_policy",
+            "pattern": r"policy\.createSync",
+        },
+        {
+            "name": "source_links_transfer_policy",
+            "pattern": r"changeTransferPolicySync|transferPolicy",
+        },
+        {
+            "name": "source_reads_stablecoin_currency",
+            "pattern": r"TEMPO_STABLECOIN_CURRENCY",
+        },
+        {
+            "name": "source_reads_policy_account",
+            "pattern": r"TEMPO_POLICY_ACCOUNT",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/create-stablecoin-with-policy-mcp/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -1,28 +1,29 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_creates_stablecoin",
-        "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
-    },
-    {
-        "name": "source_creates_transfer_policy",
-        "pattern": r"policy\.createSync",
-    },
-    {
-        "name": "source_links_transfer_policy",
-        "pattern": r"changeTransferPolicySync|transferPolicy",
-    },
-    {
-        "name": "source_reads_stablecoin_currency",
-        "pattern": r"TEMPO_STABLECOIN_CURRENCY",
-    },
-    {
-        "name": "source_reads_policy_account",
-        "pattern": r"TEMPO_POLICY_ACCOUNT",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_creates_stablecoin",
+            "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
+        },
+        {
+            "name": "source_creates_transfer_policy",
+            "pattern": r"policy\.createSync",
+        },
+        {
+            "name": "source_links_transfer_policy",
+            "pattern": r"changeTransferPolicySync|transferPolicy",
+        },
+        {
+            "name": "source_reads_stablecoin_currency",
+            "pattern": r"TEMPO_STABLECOIN_CURRENCY",
+        },
+        {
+            "name": "source_reads_policy_account",
+            "pattern": r"TEMPO_POLICY_ACCOUNT",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()

--- a/tasks/create-stablecoin-with-policy/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:750fcb90e32c9e351dbe6185bc6933d5932dadeb9f9c63c1e0bbdce865f6f15c"
+digest = "sha256:f20b3e0e90b81549ff6b3995c1986e194dac3403611549426fc178d01fcf9bc4"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:9868f8f4780caaf70aa7c07641e77cb6ee567b6a413e63c323e4078a72ae870e"
+digest = "sha256:2f04ae7cea2d878807bf2b8b83cfdfae6b04ca210ac7205552d01b946f0a5a4f"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:bbc5f91fa3cf7239a406f7bff3dd1b0e4f944848ea7b9fc0398cb2333b1fcd0f"
+digest = "sha256:5440d62b3fb5f764f85e800ee03556ca1284dd16d7b19a854c11f13d1a9e339c"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:ff8b6040685d351786ca053cd925f99c170e363c1088e89a0bb937690f4d8efb"
+digest = "sha256:04e2921c5c1c3135e6052c5dc8d7a2491b644ba7ef57c106012d472aeb42bd41"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:d4c4331cce6b4b66690432aca824eecbec401ca005a80338632d3a57de519f78"
+digest = "sha256:99a6b439d8df6aceda3a9bb590fdf089d64cd6ae7ab12c1c5502e5a1f789c106"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:440325b4d5f4b289fe53416ca495a322733bdee60d6992bfc63b615c23e801a5"
+digest = "sha256:d2cdc3b09f3817f622b90fa4b11ab381dce295b9806e933ff830d9ec0be96f38"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:99c4a2cadb23e6cc61ba594d1107493f3dba855722de080c7afc62dbc5211da6"
+digest = "sha256:a7189eba0ec2bba9d24cd76b926565d5b87d0bd40a4cc057248a3446b56d498e"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:5d22b52aef44926443f6bbb2f909db9718aaf9fede44a08dae4336ad319e7a07"
+digest = "sha256:5db127ba6e53ab68cf87cd6f034f91cb752f9a0b354e03cdd5466041468fd1dc"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:1664e7edadf3fefcc71165208fefb94eb88c6d5029c32590c158a092a6184677"
+digest = "sha256:bb87531d1b9e97acb2c4b63ffb510e437c987f86260da28e824d1d7cf2eb8567"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:9b1291f4fa4ef628a4302cc31f6ae3e13188051af7ad947707db8878bff10ff5"
+digest = "sha256:bd009945a1c6eda9d61dd08cc6812ea837beba993ceaf583bb53aa1b706cba01"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:726c62a7b7ded85633bb73724b32cc94662882816808ec4c757998ea1074083f"
+digest = "sha256:2ff8c305a400d1995b16f562bed5469c508bbbe03a6c9b1359d1e1ed4e9d8825"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:98c6d13baf2ab62bcc1e98810f22e87900f59c3f58c8dee6a0be37007827be67"
+digest = "sha256:cf382040be5231b9eab24ab8500ca510ddebc6760b50a312a0cfdbe68d5ba12b"
 

--- a/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
@@ -1,22 +1,23 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_calls_faucet_fund",
-        "pattern": r"faucet\.fundSync|fundSync",
-    },
-    {
-        "name": "source_reads_faucet_private_key",
-        "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
-    },
-    {
-        "name": "source_sends_transfer",
-        "pattern": r"transferSync|transferWithMemo",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_calls_faucet_fund",
+            "pattern": r"faucet\.fundSync|fundSync",
+        },
+        {
+            "name": "source_reads_faucet_private_key",
+            "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
+        },
+        {
+            "name": "source_sends_transfer",
+            "pattern": r"transferSync|transferWithMemo",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/faucet-funded-transfer-docs/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer-docs/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -1,22 +1,23 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_calls_faucet_fund",
-        "pattern": r"faucet\.fundSync|fundSync",
-    },
-    {
-        "name": "source_reads_faucet_private_key",
-        "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
-    },
-    {
-        "name": "source_sends_transfer",
-        "pattern": r"transferSync|transferWithMemo",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_calls_faucet_fund",
+            "pattern": r"faucet\.fundSync|fundSync",
+        },
+        {
+            "name": "source_reads_faucet_private_key",
+            "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
+        },
+        {
+            "name": "source_sends_transfer",
+            "pattern": r"transferSync|transferWithMemo",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/faucet-funded-transfer-mcp/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer/tests/correctness/criteria.py
@@ -1,20 +1,21 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_calls_faucet_fund",
-        "pattern": r"faucet\.fundSync|fundSync",
-    },
-    {
-        "name": "source_reads_faucet_private_key",
-        "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
-    },
-    {
-        "name": "source_sends_transfer",
-        "pattern": r"transferSync|transferWithMemo",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_calls_faucet_fund",
+            "pattern": r"faucet\.fundSync|fundSync",
+        },
+        {
+            "name": "source_reads_faucet_private_key",
+            "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
+        },
+        {
+            "name": "source_sends_transfer",
+            "pattern": r"transferSync|transferWithMemo",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()

--- a/tasks/faucet-funded-transfer/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/set-fee-token-docs/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-docs/tests/correctness/criteria.py
@@ -1,18 +1,19 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_calls_set_user_token",
-        "pattern": r"setUserToken",
-    },
-    {
-        "name": "source_reads_tempo_fee_token",
-        "pattern": r"TEMPO_FEE_TOKEN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_calls_set_user_token",
+            "pattern": r"setUserToken",
+        },
+        {
+            "name": "source_reads_tempo_fee_token",
+            "pattern": r"TEMPO_FEE_TOKEN",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/set-fee-token-docs/tests/quality/check.py
+++ b/tasks/set-fee-token-docs/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-mcp/tests/correctness/criteria.py
@@ -1,18 +1,19 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_calls_set_user_token",
-        "pattern": r"setUserToken",
-    },
-    {
-        "name": "source_reads_tempo_fee_token",
-        "pattern": r"TEMPO_FEE_TOKEN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_calls_set_user_token",
+            "pattern": r"setUserToken",
+        },
+        {
+            "name": "source_reads_tempo_fee_token",
+            "pattern": r"TEMPO_FEE_TOKEN",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/set-fee-token-mcp/tests/quality/check.py
+++ b/tasks/set-fee-token-mcp/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/set-fee-token/tests/correctness/criteria.py
@@ -1,16 +1,17 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_calls_set_user_token",
-        "pattern": r"setUserToken",
-    },
-    {
-        "name": "source_reads_tempo_fee_token",
-        "pattern": r"TEMPO_FEE_TOKEN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_calls_set_user_token",
+            "pattern": r"setUserToken",
+        },
+        {
+            "name": "source_reads_tempo_fee_token",
+            "pattern": r"TEMPO_FEE_TOKEN",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()

--- a/tasks/set-fee-token/tests/quality/check.py
+++ b/tasks/set-fee-token/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
@@ -1,30 +1,34 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_dex_actions",
-        "pattern": r"Actions\.dex|\.dex\.",
-    },
-    {
-        "name": "source_approves_dex_spending",
-        "pattern": r"approveSync",
-    },
-    {
-        "name": "source_provides_dex_liquidity",
-        "pattern": r"placeSync|provideLiquidity|addLiquidity",
-    },
-    {
-        "name": "source_executes_dex_swap",
-        "pattern": r"sellSync|buySync|swapSync",
-    },
-    {
-        "name": "source_reads_swap_token_env",
-        "pattern": r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_dex_actions",
+            "pattern": r"Actions\.dex|\.dex\.",
+        },
+        {
+            "name": "source_approves_dex_spending",
+            "pattern": r"approveSync",
+        },
+        {
+            "name": "source_provides_dex_liquidity",
+            "pattern": r"placeSync|provideLiquidity|addLiquidity",
+        },
+        {
+            "name": "source_executes_dex_swap",
+            "pattern": r"sellSync|buySync|swapSync",
+        },
+        {
+            "name": "source_reads_swap_token_env",
+            "pattern": (
+                r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|"
+                r"TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN"
+            ),
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/stablecoin-dex-swap-docs/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -1,30 +1,34 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_dex_actions",
-        "pattern": r"Actions\.dex|\.dex\.",
-    },
-    {
-        "name": "source_approves_dex_spending",
-        "pattern": r"approveSync",
-    },
-    {
-        "name": "source_provides_dex_liquidity",
-        "pattern": r"placeSync|provideLiquidity|addLiquidity",
-    },
-    {
-        "name": "source_executes_dex_swap",
-        "pattern": r"sellSync|buySync|swapSync",
-    },
-    {
-        "name": "source_reads_swap_token_env",
-        "pattern": r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_dex_actions",
+            "pattern": r"Actions\.dex|\.dex\.",
+        },
+        {
+            "name": "source_approves_dex_spending",
+            "pattern": r"approveSync",
+        },
+        {
+            "name": "source_provides_dex_liquidity",
+            "pattern": r"placeSync|provideLiquidity|addLiquidity",
+        },
+        {
+            "name": "source_executes_dex_swap",
+            "pattern": r"sellSync|buySync|swapSync",
+        },
+        {
+            "name": "source_reads_swap_token_env",
+            "pattern": (
+                r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|"
+                r"TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN"
+            ),
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/stablecoin-dex-swap-mcp/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -1,28 +1,32 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_dex_actions",
-        "pattern": r"Actions\.dex|\.dex\.",
-    },
-    {
-        "name": "source_approves_dex_spending",
-        "pattern": r"approveSync",
-    },
-    {
-        "name": "source_provides_dex_liquidity",
-        "pattern": r"placeSync|provideLiquidity|addLiquidity",
-    },
-    {
-        "name": "source_executes_dex_swap",
-        "pattern": r"sellSync|buySync|swapSync",
-    },
-    {
-        "name": "source_reads_swap_token_env",
-        "pattern": r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_dex_actions",
+            "pattern": r"Actions\.dex|\.dex\.",
+        },
+        {
+            "name": "source_approves_dex_spending",
+            "pattern": r"approveSync",
+        },
+        {
+            "name": "source_provides_dex_liquidity",
+            "pattern": r"placeSync|provideLiquidity|addLiquidity",
+        },
+        {
+            "name": "source_executes_dex_swap",
+            "pattern": r"sellSync|buySync|swapSync",
+        },
+        {
+            "name": "source_reads_swap_token_env",
+            "pattern": (
+                r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|"
+                r"TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN"
+            ),
+        },
+    ]
+)
 rk.tempo_onchain_verifier()

--- a/tasks/stablecoin-dex-swap/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
@@ -1,22 +1,23 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_transfer_with_memo_semantics",
-        "pattern": r"transferWithMemo|transferSync",
-    },
-    {
-        "name": "source_reads_tempo_memo",
-        "pattern": r"TEMPO_MEMO",
-    },
-    {
-        "name": "source_parses_token_units",
-        "pattern": r"parseUnits",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_transfer_with_memo_semantics",
+            "pattern": r"transferWithMemo|transferSync",
+        },
+        {
+            "name": "source_reads_tempo_memo",
+            "pattern": r"TEMPO_MEMO",
+        },
+        {
+            "name": "source_parses_token_units",
+            "pattern": r"parseUnits",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/transfer-with-memo-docs/tests/quality/check.py
+++ b/tasks/transfer-with-memo-docs/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
@@ -1,34 +1,35 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_transfer_with_memo_semantics",
-        "pattern": r"transferWithMemo|transferSync",
-    },
-    {
-        "name": "source_reads_tempo_memo",
-        "pattern": r"TEMPO_MEMO",
-    },
-    {
-        "name": "source_parses_token_units",
-        "pattern": r"parseUnits",
-    },
-    {
-        "name": "source_reads_fee_payer_private_key",
-        "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
-    },
-    {
-        "name": "source_passes_fee_payer",
-        "pattern": r"feePayer",
-    },
-    {
-        "name": "source_reads_fee_token",
-        "pattern": r"TEMPO_FEE_TOKEN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_transfer_with_memo_semantics",
+            "pattern": r"transferWithMemo|transferSync",
+        },
+        {
+            "name": "source_reads_tempo_memo",
+            "pattern": r"TEMPO_MEMO",
+        },
+        {
+            "name": "source_parses_token_units",
+            "pattern": r"parseUnits",
+        },
+        {
+            "name": "source_reads_fee_payer_private_key",
+            "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
+        },
+        {
+            "name": "source_passes_fee_payer",
+            "pattern": r"feePayer",
+        },
+        {
+            "name": "source_reads_fee_token",
+            "pattern": r"TEMPO_FEE_TOKEN",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -1,34 +1,35 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_transfer_with_memo_semantics",
-        "pattern": r"transferWithMemo|transferSync",
-    },
-    {
-        "name": "source_reads_tempo_memo",
-        "pattern": r"TEMPO_MEMO",
-    },
-    {
-        "name": "source_parses_token_units",
-        "pattern": r"parseUnits",
-    },
-    {
-        "name": "source_reads_fee_payer_private_key",
-        "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
-    },
-    {
-        "name": "source_passes_fee_payer",
-        "pattern": r"feePayer",
-    },
-    {
-        "name": "source_reads_fee_token",
-        "pattern": r"TEMPO_FEE_TOKEN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_transfer_with_memo_semantics",
+            "pattern": r"transferWithMemo|transferSync",
+        },
+        {
+            "name": "source_reads_tempo_memo",
+            "pattern": r"TEMPO_MEMO",
+        },
+        {
+            "name": "source_parses_token_units",
+            "pattern": r"parseUnits",
+        },
+        {
+            "name": "source_reads_fee_payer_private_key",
+            "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
+        },
+        {
+            "name": "source_passes_fee_payer",
+            "pattern": r"feePayer",
+        },
+        {
+            "name": "source_reads_fee_token",
+            "pattern": r"TEMPO_FEE_TOKEN",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -1,32 +1,33 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_transfer_with_memo_semantics",
-        "pattern": r"transferWithMemo|transferSync",
-    },
-    {
-        "name": "source_reads_tempo_memo",
-        "pattern": r"TEMPO_MEMO",
-    },
-    {
-        "name": "source_parses_token_units",
-        "pattern": r"parseUnits",
-    },
-    {
-        "name": "source_reads_fee_payer_private_key",
-        "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
-    },
-    {
-        "name": "source_passes_fee_payer",
-        "pattern": r"feePayer",
-    },
-    {
-        "name": "source_reads_fee_token",
-        "pattern": r"TEMPO_FEE_TOKEN",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_transfer_with_memo_semantics",
+            "pattern": r"transferWithMemo|transferSync",
+        },
+        {
+            "name": "source_reads_tempo_memo",
+            "pattern": r"TEMPO_MEMO",
+        },
+        {
+            "name": "source_parses_token_units",
+            "pattern": r"parseUnits",
+        },
+        {
+            "name": "source_reads_fee_payer_private_key",
+            "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
+        },
+        {
+            "name": "source_passes_fee_payer",
+            "pattern": r"feePayer",
+        },
+        {
+            "name": "source_reads_fee_token",
+            "pattern": r"TEMPO_FEE_TOKEN",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()

--- a/tasks/transfer-with-memo-fee-payer/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -1,22 +1,23 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_transfer_with_memo_semantics",
-        "pattern": r"transferWithMemo|transferSync",
-    },
-    {
-        "name": "source_reads_tempo_memo",
-        "pattern": r"TEMPO_MEMO",
-    },
-    {
-        "name": "source_parses_token_units",
-        "pattern": r"parseUnits",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_transfer_with_memo_semantics",
+            "pattern": r"transferWithMemo|transferSync",
+        },
+        {
+            "name": "source_reads_tempo_memo",
+            "pattern": r"TEMPO_MEMO",
+        },
+        {
+            "name": "source_parses_token_units",
+            "pattern": r"parseUnits",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()
 
 rk.tempo_trajectory_matches(

--- a/tasks/transfer-with-memo-mcp/tests/quality/check.py
+++ b/tasks/transfer-with-memo-mcp/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",

--- a/tasks/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo/tests/correctness/criteria.py
@@ -1,20 +1,21 @@
 import rewardkit as rk
 import tempo_bench_rewardkit
 
-
 rk.tempo_typescript_project()
-rk.tempo_source_patterns([
-    {
-        "name": "source_uses_transfer_with_memo_semantics",
-        "pattern": r"transferWithMemo|transferSync",
-    },
-    {
-        "name": "source_reads_tempo_memo",
-        "pattern": r"TEMPO_MEMO",
-    },
-    {
-        "name": "source_parses_token_units",
-        "pattern": r"parseUnits",
-    },
-])
+rk.tempo_source_patterns(
+    [
+        {
+            "name": "source_uses_transfer_with_memo_semantics",
+            "pattern": r"transferWithMemo|transferSync",
+        },
+        {
+            "name": "source_reads_tempo_memo",
+            "pattern": r"TEMPO_MEMO",
+        },
+        {
+            "name": "source_parses_token_units",
+            "pattern": r"parseUnits",
+        },
+    ]
+)
 rk.tempo_onchain_verifier()

--- a/tasks/transfer-with-memo/tests/quality/check.py
+++ b/tasks/transfer-with-memo/tests/quality/check.py
@@ -7,7 +7,10 @@ from rewardkit import criterion
 
 
 def _trajectory_path() -> Path | None:
-    for candidate in (Path("/logs/trajectory.json"), Path("/logs/agent/trajectory.json")):
+    for candidate in (
+        Path("/logs/trajectory.json"),
+        Path("/logs/agent/trajectory.json"),
+    ):
         if candidate.exists():
             return candidate
     return None
@@ -67,8 +70,12 @@ def _token_metrics(trajectory: dict) -> dict[str, int]:
         metrics["completion_tokens"] += int(step_metrics.get("completion_tokens") or 0)
         metrics["cached_tokens"] += int(step_metrics.get("cached_tokens") or 0)
         extra = step_metrics.get("extra") or {}
-        metrics["cache_creation_input_tokens"] += int(extra.get("cache_creation_input_tokens") or 0)
-        metrics["cache_read_input_tokens"] += int(extra.get("cache_read_input_tokens") or 0)
+        metrics["cache_creation_input_tokens"] += int(
+            extra.get("cache_creation_input_tokens") or 0
+        )
+        metrics["cache_read_input_tokens"] += int(
+            extra.get("cache_read_input_tokens") or 0
+        )
 
     metrics["total_tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
     metrics["uncached_token_estimate"] = (
@@ -93,7 +100,9 @@ def agent_turn_efficiency(_workspace: Path) -> float:
         return 0.0
 
     trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(1 for step in trajectory.get("steps", []) if step.get("source") == "agent")
+    turn_count = sum(
+        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
+    )
     score = _score_by_cutoff(turn_count, raw_cutoffs)
     _merge_efficiency(
         "turns",


### PR DESCRIPTION
## Motivation

Keep task helpers formatted, catch shell issues, and make generated dataset drift visible during pull requests.

## Summary

- Add repo-level Ruff configuration.
- Add Makefile targets for linting, task solution builds, dataset freshness, and generated artifact checks.
- Add GitHub Actions CI for Ruff, ShellCheck, and dataset freshness.
- Format the shared RewardKit and task criteria files, then refresh dataset digests.

## Key design considerations

- Keep generated-artifact validation separate from lint validation.
- Leave task solution builds available locally via `make test` without running them in pull request CI.
- Ignore intentional RewardKit side-effect imports only in task correctness criteria files.
