### PR TITLE
Configure shared criteria from task metadata

### DIFF
--- a/scripts/sync-shared.mjs
+++ b/scripts/sync-shared.mjs
@@ -36,6 +36,14 @@ const executionConstraints = `## Execution Constraints
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
 - Do not run live testnet smoke tests; local build/run checks must use the provided environment variables.
 `;
+const genericCorrectnessCriteria = `import tempo_bench_rewardkit
+
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")
+`;
+const genericQualityCheck = `import tempo_bench_rewardkit
+
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")
+`;
 
 function relativeSymlinkTarget(destination, source) {
   return path.relative(path.dirname(destination), source);
@@ -262,41 +270,6 @@ function appendProfileInstruction(taskDir, profile) {
   writeFile(instructionPath, `${content.replace(/\s*$/, "")}\n`);
 }
 
-function taskCriteriaPath(taskDir) {
-  for (const relativePath of [
-    "tests/correctness/criteria.py",
-    "tests/criteria/check.py",
-  ]) {
-    const absolutePath = path.join(taskDir, relativePath);
-    if (fs.existsSync(absolutePath)) return absolutePath;
-  }
-  throw new Error(`Missing task-local criteria checks in ${taskDir}`);
-}
-
-function updateProfileCriteria(taskDir, profile) {
-  const criteriaPath = taskCriteriaPath(taskDir);
-  let content = fs.readFileSync(criteriaPath, "utf8");
-  content = content.replace(
-    /\nrk\.tempo_trajectory_matches\([\s\S]*?\n\)\n/g,
-    "\n",
-  );
-  content = content.replace(/\nrk\.tempo_mcp_tool_used\([\s\S]*?\)\n/g, "\n");
-
-  if (profile.id === "docs") {
-    content += `
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\\.txt|/developers/llms-full\\.txt|/developers/docs/.*\\.md|TEMPO_DOCS_URL",
-)
-`;
-  } else if (profile.id === "mcp") {
-    content += `
-rk.tempo_mcp_tool_used("tempo")
-`;
-  }
-
-  writeFile(criteriaPath, `${content.replace(/\s*$/, "")}\n`);
-}
-
 function materializeTaskMatrix() {
   const generatedSlugs = new Set();
   for (const sourceSlug of sourceTaskSlugs) {
@@ -312,7 +285,6 @@ function materializeTaskMatrix() {
       generatedSlugs.add(slug);
       updateTaskToml(taskDir, sourceSlug, profile);
       appendProfileInstruction(taskDir, profile);
-      updateProfileCriteria(taskDir, profile);
     }
   }
 
@@ -415,29 +387,35 @@ function assertTaskRewardKit(taskDir) {
   if (!fs.existsSync(path.join(taskDir, "tests/reward.toml"))) {
     throw new Error(`Missing task-local RewardKit file: ${path.join(taskDir, "tests/reward.toml")}`);
   }
-  const criteriaCandidates = ["tests/correctness/criteria.py", "tests/criteria/check.py"];
-  if (!criteriaCandidates.some((relativePath) => fs.existsSync(path.join(taskDir, relativePath)))) {
-    throw new Error(`Missing task-local RewardKit file: ${criteriaCandidates.join(" or ")} in ${taskDir}`);
-  }
 }
 
-function readFirstExisting(taskDir, relativePaths) {
-  for (const relativePath of relativePaths) {
-    const absolutePath = path.join(taskDir, relativePath);
-    if (fs.existsSync(absolutePath)) {
-      return fs.readFileSync(absolutePath, "utf8");
+function extractTempoBenchMetadata(taskDir) {
+  const taskConfigPath = path.join(taskDir, "task.toml");
+  const content = fs.readFileSync(taskConfigPath, "utf8");
+  const output = [];
+  let inTempoBenchSection = false;
+
+  for (const line of content.split(/\r?\n/)) {
+    const section = line.match(/^\s*\[\[?([^\]]+)\]\]?\s*$/);
+    if (section) {
+      inTempoBenchSection = section[1].startsWith("metadata.tempo_bench");
     }
+    if (inTempoBenchSection) output.push(line);
   }
-  throw new Error(`Missing required file in ${taskDir}: ${relativePaths.join(" or ")}`);
+
+  const metadata = output.join("\n").replace(/\s*$/, "");
+  if (!metadata) {
+    throw new Error(`Missing [metadata.tempo_bench] criteria config in ${taskConfigPath}`);
+  }
+  return `${metadata}\n`;
+}
+
+function materializeTempoBenchConfig(taskDir) {
+  writeFile(path.join(taskDir, "tests/tempo-bench.toml"), extractTempoBenchMetadata(taskDir));
 }
 
 function syncRewardKit(taskDir) {
   assertTaskRewardKit(taskDir);
-  const criteriaContent = readFirstExisting(taskDir, [
-    "tests/correctness/criteria.py",
-    "tests/criteria/check.py",
-  ]).replaceAll("/tests/e2e/verify-tempo.sh", "/tests/correctness/verify-tempo.sh");
-
   removePath(path.join(taskDir, "tests/turns"));
   removePath(path.join(taskDir, "tests/tokens"));
   removePath(path.join(taskDir, "tests/reward"));
@@ -450,11 +428,13 @@ function syncRewardKit(taskDir) {
     path.join(taskDir, "tests/reward.toml"),
     `[[reward]]\nname = "reward"\naggregation = "weighted_mean"\n`,
   );
-  writeFile(path.join(taskDir, "tests/correctness/criteria.py"), criteriaContent);
+  writeFile(path.join(taskDir, "tests/correctness/criteria.py"), genericCorrectnessCriteria);
   copyDir(
     path.join(root, "shared/rewardkit/quality"),
     path.join(taskDir, "tests/quality"),
   );
+  writeFile(path.join(taskDir, "tests/quality/check.py"), genericQualityCheck);
+  materializeTempoBenchConfig(taskDir);
   copyFile(
     path.join(root, "shared/rewardkit/verify-tempo.sh"),
     path.join(taskDir, "tests/correctness/verify-tempo.sh"),

--- a/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -1,6 +1,9 @@
 from .criteria import (
     agent_token_efficiency,
     agent_turn_efficiency,
+    register_correctness_from_config,
+    register_quality_from_config,
+    tempo_build_run_onchain,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -11,6 +14,9 @@ from .criteria import (
 __all__ = [
     "agent_token_efficiency",
     "agent_turn_efficiency",
+    "register_correctness_from_config",
+    "register_quality_from_config",
+    "tempo_build_run_onchain",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -4,12 +4,78 @@ import os
 import re
 import subprocess
 import threading
+import tomllib
 from pathlib import Path
 
+import rewardkit as rk
 from rewardkit import criterion
 
 LOG_DIR = Path("/logs/verifier")
 _EFFICIENCY_LOCK = threading.Lock()
+DEFAULT_CONFIG_PATH = "/tests/tempo-bench.toml"
+
+
+def _read_tempo_bench_config(config_path: str = DEFAULT_CONFIG_PATH) -> dict:
+    with open(config_path, "rb") as config_file:
+        data = tomllib.load(config_file)
+    return data.get("metadata", {}).get("tempo_bench", data.get("tempo_bench", {}))
+
+
+def _shared_criteria(config: dict, section: str) -> list[str]:
+    criteria = config.get(section, {}).get("shared", [])
+    if not isinstance(criteria, list):
+        raise TypeError(f"{section}.shared must be a list")
+    return [str(criterion_name) for criterion_name in criteria]
+
+
+def register_correctness_from_config(config_path: str = DEFAULT_CONFIG_PATH) -> None:
+    config = _read_tempo_bench_config(config_path)
+    correctness = config.get("correctness", {})
+    for criterion_name in _shared_criteria(config, "correctness"):
+        if criterion_name == "typescript_project":
+            rk.tempo_typescript_project()
+        elif criterion_name == "source_patterns":
+            patterns = correctness.get("source_patterns", [])
+            if not patterns:
+                raise ValueError("source_patterns criterion selected without patterns")
+            rk.tempo_source_patterns(patterns)
+        elif criterion_name in {"build_run_onchain", "onchain_verifier"}:
+            rk.tempo_build_run_onchain()
+        elif criterion_name == "mcp_tool_use":
+            rk.tempo_mcp_tool_used(str(correctness.get("mcp_server", "tempo")))
+        elif criterion_name == "trajectory_matches":
+            pattern = correctness.get("trajectory_pattern")
+            if not pattern:
+                raise ValueError(
+                    "trajectory_matches criterion selected without pattern"
+                )
+            rk.tempo_trajectory_matches(str(pattern))
+        else:
+            raise ValueError(f"Unknown shared correctness criterion: {criterion_name}")
+
+
+def register_quality_from_config(config_path: str = DEFAULT_CONFIG_PATH) -> None:
+    config = _read_tempo_bench_config(config_path)
+    quality = config.get("quality", {})
+    for criterion_name in _shared_criteria(config, "quality"):
+        if criterion_name == "agent_turn_efficiency":
+            rk.agent_turn_efficiency()
+        elif criterion_name == "agent_token_efficiency":
+            rk.agent_token_efficiency()
+        elif criterion_name == "mcp_tool_use":
+            rk.tempo_mcp_tool_used(str(quality.get("mcp_server", "tempo")))
+        elif criterion_name == "trajectory_matches":
+            pattern = quality.get("trajectory_pattern")
+            if not pattern:
+                raise ValueError(
+                    "trajectory_matches criterion selected without pattern"
+                )
+            rk.tempo_trajectory_matches(str(pattern))
+        elif criterion_name == "llm_judge":
+            # LLM judges are configured natively in tests/quality/reward.toml.
+            continue
+        else:
+            raise ValueError(f"Unknown shared quality criterion: {criterion_name}")
 
 
 def _write_json(name: str, payload: dict) -> None:
@@ -168,8 +234,7 @@ def tempo_source_patterns(workspace: Path, patterns: list[dict]) -> bool:
     return all(result["passed"] for result in results)
 
 
-@criterion(shared=True)
-def tempo_onchain_verifier(workspace: Path) -> bool:
+def _run_build_run_onchain(workspace: Path) -> bool:
     timeout = int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900"))
     result = subprocess.run(
         ["bash", "/tests/correctness/verify-tempo.sh"],
@@ -189,6 +254,16 @@ def tempo_onchain_verifier(workspace: Path) -> bool:
         },
     )
     return result.returncode == 0
+
+
+@criterion(shared=True)
+def tempo_build_run_onchain(workspace: Path) -> bool:
+    return _run_build_run_onchain(workspace)
+
+
+@criterion(shared=True)
+def tempo_onchain_verifier(workspace: Path) -> bool:
+    return _run_build_run_onchain(workspace)
 
 
 @criterion(shared=True)

--- a/shared/rewardkit/quality/check.py
+++ b/shared/rewardkit/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy-docs/task.toml
+++ b/tasks/create-stablecoin-with-policy-docs/task.toml
@@ -12,6 +12,32 @@ keywords = ["tempo", "tip20", "stablecoin", "tip403", "policy", "localnet", "typ
 category = "integration"
 feature = "create-stablecoin-with-policy"
 profile = "docs"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_stablecoin"
+pattern = "token\\.createSync|createSync\\(client,\\s*\\{[\\s\\S]*currency"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_transfer_policy"
+pattern = "policy\\.createSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_links_transfer_policy"
+pattern = "changeTransferPolicySync|transferPolicy"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_stablecoin_currency"
+pattern = "TEMPO_STABLECOIN_CURRENCY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_policy_account"
+pattern = "TEMPO_POLICY_ACCOUNT"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
@@ -1,33 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_creates_stablecoin",
-            "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
-        },
-        {
-            "name": "source_creates_transfer_policy",
-            "pattern": r"policy\.createSync",
-        },
-        {
-            "name": "source_links_transfer_policy",
-            "pattern": r"changeTransferPolicySync|transferPolicy",
-        },
-        {
-            "name": "source_reads_stablecoin_currency",
-            "pattern": r"TEMPO_STABLECOIN_CURRENCY",
-        },
-        {
-            "name": "source_reads_policy_account",
-            "pattern": r"TEMPO_POLICY_ACCOUNT",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy-docs/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy-docs/tests/tempo-bench.toml
+++ b/tasks/create-stablecoin-with-policy-docs/tests/tempo-bench.toml
@@ -1,0 +1,25 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_stablecoin"
+pattern = "token\\.createSync|createSync\\(client,\\s*\\{[\\s\\S]*currency"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_transfer_policy"
+pattern = "policy\\.createSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_links_transfer_policy"
+pattern = "changeTransferPolicySync|transferPolicy"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_stablecoin_currency"
+pattern = "TEMPO_STABLECOIN_CURRENCY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_policy_account"
+pattern = "TEMPO_POLICY_ACCOUNT"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/create-stablecoin-with-policy-mcp/task.toml
+++ b/tasks/create-stablecoin-with-policy-mcp/task.toml
@@ -12,6 +12,32 @@ keywords = ["tempo", "tip20", "stablecoin", "tip403", "policy", "localnet", "typ
 category = "integration"
 feature = "create-stablecoin-with-policy"
 profile = "mcp"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_stablecoin"
+pattern = "token\\.createSync|createSync\\(client,\\s*\\{[\\s\\S]*currency"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_transfer_policy"
+pattern = "policy\\.createSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_links_transfer_policy"
+pattern = "changeTransferPolicySync|transferPolicy"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_stablecoin_currency"
+pattern = "TEMPO_STABLECOIN_CURRENCY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_policy_account"
+pattern = "TEMPO_POLICY_ACCOUNT"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -1,31 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_creates_stablecoin",
-            "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
-        },
-        {
-            "name": "source_creates_transfer_policy",
-            "pattern": r"policy\.createSync",
-        },
-        {
-            "name": "source_links_transfer_policy",
-            "pattern": r"changeTransferPolicySync|transferPolicy",
-        },
-        {
-            "name": "source_reads_stablecoin_currency",
-            "pattern": r"TEMPO_STABLECOIN_CURRENCY",
-        },
-        {
-            "name": "source_reads_policy_account",
-            "pattern": r"TEMPO_POLICY_ACCOUNT",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy-mcp/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy-mcp/tests/tempo-bench.toml
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/tempo-bench.toml
@@ -1,0 +1,25 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_stablecoin"
+pattern = "token\\.createSync|createSync\\(client,\\s*\\{[\\s\\S]*currency"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_transfer_policy"
+pattern = "policy\\.createSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_links_transfer_policy"
+pattern = "changeTransferPolicySync|transferPolicy"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_stablecoin_currency"
+pattern = "TEMPO_STABLECOIN_CURRENCY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_policy_account"
+pattern = "TEMPO_POLICY_ACCOUNT"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/create-stablecoin-with-policy/task.toml
+++ b/tasks/create-stablecoin-with-policy/task.toml
@@ -12,6 +12,32 @@ keywords = ["tempo", "tip20", "stablecoin", "tip403", "policy", "localnet", "typ
 category = "integration"
 feature = "create-stablecoin-with-policy"
 
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_stablecoin"
+pattern = "token\\.createSync|createSync\\(client,\\s*\\{[\\s\\S]*currency"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_transfer_policy"
+pattern = "policy\\.createSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_links_transfer_policy"
+pattern = "changeTransferPolicySync|transferPolicy"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_stablecoin_currency"
+pattern = "TEMPO_STABLECOIN_CURRENCY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_policy_account"
+pattern = "TEMPO_POLICY_ACCOUNT"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -1,29 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_creates_stablecoin",
-            "pattern": r"token\.createSync|createSync\(client,\s*\{[\s\S]*currency",
-        },
-        {
-            "name": "source_creates_transfer_policy",
-            "pattern": r"policy\.createSync",
-        },
-        {
-            "name": "source_links_transfer_policy",
-            "pattern": r"changeTransferPolicySync|transferPolicy",
-        },
-        {
-            "name": "source_reads_stablecoin_currency",
-            "pattern": r"TEMPO_STABLECOIN_CURRENCY",
-        },
-        {
-            "name": "source_reads_policy_account",
-            "pattern": r"TEMPO_POLICY_ACCOUNT",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/create-stablecoin-with-policy/tests/tempo-bench.toml
+++ b/tasks/create-stablecoin-with-policy/tests/tempo-bench.toml
@@ -1,0 +1,25 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_stablecoin"
+pattern = "token\\.createSync|createSync\\(client,\\s*\\{[\\s\\S]*currency"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_creates_transfer_policy"
+pattern = "policy\\.createSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_links_transfer_policy"
+pattern = "changeTransferPolicySync|transferPolicy"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_stablecoin_currency"
+pattern = "TEMPO_STABLECOIN_CURRENCY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_policy_account"
+pattern = "TEMPO_POLICY_ACCOUNT"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:da2ea37270ff39decfdc050f3967cc0f270ff69deb674c75e7aec8918e938030"
+digest = "sha256:4f012bad1740a3a28d8ba2164673a3fcbdd93ae2be80029b2c24985214554d48"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:a92fb8d0f076042146c89c495aea46294943c129635d97366086db891d764748"
+digest = "sha256:c75fea793ba4fd1f3431d43629b35023aa8e6c715765e1e0d29aba5ba4891945"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:ebf991cbee22d1f4b5679c2c6ec233bd3df80b4a572aec0f7f38987c3973d1c5"
+digest = "sha256:51ee4459e439b3f38fc09a03221350b030138512bbe2f4234755c34b648bcd89"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:60e66b4f975e31751f31b876f0f5f18a25df24b9b9a039775934e2d0d243f6fb"
+digest = "sha256:4b9259f94e308477473d997a65bdf20fe8ec52906add3c9e8a52977976988d8d"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:462643fee69bec7f19820b1fc0908e316963aac9b56666f2bc9226c9f9713e3a"
+digest = "sha256:fd0a0e42c6377935d7aef77e78355beba96fd8029729f4febe4a239f66a959a6"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:b532e93bd11b92baeaf39fd06bd7ff4cfcee43abb6461888e4d256c8762e6be6"
+digest = "sha256:777881a625d3c719648371dee14be2246eb08881dc265e7a39771041df6f0eac"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:f1c01d960e4c1631830c3cb0dc435b550cea1e9f14dfab8a3988ebaec6735036"
+digest = "sha256:f73aa81958e519258f3ee28303dd3792fd547b20f8963b7de1d8964f28471456"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:a054983a28b5f009aa7c4153752808faffe98dc127baf839b12a50b99cab55af"
+digest = "sha256:9aae3c3c7fe1754e7d4a1cff53250a1faf6fc5fc0c8cb35fa09bb17cfd610964"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:cef76f945e7706da47702adc4d9b28d64063e913db78ca61c0a9c253fada3e99"
+digest = "sha256:d810dde3994104951f28aa555156a291f2514506745217f274df1b4e29e91321"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:99299b4d51fc11c239d10d7cc2ee14ad388071e1a30808f118874370051f4d3b"
+digest = "sha256:722e961a3414803f79a9284095dd0bb710f000c3037ec3ef40d6ddc7cd23bd3d"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:279f6176120dbc2a883a26203bf668bc9fcadea1c9e3888e6d484fd8fb3526ef"
+digest = "sha256:aa4cfd73bd23fed9a6a31a2c52b03bb15b3a5a64370f544031ca57df0c3ee2bf"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:ac8ff8fa3582cf00d51c2dd3942f51e5c466f692a5c1c3d97fe85182d8f44104"
+digest = "sha256:5d797b8792fb8cec1c0bcf6e1a79fcb223d291f32a465f66fd50f3b7720fbc33"
 

--- a/tasks/faucet-funded-transfer-docs/task.toml
+++ b/tasks/faucet-funded-transfer-docs/task.toml
@@ -12,6 +12,24 @@ keywords = ["tempo", "faucet", "tip20", "transfer", "localnet", "typescript", "d
 category = "integration"
 feature = "faucet-funded-transfer"
 profile = "docs"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_faucet_fund"
+pattern = "faucet\\.fundSync|fundSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_faucet_private_key"
+pattern = "TEMPO_FAUCET_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_sends_transfer"
+pattern = "transferSync|transferWithMemo"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
@@ -1,25 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
-        },
-        {
-            "name": "source_reads_faucet_private_key",
-            "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
-        },
-        {
-            "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/faucet-funded-transfer-docs/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer-docs/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/faucet-funded-transfer-docs/tests/tempo-bench.toml
+++ b/tasks/faucet-funded-transfer-docs/tests/tempo-bench.toml
@@ -1,0 +1,17 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_faucet_fund"
+pattern = "faucet\\.fundSync|fundSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_faucet_private_key"
+pattern = "TEMPO_FAUCET_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_sends_transfer"
+pattern = "transferSync|transferWithMemo"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/faucet-funded-transfer-mcp/task.toml
+++ b/tasks/faucet-funded-transfer-mcp/task.toml
@@ -12,6 +12,24 @@ keywords = ["tempo", "faucet", "tip20", "transfer", "localnet", "typescript", "m
 category = "integration"
 feature = "faucet-funded-transfer"
 profile = "mcp"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_faucet_fund"
+pattern = "faucet\\.fundSync|fundSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_faucet_private_key"
+pattern = "TEMPO_FAUCET_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_sends_transfer"
+pattern = "transferSync|transferWithMemo"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -1,23 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
-        },
-        {
-            "name": "source_reads_faucet_private_key",
-            "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
-        },
-        {
-            "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/faucet-funded-transfer-mcp/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/faucet-funded-transfer-mcp/tests/tempo-bench.toml
+++ b/tasks/faucet-funded-transfer-mcp/tests/tempo-bench.toml
@@ -1,0 +1,17 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_faucet_fund"
+pattern = "faucet\\.fundSync|fundSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_faucet_private_key"
+pattern = "TEMPO_FAUCET_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_sends_transfer"
+pattern = "transferSync|transferWithMemo"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/faucet-funded-transfer/task.toml
+++ b/tasks/faucet-funded-transfer/task.toml
@@ -12,6 +12,24 @@ keywords = ["tempo", "faucet", "tip20", "transfer", "localnet", "typescript"]
 category = "integration"
 feature = "faucet-funded-transfer"
 
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_faucet_fund"
+pattern = "faucet\\.fundSync|fundSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_faucet_private_key"
+pattern = "TEMPO_FAUCET_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_sends_transfer"
+pattern = "transferSync|transferWithMemo"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer/tests/correctness/criteria.py
@@ -1,21 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
-        },
-        {
-            "name": "source_reads_faucet_private_key",
-            "pattern": r"TEMPO_FAUCET_PRIVATE_KEY",
-        },
-        {
-            "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/faucet-funded-transfer/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/faucet-funded-transfer/tests/tempo-bench.toml
+++ b/tasks/faucet-funded-transfer/tests/tempo-bench.toml
@@ -1,0 +1,17 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_faucet_fund"
+pattern = "faucet\\.fundSync|fundSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_faucet_private_key"
+pattern = "TEMPO_FAUCET_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_sends_transfer"
+pattern = "transferSync|transferWithMemo"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/set-fee-token-docs/task.toml
+++ b/tasks/set-fee-token-docs/task.toml
@@ -12,6 +12,20 @@ keywords = ["tempo", "fee-token", "alpha-usd", "localnet", "typescript", "docs"]
 category = "integration"
 feature = "set-fee-token"
 profile = "docs"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_set_user_token"
+pattern = "setUserToken"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/set-fee-token-docs/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-docs/tests/correctness/criteria.py
@@ -1,21 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_calls_set_user_token",
-            "pattern": r"setUserToken",
-        },
-        {
-            "name": "source_reads_tempo_fee_token",
-            "pattern": r"TEMPO_FEE_TOKEN",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/set-fee-token-docs/tests/quality/check.py
+++ b/tasks/set-fee-token-docs/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/set-fee-token-docs/tests/tempo-bench.toml
+++ b/tasks/set-fee-token-docs/tests/tempo-bench.toml
@@ -1,0 +1,13 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_set_user_token"
+pattern = "setUserToken"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/set-fee-token-mcp/task.toml
+++ b/tasks/set-fee-token-mcp/task.toml
@@ -12,6 +12,20 @@ keywords = ["tempo", "fee-token", "alpha-usd", "localnet", "typescript", "mcp"]
 category = "integration"
 feature = "set-fee-token"
 profile = "mcp"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_set_user_token"
+pattern = "setUserToken"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-mcp/tests/correctness/criteria.py
@@ -1,19 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_calls_set_user_token",
-            "pattern": r"setUserToken",
-        },
-        {
-            "name": "source_reads_tempo_fee_token",
-            "pattern": r"TEMPO_FEE_TOKEN",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/set-fee-token-mcp/tests/quality/check.py
+++ b/tasks/set-fee-token-mcp/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/set-fee-token-mcp/tests/tempo-bench.toml
+++ b/tasks/set-fee-token-mcp/tests/tempo-bench.toml
@@ -1,0 +1,13 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_set_user_token"
+pattern = "setUserToken"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/set-fee-token/task.toml
+++ b/tasks/set-fee-token/task.toml
@@ -12,6 +12,20 @@ keywords = ["tempo", "fee-token", "alpha-usd", "localnet", "typescript"]
 category = "integration"
 feature = "set-fee-token"
 
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_set_user_token"
+pattern = "setUserToken"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/set-fee-token/tests/correctness/criteria.py
@@ -1,17 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_calls_set_user_token",
-            "pattern": r"setUserToken",
-        },
-        {
-            "name": "source_reads_tempo_fee_token",
-            "pattern": r"TEMPO_FEE_TOKEN",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/set-fee-token/tests/quality/check.py
+++ b/tasks/set-fee-token/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/set-fee-token/tests/tempo-bench.toml
+++ b/tasks/set-fee-token/tests/tempo-bench.toml
@@ -1,0 +1,13 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_calls_set_user_token"
+pattern = "setUserToken"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/stablecoin-dex-swap-docs/task.toml
+++ b/tasks/stablecoin-dex-swap-docs/task.toml
@@ -12,6 +12,32 @@ keywords = ["tempo", "stablecoin-dex", "swap", "tip20", "localnet", "typescript"
 category = "integration"
 feature = "stablecoin-dex-swap"
 profile = "docs"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_dex_actions"
+pattern = "Actions\\.dex|\\.dex\\."
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_approves_dex_spending"
+pattern = "approveSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_provides_dex_liquidity"
+pattern = "placeSync|provideLiquidity|addLiquidity"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_executes_dex_swap"
+pattern = "sellSync|buySync|swapSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_swap_token_env"
+pattern = "TEMPO_SWAP_TOKEN_IN[\\s\\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\\s\\S]*TEMPO_SWAP_TOKEN_IN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
@@ -1,36 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_dex_actions",
-            "pattern": r"Actions\.dex|\.dex\.",
-        },
-        {
-            "name": "source_approves_dex_spending",
-            "pattern": r"approveSync",
-        },
-        {
-            "name": "source_provides_dex_liquidity",
-            "pattern": r"placeSync|provideLiquidity|addLiquidity",
-        },
-        {
-            "name": "source_executes_dex_swap",
-            "pattern": r"sellSync|buySync|swapSync",
-        },
-        {
-            "name": "source_reads_swap_token_env",
-            "pattern": (
-                r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|"
-                r"TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN"
-            ),
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/stablecoin-dex-swap-docs/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/stablecoin-dex-swap-docs/tests/tempo-bench.toml
+++ b/tasks/stablecoin-dex-swap-docs/tests/tempo-bench.toml
@@ -1,0 +1,25 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_dex_actions"
+pattern = "Actions\\.dex|\\.dex\\."
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_approves_dex_spending"
+pattern = "approveSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_provides_dex_liquidity"
+pattern = "placeSync|provideLiquidity|addLiquidity"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_executes_dex_swap"
+pattern = "sellSync|buySync|swapSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_swap_token_env"
+pattern = "TEMPO_SWAP_TOKEN_IN[\\s\\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\\s\\S]*TEMPO_SWAP_TOKEN_IN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/stablecoin-dex-swap-mcp/task.toml
+++ b/tasks/stablecoin-dex-swap-mcp/task.toml
@@ -12,6 +12,32 @@ keywords = ["tempo", "stablecoin-dex", "swap", "tip20", "localnet", "typescript"
 category = "integration"
 feature = "stablecoin-dex-swap"
 profile = "mcp"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_dex_actions"
+pattern = "Actions\\.dex|\\.dex\\."
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_approves_dex_spending"
+pattern = "approveSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_provides_dex_liquidity"
+pattern = "placeSync|provideLiquidity|addLiquidity"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_executes_dex_swap"
+pattern = "sellSync|buySync|swapSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_swap_token_env"
+pattern = "TEMPO_SWAP_TOKEN_IN[\\s\\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\\s\\S]*TEMPO_SWAP_TOKEN_IN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -1,34 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_dex_actions",
-            "pattern": r"Actions\.dex|\.dex\.",
-        },
-        {
-            "name": "source_approves_dex_spending",
-            "pattern": r"approveSync",
-        },
-        {
-            "name": "source_provides_dex_liquidity",
-            "pattern": r"placeSync|provideLiquidity|addLiquidity",
-        },
-        {
-            "name": "source_executes_dex_swap",
-            "pattern": r"sellSync|buySync|swapSync",
-        },
-        {
-            "name": "source_reads_swap_token_env",
-            "pattern": (
-                r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|"
-                r"TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN"
-            ),
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/stablecoin-dex-swap-mcp/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/stablecoin-dex-swap-mcp/tests/tempo-bench.toml
+++ b/tasks/stablecoin-dex-swap-mcp/tests/tempo-bench.toml
@@ -1,0 +1,25 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_dex_actions"
+pattern = "Actions\\.dex|\\.dex\\."
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_approves_dex_spending"
+pattern = "approveSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_provides_dex_liquidity"
+pattern = "placeSync|provideLiquidity|addLiquidity"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_executes_dex_swap"
+pattern = "sellSync|buySync|swapSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_swap_token_env"
+pattern = "TEMPO_SWAP_TOKEN_IN[\\s\\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\\s\\S]*TEMPO_SWAP_TOKEN_IN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/stablecoin-dex-swap/task.toml
+++ b/tasks/stablecoin-dex-swap/task.toml
@@ -12,6 +12,32 @@ keywords = ["tempo", "stablecoin-dex", "swap", "tip20", "localnet", "typescript"
 category = "integration"
 feature = "stablecoin-dex-swap"
 
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_dex_actions"
+pattern = "Actions\\.dex|\\.dex\\."
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_approves_dex_spending"
+pattern = "approveSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_provides_dex_liquidity"
+pattern = "placeSync|provideLiquidity|addLiquidity"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_executes_dex_swap"
+pattern = "sellSync|buySync|swapSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_swap_token_env"
+pattern = "TEMPO_SWAP_TOKEN_IN[\\s\\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\\s\\S]*TEMPO_SWAP_TOKEN_IN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -1,32 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_dex_actions",
-            "pattern": r"Actions\.dex|\.dex\.",
-        },
-        {
-            "name": "source_approves_dex_spending",
-            "pattern": r"approveSync",
-        },
-        {
-            "name": "source_provides_dex_liquidity",
-            "pattern": r"placeSync|provideLiquidity|addLiquidity",
-        },
-        {
-            "name": "source_executes_dex_swap",
-            "pattern": r"sellSync|buySync|swapSync",
-        },
-        {
-            "name": "source_reads_swap_token_env",
-            "pattern": (
-                r"TEMPO_SWAP_TOKEN_IN[\s\S]*TEMPO_SWAP_TOKEN_OUT|"
-                r"TEMPO_SWAP_TOKEN_OUT[\s\S]*TEMPO_SWAP_TOKEN_IN"
-            ),
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/stablecoin-dex-swap/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/stablecoin-dex-swap/tests/tempo-bench.toml
+++ b/tasks/stablecoin-dex-swap/tests/tempo-bench.toml
@@ -1,0 +1,25 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_dex_actions"
+pattern = "Actions\\.dex|\\.dex\\."
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_approves_dex_spending"
+pattern = "approveSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_provides_dex_liquidity"
+pattern = "placeSync|provideLiquidity|addLiquidity"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_executes_dex_swap"
+pattern = "sellSync|buySync|swapSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_swap_token_env"
+pattern = "TEMPO_SWAP_TOKEN_IN[\\s\\S]*TEMPO_SWAP_TOKEN_OUT|TEMPO_SWAP_TOKEN_OUT[\\s\\S]*TEMPO_SWAP_TOKEN_IN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/transfer-with-memo-docs/task.toml
+++ b/tasks/transfer-with-memo-docs/task.toml
@@ -12,6 +12,24 @@ keywords = ["tempo", "tip20", "memo", "localnet", "typescript", "docs"]
 category = "integration"
 feature = "transfer-with-memo"
 profile = "docs"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
@@ -1,25 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_transfer_with_memo_semantics",
-            "pattern": r"transferWithMemo|transferSync",
-        },
-        {
-            "name": "source_reads_tempo_memo",
-            "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-docs/tests/quality/check.py
+++ b/tasks/transfer-with-memo-docs/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-docs/tests/tempo-bench.toml
+++ b/tasks/transfer-with-memo-docs/tests/tempo-bench.toml
@@ -1,0 +1,17 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/transfer-with-memo-fee-payer-docs/task.toml
+++ b/tasks/transfer-with-memo-fee-payer-docs/task.toml
@@ -12,6 +12,36 @@ keywords = ["tempo", "tip20", "memo", "fee-payer", "localnet", "typescript", "do
 category = "integration"
 feature = "transfer-with-memo-fee-payer"
 profile = "docs"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_payer_private_key"
+pattern = "TEMPO_FEE_PAYER_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_passes_fee_payer"
+pattern = "feePayer"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
@@ -1,37 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_transfer_with_memo_semantics",
-            "pattern": r"transferWithMemo|transferSync",
-        },
-        {
-            "name": "source_reads_tempo_memo",
-            "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-        {
-            "name": "source_reads_fee_payer_private_key",
-            "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
-        },
-        {
-            "name": "source_passes_fee_payer",
-            "pattern": r"feePayer",
-        },
-        {
-            "name": "source_reads_fee_token",
-            "pattern": r"TEMPO_FEE_TOKEN",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/tempo-bench.toml
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/tempo-bench.toml
@@ -1,0 +1,29 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_payer_private_key"
+pattern = "TEMPO_FEE_PAYER_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_passes_fee_payer"
+pattern = "feePayer"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/transfer-with-memo-fee-payer-mcp/task.toml
+++ b/tasks/transfer-with-memo-fee-payer-mcp/task.toml
@@ -12,6 +12,36 @@ keywords = ["tempo", "tip20", "memo", "fee-payer", "localnet", "typescript", "mc
 category = "integration"
 feature = "transfer-with-memo-fee-payer"
 profile = "mcp"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_payer_private_key"
+pattern = "TEMPO_FEE_PAYER_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_passes_fee_payer"
+pattern = "feePayer"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -1,35 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_transfer_with_memo_semantics",
-            "pattern": r"transferWithMemo|transferSync",
-        },
-        {
-            "name": "source_reads_tempo_memo",
-            "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-        {
-            "name": "source_reads_fee_payer_private_key",
-            "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
-        },
-        {
-            "name": "source_passes_fee_payer",
-            "pattern": r"feePayer",
-        },
-        {
-            "name": "source_reads_fee_token",
-            "pattern": r"TEMPO_FEE_TOKEN",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/tempo-bench.toml
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/tempo-bench.toml
@@ -1,0 +1,29 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_payer_private_key"
+pattern = "TEMPO_FEE_PAYER_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_passes_fee_payer"
+pattern = "feePayer"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/transfer-with-memo-fee-payer/task.toml
+++ b/tasks/transfer-with-memo-fee-payer/task.toml
@@ -12,6 +12,36 @@ keywords = ["tempo", "tip20", "memo", "fee-payer", "localnet", "typescript"]
 category = "integration"
 feature = "transfer-with-memo-fee-payer"
 
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_payer_private_key"
+pattern = "TEMPO_FEE_PAYER_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_passes_fee_payer"
+pattern = "feePayer"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -1,33 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_transfer_with_memo_semantics",
-            "pattern": r"transferWithMemo|transferSync",
-        },
-        {
-            "name": "source_reads_tempo_memo",
-            "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-        {
-            "name": "source_reads_fee_payer_private_key",
-            "pattern": r"TEMPO_FEE_PAYER_PRIVATE_KEY",
-        },
-        {
-            "name": "source_passes_fee_payer",
-            "pattern": r"feePayer",
-        },
-        {
-            "name": "source_reads_fee_token",
-            "pattern": r"TEMPO_FEE_TOKEN",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-fee-payer/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-fee-payer/tests/tempo-bench.toml
+++ b/tasks/transfer-with-memo-fee-payer/tests/tempo-bench.toml
@@ -1,0 +1,29 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_payer_private_key"
+pattern = "TEMPO_FEE_PAYER_PRIVATE_KEY"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_passes_fee_payer"
+pattern = "feePayer"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_fee_token"
+pattern = "TEMPO_FEE_TOKEN"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/transfer-with-memo-mcp/task.toml
+++ b/tasks/transfer-with-memo-mcp/task.toml
@@ -12,6 +12,24 @@ keywords = ["tempo", "tip20", "memo", "localnet", "typescript", "mcp"]
 category = "integration"
 feature = "transfer-with-memo"
 profile = "mcp"
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -1,23 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_transfer_with_memo_semantics",
-            "pattern": r"transferWithMemo|transferSync",
-        },
-        {
-            "name": "source_reads_tempo_memo",
-            "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-mcp/tests/quality/check.py
+++ b/tasks/transfer-with-memo-mcp/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo-mcp/tests/tempo-bench.toml
+++ b/tasks/transfer-with-memo-mcp/tests/tempo-bench.toml
@@ -1,0 +1,17 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]

--- a/tasks/transfer-with-memo/task.toml
+++ b/tasks/transfer-with-memo/task.toml
@@ -12,6 +12,24 @@ keywords = ["tempo", "tip20", "memo", "localnet", "typescript"]
 category = "integration"
 feature = "transfer-with-memo"
 
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]
+
 [verifier]
 timeout_sec = 300.0
 environment_mode = "shared"

--- a/tasks/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo/tests/correctness/criteria.py
@@ -1,21 +1,3 @@
-import rewardkit as rk
 import tempo_bench_rewardkit
 
-rk.tempo_typescript_project()
-rk.tempo_source_patterns(
-    [
-        {
-            "name": "source_uses_transfer_with_memo_semantics",
-            "pattern": r"transferWithMemo|transferSync",
-        },
-        {
-            "name": "source_reads_tempo_memo",
-            "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-    ]
-)
-rk.tempo_onchain_verifier()
+tempo_bench_rewardkit.register_correctness_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo/tests/quality/check.py
+++ b/tasks/transfer-with-memo/tests/quality/check.py
@@ -1,5 +1,3 @@
-import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+import tempo_bench_rewardkit
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+tempo_bench_rewardkit.register_quality_from_config("/tests/tempo-bench.toml")

--- a/tasks/transfer-with-memo/tests/tempo-bench.toml
+++ b/tasks/transfer-with-memo/tests/tempo-bench.toml
@@ -1,0 +1,17 @@
+[metadata.tempo_bench.correctness]
+shared = ["typescript_project", "source_patterns", "build_run_onchain"]
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_uses_transfer_with_memo_semantics"
+pattern = "transferWithMemo|transferSync"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_reads_tempo_memo"
+pattern = "TEMPO_MEMO"
+
+[[metadata.tempo_bench.correctness.source_patterns]]
+name = "source_parses_token_units"
+pattern = "parseUnits"
+
+[metadata.tempo_bench.quality]
+shared = ["agent_turn_efficiency", "agent_token_efficiency", "llm_judge"]


### PR DESCRIPTION
## Summary
- add shared RewardKit registrars that read selected correctness/quality criteria from task TOML metadata
- generate one small /tests/tempo-bench.toml per task and replace duplicated generated criteria/check files with shared registrations
- keep task-specific onchain verification through the existing shared verify-tempo.sh + Node case harness

## Validation
- npm run check:scripts
- npm run check:format
- npm run check:lint
- npm run check:generated
- npm run check:dataset
- Daytona agent: tempo-bench-criteria-base-daytona-20260707124351, set-fee-token, reward 1, exceptions 0
- Daytona oracle: tempo-bench-criteria-docs-oracle-daytona-20260707125147, set-fee-token-docs, verifier correctness 1
- Daytona agent: tempo-bench-criteria-mcp-daytona-20260707125541, set-fee-token-mcp, reward 1, exceptions 0; trajectory includes Tempo MCP ToolSearch plus mcp__tempo__search and mcp__tempo__read_page