### PR TITLE
Fix Daytona benchmark runner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ profile configures the remote `tempo` MCP server at `https://mcp.tempo.xyz`.
 | `config/job.local.*.yaml` | Local Docker Harbor jobs. |
 | `config/job.daytona.*.yaml` | Daytona DinD Harbor jobs. |
 | `scripts/run-benchmark.ts` | Single entrypoint for sync, dataset refresh, checks, local runs, Daytona runs, and cleanup. |
-| `scripts/create-daytona-dind-snapshot.py` | Creates the DinD snapshot referenced by Daytona configs. |
+| `scripts/create-daytona-dind-snapshot.py` | Optional helper for creating reusable Daytona DinD snapshots. |
 | `scripts/sync-shared.mjs` | Generates docs/MCP task variants and syncs shared verifier/assets into task contexts. |
 | `shared/` | Source of truth for reusable Docker, verifier, RewardKit, MCP, and localnet code. |
 | `tasks/` | Harbor dataset and task directories. Some shared assets are intentionally symlinked. |
@@ -97,13 +97,12 @@ Create `.env` with the runtime credentials you need:
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code subscription auth. |
 | `CLAUDE_FORCE_OAUTH` | Optional Claude Code OAuth forcing; use `1`/`true`, not an empty value. |
 | `DAYTONA_API_KEY` | Daytona runs. |
-| `DAYTONA_TARGET` | Optional Daytona target; defaults to `us`. |
+| `DAYTONA_TARGET` | Optional Daytona target. |
 
-Create or verify the Daytona DinD snapshot:
-
-```bash
-uv run scripts/create-daytona-dind-snapshot.py --recreate-error
-```
+The checked-in Daytona configs start from `docker:28.3.3-dind` directly. If you
+want to experiment with snapshot-backed startup later, create a snapshot with
+`uv run scripts/create-daytona-dind-snapshot.py --recreate-error` and set
+`environment.kwargs.dind_snapshot` in the Daytona config.
 
 ## Run
 
@@ -133,6 +132,12 @@ Override concurrency:
 
 ```bash
 npm run bench:daytona:agent -- --concurrency 4 --agent-concurrency 2
+```
+
+Run a single task through a config-backed Daytona job:
+
+```bash
+npm run bench:daytona:agent:dev -- --task-filter transfer-with-memo-mcp --concurrency 1 --agent-concurrency 1
 ```
 
 Use a stable job name:

--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ npm run bench:daytona:agent
 Override concurrency:
 
 ```bash
-npm run bench:daytona:agent -- --concurrency 4 --agent-concurrency 2 --max-retries 2
+npm run bench:daytona:agent -- --concurrency 4 --agent-concurrency 2
 ```
 
-For Daytona runs, use `--max-retries 2` to retry transient remote Docker
-startup failures in a fresh sandbox.
+Daytona runs default to two retries for transient remote Docker startup
+failures in a fresh sandbox.
 
 Run a single task through a config-backed Daytona job:
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ npm run bench:daytona:agent
 Override concurrency:
 
 ```bash
-npm run bench:daytona:agent -- --concurrency 4 --agent-concurrency 2
+npm run bench:daytona:agent -- --concurrency 4 --agent-concurrency 2 --max-retries 2
 ```
+
+For Daytona runs, use `--max-retries 2` to retry transient remote Docker
+startup failures in a fresh sandbox.
 
 Run a single task through a config-backed Daytona job:
 

--- a/config/job.daytona.agent.dev.yaml
+++ b/config/job.daytona.agent.dev.yaml
@@ -15,7 +15,7 @@ environment:
   force_build: false
   delete: true
   kwargs:
-    dind_snapshot: tempo-bench-dind-28-3-3
+    dind_image: docker:28.3.3-dind
     connection_pool_maxsize: null
 verifier:
   env:

--- a/config/job.daytona.agent.yaml
+++ b/config/job.daytona.agent.yaml
@@ -14,7 +14,7 @@ environment:
   force_build: false
   delete: true
   kwargs:
-    dind_snapshot: tempo-bench-dind-28-3-3
+    dind_image: docker:28.3.3-dind
     connection_pool_maxsize: null
 verifier:
   env:

--- a/config/job.daytona.oracle.yaml
+++ b/config/job.daytona.oracle.yaml
@@ -14,7 +14,7 @@ environment:
   force_build: false
   delete: true
   kwargs:
-    dind_snapshot: tempo-bench-dind-28-3-3
+    dind_image: docker:28.3.3-dind
     connection_pool_maxsize: null
 verifier:
   env:

--- a/scripts/create-daytona-dind-snapshot.py
+++ b/scripts/create-daytona-dind-snapshot.py
@@ -22,6 +22,11 @@ DEFAULT_NAME = "tempo-bench-dind-28-3-3"
 DEFAULT_IMAGE = "docker:28.3.3-dind"
 
 
+def snapshot_state(snapshot) -> str:
+    state = getattr(snapshot, "state", "")
+    return str(getattr(state, "value", state)).upper()
+
+
 def load_env_file(path: Path) -> None:
     if not path.exists():
         return
@@ -57,7 +62,8 @@ def parse_args() -> argparse.Namespace:
 
 
 async def snapshot_by_name(daytona: AsyncDaytona, name: str):
-    snapshots = await daytona.snapshot.list()
+    response = await daytona.snapshot.list()
+    snapshots = getattr(response, "items", response)
     for snapshot in snapshots:
         if snapshot.name == name:
             return snapshot
@@ -76,7 +82,7 @@ async def wait_for_snapshot(
             await asyncio.sleep(5)
             continue
 
-        state = str(getattr(snapshot, "state", "")).upper()
+        state = snapshot_state(snapshot)
         print(f"{name}: {state or 'UNKNOWN'}")
         if state == "ACTIVE":
             return snapshot
@@ -95,33 +101,36 @@ async def main() -> None:
         raise SystemExit("DAYTONA_API_KEY is required")
 
     daytona = AsyncDaytona(DaytonaConfig(target=args.target))
-    existing = await snapshot_by_name(daytona, args.name)
-    if existing is not None:
-        state = str(getattr(existing, "state", "")).upper()
-        if state == "ACTIVE":
-            print(f"snapshot ready: {args.name}")
-            return
-        if args.recreate_error and ("ERROR" in state or "FAILED" in state):
-            await daytona.snapshot.delete(existing)
-        else:
-            print(f"snapshot exists: {args.name} ({state or 'UNKNOWN'})")
-            await wait_for_snapshot(daytona, args.name, args.timeout_seconds)
-            print(f"snapshot ready: {args.name}")
-            return
+    try:
+        existing = await snapshot_by_name(daytona, args.name)
+        if existing is not None:
+            state = snapshot_state(existing)
+            if state == "ACTIVE":
+                print(f"snapshot ready: {args.name}")
+                return
+            if args.recreate_error and ("ERROR" in state or "FAILED" in state):
+                await daytona.snapshot.delete(existing)
+            else:
+                print(f"snapshot exists: {args.name} ({state or 'UNKNOWN'})")
+                await wait_for_snapshot(daytona, args.name, args.timeout_seconds)
+                print(f"snapshot ready: {args.name}")
+                return
 
-    await daytona.snapshot.create(
-        CreateSnapshotParams(
-            name=args.name,
-            image=args.image,
-            resources=Resources(
-                cpu=args.cpu,
-                memory=args.memory,
-                disk=args.disk,
-            ),
+        await daytona.snapshot.create(
+            CreateSnapshotParams(
+                name=args.name,
+                image=args.image,
+                resources=Resources(
+                    cpu=args.cpu,
+                    memory=args.memory,
+                    disk=args.disk,
+                ),
+            )
         )
-    )
-    await wait_for_snapshot(daytona, args.name, args.timeout_seconds)
-    print(f"snapshot ready: {args.name}")
+        await wait_for_snapshot(daytona, args.name, args.timeout_seconds)
+        print(f"snapshot ready: {args.name}")
+    finally:
+        await daytona.close()
 
 
 if __name__ == "__main__":

--- a/scripts/run-benchmark.ts
+++ b/scripts/run-benchmark.ts
@@ -99,7 +99,7 @@ Options:
   --agent-concurrency N   Override per-agent n_concurrent
   --agent NAME            Agent for the model variant (default: claude-code)
   --model NAME            Model for the model variant (default: haiku)
-  --task-filter GLOB      Include matching task names for the model variant
+  --task-filter GLOB      Include matching task names for model and Daytona config variants
   --n-tasks N             Limit task count for the model variant
   --tasks PATH            Task dataset path for dataset/model variants (default: tasks)
   --no-sync               Skip task asset and dataset sync before running Harbor
@@ -254,7 +254,23 @@ function syncDataset(options: Options) {
   run("uv", ["run", "harbor", "sync", taskPath(options)]);
 }
 
-function stageDaytonaConfig(configPath: string, runId: string): string {
+function applyTaskFilter(config: string, taskFilter?: string): string {
+  if (!taskFilter) return config;
+  const filtered = config.replace(
+    /(^\s+task_names:\n)(?:^\s+-\s+.*\n)+/m,
+    `$1      - ${JSON.stringify(taskFilter)}\n`,
+  );
+  if (filtered === config) {
+    throw new Error("Could not apply task filter to config");
+  }
+  return filtered;
+}
+
+function stageDaytonaConfig(
+  configPath: string,
+  runId: string,
+  taskFilter?: string,
+): string {
   const stagingRoot = path.join(".cache", "harbor-daytona", runId);
   const stagedTasks = path.join(stagingRoot, "tasks");
   const stagedConfig = path.join(stagingRoot, path.basename(configPath));
@@ -270,7 +286,7 @@ function stageDaytonaConfig(configPath: string, runId: string): string {
   });
 
   const config = fs.readFileSync(configPath, "utf8");
-  const redirected = config.replace(
+  const redirected = applyTaskFilter(config, taskFilter).replace(
     /(^\s*-\s*path:\s*)tasks\s*$/m,
     `$1${JSON.stringify(stagedTasks)}`,
   );
@@ -331,7 +347,7 @@ try {
   const args = ["run", "harbor", "run"];
   if (variant.config) {
     const config = variant.needsDaytonaAuth
-      ? stageDaytonaConfig(variant.config, runId)
+      ? stageDaytonaConfig(variant.config, runId, options.taskFilter)
       : variant.config;
     args.push("-c", config);
   } else {

--- a/scripts/run-benchmark.ts
+++ b/scripts/run-benchmark.ts
@@ -23,6 +23,7 @@ type Options = {
   jobName?: string;
   concurrency?: string;
   agentConcurrency?: string;
+  maxRetries?: string;
   agent?: string;
   model?: string;
   taskFilter?: string;
@@ -97,6 +98,7 @@ Options:
   --job-name NAME          Override generated job name
   --concurrency N         Override n_concurrent_trials
   --agent-concurrency N   Override per-agent n_concurrent
+  --max-retries N         Retry transient trial/setup failures
   --agent NAME            Agent for the model variant (default: claude-code)
   --model NAME            Model for the model variant (default: haiku)
   --task-filter GLOB      Include matching task names for model and Daytona config variants
@@ -149,6 +151,9 @@ function parseArgs(argv: string[]): { variant?: string; options: Options } {
       i += 1;
     } else if (arg === "--agent-concurrency") {
       options.agentConcurrency = readPositiveInteger(readOptionValue(rest, i, arg), arg);
+      i += 1;
+    } else if (arg === "--max-retries") {
+      options.maxRetries = readPositiveInteger(readOptionValue(rest, i, arg), arg);
       i += 1;
     } else if (arg === "--agent") {
       options.agent = readOptionValue(rest, i, arg);
@@ -364,6 +369,7 @@ try {
   if (options.agentConcurrency) {
     args.push("--n-concurrent-agents", options.agentConcurrency);
   }
+  if (options.maxRetries) args.push("--max-retries", options.maxRetries);
   args.push("-y");
   run("uv", args);
 } catch (error) {

--- a/scripts/run-benchmark.ts
+++ b/scripts/run-benchmark.ts
@@ -98,7 +98,7 @@ Options:
   --job-name NAME          Override generated job name
   --concurrency N         Override n_concurrent_trials
   --agent-concurrency N   Override per-agent n_concurrent
-  --max-retries N         Retry transient trial/setup failures
+  --max-retries N         Retry transient trial/setup failures (default: 2 for Daytona runs)
   --agent NAME            Agent for the model variant (default: claude-code)
   --model NAME            Model for the model variant (default: haiku)
   --task-filter GLOB      Include matching task names for model and Daytona config variants
@@ -369,7 +369,8 @@ try {
   if (options.agentConcurrency) {
     args.push("--n-concurrent-agents", options.agentConcurrency);
   }
-  if (options.maxRetries) args.push("--max-retries", options.maxRetries);
+  const maxRetries = options.maxRetries ?? (variant.needsDaytonaAuth ? "2" : undefined);
+  if (maxRetries) args.push("--max-retries", maxRetries);
   args.push("-y");
   run("uv", args);
 } catch (error) {


### PR DESCRIPTION
## Summary

- Use `docker:28.3.3-dind` directly in Daytona configs instead of requiring an account-local `dind_snapshot`.
- Support `--task-filter` for Daytona config-backed jobs so remote smoke runs do not require YAML edits.
- Default Daytona runs to two Harbor retries for transient remote Docker startup failures, while still allowing `--max-retries` overrides.
- Keep the snapshot helper working for teams that still want to experiment with snapshots later.

## Why

The snapshot-backed Daytona path was not portable in a fresh setup and failed during Docker startup/build with Docker socket reset errors. The direct image path worked for agent and oracle Daytona runs.

Full Daytona agent runs can still hit occasional pre-agent Docker-in-Docker startup flakes. Harbor already supports retries, so this PR defaults Daytona variants to two retries instead of adding custom retry logic.

## Validation

- `npm run check`
- `npm run bench:daytona:oracle -- --task-filter transfer-with-memo-mcp --concurrency 1 --job-name pr16-dind-image-oracle-smoke-20260706 --no-sync --max-retries 2`
  - completed 1 trial, 0 exceptions, reward 1
- `npm run bench:daytona:agent:dev -- --task-filter transfer-with-memo-mcp --concurrency 1 --agent-concurrency 1 --job-name pr16-dind-image-agent-dev-smoke-20260706 --no-sync --max-retries 2`
  - completed 1 trial, 0 exceptions, reward 0
- `npm run bench:daytona:oracle -- --concurrency 4 --job-name pr16-dind-image-oracle-full-c4-20260706 --no-sync --max-retries 2`
  - completed 12 trials, 0 exceptions, mean 1.000
- `npm run bench:daytona:agent -- --concurrency 4 --agent-concurrency 2 --job-name pr16-dind-image-agent-full-c4-a2-r2-20260706 --no-sync --max-retries 2`
  - completed 36 trials, 0 exceptions, mean 0.194, Pass@2 0.222, 1 retry
- `npm run bench:daytona:oracle -- --task-filter transfer-with-memo-mcp --concurrency 1 --job-name pr16-default-retries-oracle-smoke-20260706 --no-sync`
  - completed 1 trial, 0 exceptions, reward 1