### PR TITLE
Fix Claude Code MCP profile setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The docs profile exposes a local HTTP docs sidecar at
 `TEMPO_DOCS_URL=http://tempo-docs:3000/developers`. The sidecar is generated
 from the locked `tempoxyz/docs` commit in `config/tempo-docs.lock.json` and
 serves public-compatible agent docs routes such as `/developers/llms.txt`,
-`/developers/llms-full.txt`, and `/developers/docs/*.md`. The MCP profile
-configures the remote `tempo` MCP server at `https://mcp.tempo.xyz`.
+`/developers/llms-full.txt`, and `/developers/docs/*.md`. The MCP profile uses
+Harbor's native `[[environment.mcp_servers]]` task config to register the
+public `tempo` MCP server at `https://mcp.tempo.xyz`.
 
 ## Structure
 

--- a/scripts/sync-shared.mjs
+++ b/scripts/sync-shared.mjs
@@ -280,6 +280,7 @@ function updateProfileCriteria(taskDir, profile) {
     /\nrk\.tempo_trajectory_matches\([\s\S]*?\n\)\n/g,
     "\n",
   );
+  content = content.replace(/\nrk\.tempo_mcp_tool_used\([\s\S]*?\)\n/g, "\n");
 
   if (profile.id === "docs") {
     content += `
@@ -289,9 +290,7 @@ rk.tempo_trajectory_matches(
 `;
   } else if (profile.id === "mcp") {
     content += `
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")
 `;
   }
 
@@ -565,7 +564,11 @@ function taskUsesLocalTempoDocs(taskDir) {
   const taskConfig = fs.existsSync(taskConfigPath) ? fs.readFileSync(taskConfigPath, "utf8") : "";
   const compose = fs.existsSync(composePath) ? fs.readFileSync(composePath, "utf8") : "";
 
-  return taskConfig.includes('profile = "docs"') || taskConfig.includes("TEMPO_DOCS_URL") || compose.includes("tempo-docs");
+  return (
+    taskConfig.includes('profile = "docs"') ||
+    taskConfig.includes("TEMPO_DOCS_URL") ||
+    compose.includes("tempo-docs:")
+  );
 }
 
 function assertComposeBuildContexts(taskDir) {

--- a/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -1,6 +1,7 @@
 from .criteria import (
     agent_token_efficiency,
     agent_turn_efficiency,
+    tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
     tempo_trajectory_matches,
@@ -10,6 +11,7 @@ from .criteria import (
 __all__ = [
     "agent_token_efficiency",
     "agent_turn_efficiency",
+    "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",
     "tempo_trajectory_matches",

--- a/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -224,6 +224,52 @@ def tempo_trajectory_matches(_workspace: Path, pattern: str) -> bool:
 
 
 @criterion(shared=True)
+def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
+    path = _trajectory_path()
+    prefix = f"mcp__{server_name}__"
+    if path is None:
+        _write_json(
+            "mcp-tool-use.json",
+            {
+                "trajectory": None,
+                "server_name": server_name,
+                "tool_prefix": prefix,
+                "tool_calls": [],
+                "passed": False,
+            },
+        )
+        return False
+
+    trajectory = json.loads(path.read_text(encoding="utf-8"))
+    tool_calls = []
+    for step_index, step in enumerate(trajectory.get("steps", [])):
+        for call in step.get("tool_calls") or []:
+            function_name = call.get("function_name")
+            if not isinstance(function_name, str):
+                continue
+            tool_calls.append(
+                {
+                    "step_index": step_index,
+                    "function_name": function_name,
+                    "matched": function_name.startswith(prefix),
+                },
+            )
+
+    passed = any(call["matched"] for call in tool_calls)
+    _write_json(
+        "mcp-tool-use.json",
+        {
+            "trajectory": str(path),
+            "server_name": server_name,
+            "tool_prefix": prefix,
+            "tool_calls": tool_calls,
+            "passed": passed,
+        },
+    )
+    return passed
+
+
+@criterion(shared=True)
 def agent_turn_efficiency(_workspace: Path) -> float:
     raw_cutoffs = os.environ.get(
         "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",

--- a/shared/rewardkit/test.sh
+++ b/shared/rewardkit/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/create-stablecoin-with-policy-docs/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy-docs/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -28,6 +28,4 @@ rk.tempo_source_patterns(
 )
 rk.tempo_onchain_verifier()
 
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/create-stablecoin-with-policy/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:11abf953d7d0ee3d6a56589541c98466f8f965e3c7941ac29ae5182599eea4e3"
+digest = "sha256:da2ea37270ff39decfdc050f3967cc0f270ff69deb674c75e7aec8918e938030"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:ba1d92233f0534fddd59c5e65fcad86ca9168ed94d43b893cb4cb330bbf3f365"
+digest = "sha256:a92fb8d0f076042146c89c495aea46294943c129635d97366086db891d764748"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:5e16f29b92b2104e6ee75cb66e3bb4ce25a3ab86e34d961e2c1c029dfc05e74b"
+digest = "sha256:ebf991cbee22d1f4b5679c2c6ec233bd3df80b4a572aec0f7f38987c3973d1c5"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:67bcf72c8f58856def8bc9c6ac6108ca9214ad4d878c115f7d168cc42dab64b0"
+digest = "sha256:60e66b4f975e31751f31b876f0f5f18a25df24b9b9a039775934e2d0d243f6fb"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:525e1207f570d3750bb4dd29f99750f98a8243047a92193d060f02e36dbef926"
+digest = "sha256:462643fee69bec7f19820b1fc0908e316963aac9b56666f2bc9226c9f9713e3a"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:2293d9fe466cc99a03fdb53a5d976b34bb0159f462c72cfc2da0c6ea72df431b"
+digest = "sha256:b532e93bd11b92baeaf39fd06bd7ff4cfcee43abb6461888e4d256c8762e6be6"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:55da53d20d6ffd0726373925290ef8df9cfff1c7d82409eb1ac5ab792ade55e8"
+digest = "sha256:f1c01d960e4c1631830c3cb0dc435b550cea1e9f14dfab8a3988ebaec6735036"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:919b4085537040c242cfdc100ecc5169757bc8a9a21fb0e6823acc1873225142"
+digest = "sha256:a054983a28b5f009aa7c4153752808faffe98dc127baf839b12a50b99cab55af"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:e38ec81a5142f4be7711b55f9dd48f98c6d476959d64baf4f57185f5a939b795"
+digest = "sha256:cef76f945e7706da47702adc4d9b28d64063e913db78ca61c0a9c253fada3e99"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:14dba134c43f037d79055267a601db82eed42fb4f2298f3015d9213ba57a5031"
+digest = "sha256:99299b4d51fc11c239d10d7cc2ee14ad388071e1a30808f118874370051f4d3b"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:d80cb2452c730934be7d8b3396060f6cf074c79c4bf5e34b8455ca7179b1d910"
+digest = "sha256:279f6176120dbc2a883a26203bf668bc9fcadea1c9e3888e6d484fd8fb3526ef"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:148dd607b25ee4ac77498c5a668cccfcdf78129125c428facff38b24374ea5e9"
+digest = "sha256:ac8ff8fa3582cf00d51c2dd3942f51e5c466f692a5c1c3d97fe85182d8f44104"
 

--- a/tasks/faucet-funded-transfer-docs/tests/test.sh
+++ b/tasks/faucet-funded-transfer-docs/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -20,6 +20,4 @@ rk.tempo_source_patterns(
 )
 rk.tempo_onchain_verifier()
 
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/faucet-funded-transfer-mcp/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/faucet-funded-transfer/tests/test.sh
+++ b/tasks/faucet-funded-transfer/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/set-fee-token-docs/tests/test.sh
+++ b/tasks/set-fee-token-docs/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-mcp/tests/correctness/criteria.py
@@ -16,6 +16,4 @@ rk.tempo_source_patterns(
 )
 rk.tempo_onchain_verifier()
 
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/set-fee-token-mcp/tests/test.sh
+++ b/tasks/set-fee-token-mcp/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/set-fee-token/tests/test.sh
+++ b/tasks/set-fee-token/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/stablecoin-dex-swap-docs/tests/test.sh
+++ b/tasks/stablecoin-dex-swap-docs/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -31,6 +31,4 @@ rk.tempo_source_patterns(
 )
 rk.tempo_onchain_verifier()
 
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/stablecoin-dex-swap-mcp/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/stablecoin-dex-swap/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/transfer-with-memo-docs/tests/test.sh
+++ b/tasks/transfer-with-memo-docs/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -32,6 +32,4 @@ rk.tempo_source_patterns(
 )
 rk.tempo_onchain_verifier()
 
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/transfer-with-memo-fee-payer/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -20,6 +20,4 @@ rk.tempo_source_patterns(
 )
 rk.tempo_onchain_verifier()
 
-rk.tempo_trajectory_matches(
-    r"tempo|mcp|docs|documentation|search",
-)
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/transfer-with-memo-mcp/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))

--- a/tasks/transfer-with-memo/tests/test.sh
+++ b/tasks/transfer-with-memo/tests/test.sh
@@ -42,14 +42,14 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
-elif details_path.exists():
+if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+elif tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))


### PR DESCRIPTION
## Summary
- Add a repo-local Claude Code Harbor adapter that writes MCP config and waits for each configured MCP server to report connected before `claude --print`.
- Switch generated MCP-profile tasks to the local `tempo-docs-mcp` sidecar and stage that sidecar in their compose environments.
- Pass MCP preflight tuning env vars through the agent configs and add the repo root to `PYTHONPATH` before invoking Harbor so the custom adapter imports in subprocesses.

## Root cause
The Daytona DinD main container was not able to complete TLS to `https://mcp.tempo.xyz`: direct diagnostics showed the connection reset after the TLS ClientHello. That left Claude Code with the `tempo` MCP server pending and no usable deferred Tempo tools. The local sidecar then also needed to bind as `0.0.0.0` because the MCP SDK's default host-header protection rejected the compose service hostname `tempo-docs-mcp`.

## Validation
- `npm run check:scripts`
- `uv run ruff check tempo_bench_harbor && uv run ruff format --check tempo_bench_harbor`
- generated preflight shell syntax: `bash -n /tmp/tempo-bench-mcp-preflight.sh`
- Daytona smoke:
  `source ~/.zshrc && CLAUDE_MCP_READY_ATTEMPTS=3 CLAUDE_MCP_READY_SLEEP_SECONDS=1 npm run bench:daytona:agent:dev -- --job-name mcp-preflight-daytona-local-sidecar-host --task-filter set-fee-token-mcp --concurrency 1 --agent-concurrency 1 --max-retries 1`
  - preflight: `Status: ✔ Connected` on attempt 1/3 for `tempo`
  - trajectory: `ToolSearch` returned `mcp__tempo__get_tempo_doc` and `mcp__tempo__search_tempo_docs`
  - trajectory: agent invoked `mcp__tempo__search_tempo_docs`
  - result: 1/1 completed, 0 errors, reward 1.0