### PR TITLE
Cache workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,24 +23,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
-      - name: Add uv tool directory to PATH
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install ShellCheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
-
-      - name: Install Ruff
-        run: python -m pip install ruff==0.15.0
-
-      - name: Install Harbor
-        run: uv tool install harbor
+      - name: Install Python dependencies
+        run: uv sync --locked --dev --all-extras
 
       - name: Install npm dependencies
-        run: npm install --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Run lint checks
         run: npm run check

--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -27,15 +27,12 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
-      - name: Add uv tool directory to PATH
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install Harbor
-        run: uv tool install harbor
-
-      - name: Install npm dependencies
-        run: npm install --no-audit --no-fund
+      - name: Install Python dependencies
+        run: uv sync --locked --dev --all-extras
 
       - name: Verify generated artifacts
         run: npm run check:generated

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pnpm-debug.log*
 # JavaScript package/install output
 node_modules/
 package-lock.json
+!/package-lock.json
 yarn.lock
 pnpm-lock.yaml
 tasks/**/tests/node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "tempo-bench",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tempo-bench",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

CI should avoid reinstalling toolchains from scratch when lockfiles already define the Python and Node dependency sets.

## Summary

- Enable npm caching with a tracked root lockfile
- Enable uv caching keyed by `uv.lock`
- Replace separate apt, pip, and uv tool installs with `uv sync --locked`
- Skip npm dependency install in the generated-artifact workflow where runtime scripts only use built-in Node APIs

## Key design considerations

- Keep dependency installs lockfile-driven for reproducibility
- Remove unused setup steps instead of adding more cache layers
- Preserve the existing workflow jobs and check names
