### PR TITLE
Move profile usage checks to quality

### DIFF
--- a/scripts/sync-shared.mjs
+++ b/scripts/sync-shared.mjs
@@ -273,28 +273,49 @@ function taskCriteriaPath(taskDir) {
   throw new Error(`Missing task-local criteria checks in ${taskDir}`);
 }
 
-function updateProfileCriteria(taskDir, profile) {
-  const criteriaPath = taskCriteriaPath(taskDir);
-  let content = fs.readFileSync(criteriaPath, "utf8");
+function removeProfileUsageChecks(content) {
   content = content.replace(
     /\nrk\.tempo_trajectory_matches\([\s\S]*?\n\)\n/g,
     "\n",
   );
-  content = content.replace(/\nrk\.tempo_mcp_tool_used\([\s\S]*?\)\n/g, "\n");
+  return content.replace(/\nrk\.tempo_mcp_tool_used\([\s\S]*?\)\n/g, "\n");
+}
 
-  if (profile.id === "docs") {
-    content += `
+function updateProfileCriteria(taskDir, profile) {
+  const criteriaPath = taskCriteriaPath(taskDir);
+  let content = fs.readFileSync(criteriaPath, "utf8");
+  content = removeProfileUsageChecks(content);
+
+  writeFile(criteriaPath, `${content.replace(/\s*$/, "")}\n`);
+}
+
+function profileQualityCheck(profileId) {
+  if (profileId === "docs") {
+    return `
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\\.txt|/developers/llms-full\\.txt|/developers/docs/.*\\.md|TEMPO_DOCS_URL",
 )
 `;
-  } else if (profile.id === "mcp") {
-    content += `
+  }
+
+  if (profileId === "mcp") {
+    return `
 rk.tempo_mcp_tool_used("tempo")
 `;
   }
 
-  writeFile(criteriaPath, `${content.replace(/\s*$/, "")}\n`);
+  return "";
+}
+
+function updateProfileQuality(taskDir) {
+  const profileId = readStringValue(path.join(taskDir, "task.toml"), "metadata.profile");
+  const check = profileQualityCheck(profileId);
+  if (!check) return;
+
+  const checkPath = path.join(taskDir, "tests/quality/check.py");
+  let content = fs.readFileSync(checkPath, "utf8");
+  content = removeProfileUsageChecks(content);
+  writeFile(checkPath, `${content.replace(/\s*$/, "")}\n${check}`);
 }
 
 function materializeTaskMatrix() {
@@ -455,6 +476,7 @@ function syncRewardKit(taskDir) {
     path.join(root, "shared/rewardkit/quality"),
     path.join(taskDir, "tests/quality"),
   );
+  updateProfileQuality(taskDir);
   copyFile(
     path.join(root, "shared/rewardkit/verify-tempo.sh"),
     path.join(taskDir, "tests/correctness/verify-tempo.sh"),

--- a/scripts/sync-shared.mjs
+++ b/scripts/sync-shared.mjs
@@ -262,33 +262,6 @@ function appendProfileInstruction(taskDir, profile) {
   writeFile(instructionPath, `${content.replace(/\s*$/, "")}\n`);
 }
 
-function taskCriteriaPath(taskDir) {
-  for (const relativePath of [
-    "tests/correctness/criteria.py",
-    "tests/criteria/check.py",
-  ]) {
-    const absolutePath = path.join(taskDir, relativePath);
-    if (fs.existsSync(absolutePath)) return absolutePath;
-  }
-  throw new Error(`Missing task-local criteria checks in ${taskDir}`);
-}
-
-function removeProfileUsageChecks(content) {
-  content = content.replace(
-    /\nrk\.tempo_trajectory_matches\([\s\S]*?\n\)\n/g,
-    "\n",
-  );
-  return content.replace(/\nrk\.tempo_mcp_tool_used\([\s\S]*?\)\n/g, "\n");
-}
-
-function updateProfileCriteria(taskDir, profile) {
-  const criteriaPath = taskCriteriaPath(taskDir);
-  let content = fs.readFileSync(criteriaPath, "utf8");
-  content = removeProfileUsageChecks(content);
-
-  writeFile(criteriaPath, `${content.replace(/\s*$/, "")}\n`);
-}
-
 function profileQualityCheck(profileId) {
   if (profileId === "docs") {
     return `
@@ -313,8 +286,7 @@ function updateProfileQuality(taskDir) {
   if (!check) return;
 
   const checkPath = path.join(taskDir, "tests/quality/check.py");
-  let content = fs.readFileSync(checkPath, "utf8");
-  content = removeProfileUsageChecks(content);
+  const content = fs.readFileSync(checkPath, "utf8");
   writeFile(checkPath, `${content.replace(/\s*$/, "")}\n${check}`);
 }
 
@@ -333,7 +305,6 @@ function materializeTaskMatrix() {
       generatedSlugs.add(slug);
       updateTaskToml(taskDir, sourceSlug, profile);
       appendProfileInstruction(taskDir, profile);
-      updateProfileCriteria(taskDir, profile);
     }
   }
 

--- a/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -217,10 +217,10 @@ def tempo_trajectory_matches(_workspace: Path, pattern: str) -> bool:
         {
             "trajectory": None,
             "pattern": pattern,
-            "passed": True,
+            "passed": False,
         },
     )
-    return True
+    return False
 
 
 @criterion(shared=True)

--- a/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
@@ -27,7 +27,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)

--- a/tasks/create-stablecoin-with-policy-docs/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy-docs/tests/quality/check.py
@@ -3,3 +3,7 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_trajectory_matches(
+    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
+)

--- a/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -27,5 +27,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")

--- a/tasks/create-stablecoin-with-policy-mcp/tests/quality/check.py
+++ b/tasks/create-stablecoin-with-policy-mcp/tests/quality/check.py
@@ -3,3 +3,5 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:15cb5262f1d15a417c2719086b642d3b79659c532630b122791c0065d5b061cd"
+digest = "sha256:b3703b260a2e0ab872162a869f699ce7fd39c22ab237d0efa95d63204996550c"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:1252b50f9aab60dd4f674fd6e43263e47a3d561a8f0cc86ea57b13db6c7eb088"
+digest = "sha256:d436868f7400a606dfb90a677e9c5df82cc51050746dc899000cc0918e363303"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:4d6e7cba6fd7f594f5e176a20b652f76aa4e3fec3d9df101636573b6a6141105"
+digest = "sha256:313ad3c1d82444b3c12661bb2cc743202d1d5739e5ffc0bfece8dd1b1844fc1d"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:d45252917fc19b27eb02d6b69ae9e4eb709931270ba8f87ce27499d6177b70e6"
+digest = "sha256:c86016e1317f90d45c7e558d6f098927a3604649f40567018d87da6d6bbe1ee8"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:2a8e8553fcc5346d72ccd5b7b9b7f330769cb97611de6c5f6edd6f90dda51012"
+digest = "sha256:786ea2af47a94aa2e1a97bf72ad5a86520bb83e14ee7319b2e9e5e9170384cb3"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:68d52513f10128425690e92c079f7c18b59070e22b99ea72a22030657921b50d"
+digest = "sha256:13c678916a60a576eae376d0b94e090134ce370c467a01419d8e2b4023cc0daf"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:9cb27f49efa221be71eb1d97d58952895e7fd5e2b1e183692591f33550cfcb84"
+digest = "sha256:83bff4e3a031f28161f618eea513acd9a5e6c558da6029cabf9d8e11f6ba1496"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:4ac289caf21a39e9c9210a9f9919a174bb3da96bc53c2cddb900e548e822b2d9"
+digest = "sha256:c509983c44829c33ef4d99cae6a707340253588f7a3b330d03aec0533c616fd9"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:d4f9dfb1dc6877d386061ee3d309efb73a611d10c87130b38e1f82fe7930ee07"
+digest = "sha256:f8b8d027f51291f2c93c472cf8b8873b5c91c34aa3a16942516db46c40c97bee"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:331edf54ac27945bb786250e70c05e1e035bf90374ab85182ea9a2c82d7a2e4f"
+digest = "sha256:0d2cecbd1b74a43409147addac9ed4af674b0bf2a0dea2b430b734363c18a93c"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:40ed6c109cf477b14f87601b8833d2b9e34ffa709927aaa410a0138d431c7755"
+digest = "sha256:1df4691012e8033e85eaa497ad81e2220e41b8f671b4ddb031156d1c48c59591"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:f382452af8492ec8387443776467fa0ee6a2a56dbc1ea573e36a58447e46e56d"
+digest = "sha256:d855cb80e6c2e3e133fa98d7d0d80e39e4b4e6342dd055f1417c24d2a6a633ae"
 

--- a/tasks/dataset.toml
+++ b/tasks/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:da2ea37270ff39decfdc050f3967cc0f270ff69deb674c75e7aec8918e938030"
+digest = "sha256:15cb5262f1d15a417c2719086b642d3b79659c532630b122791c0065d5b061cd"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:a92fb8d0f076042146c89c495aea46294943c129635d97366086db891d764748"
+digest = "sha256:1252b50f9aab60dd4f674fd6e43263e47a3d561a8f0cc86ea57b13db6c7eb088"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:ebf991cbee22d1f4b5679c2c6ec233bd3df80b4a572aec0f7f38987c3973d1c5"
+digest = "sha256:4d6e7cba6fd7f594f5e176a20b652f76aa4e3fec3d9df101636573b6a6141105"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:60e66b4f975e31751f31b876f0f5f18a25df24b9b9a039775934e2d0d243f6fb"
+digest = "sha256:d45252917fc19b27eb02d6b69ae9e4eb709931270ba8f87ce27499d6177b70e6"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:462643fee69bec7f19820b1fc0908e316963aac9b56666f2bc9226c9f9713e3a"
+digest = "sha256:2a8e8553fcc5346d72ccd5b7b9b7f330769cb97611de6c5f6edd6f90dda51012"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:b532e93bd11b92baeaf39fd06bd7ff4cfcee43abb6461888e4d256c8762e6be6"
+digest = "sha256:68d52513f10128425690e92c079f7c18b59070e22b99ea72a22030657921b50d"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:f1c01d960e4c1631830c3cb0dc435b550cea1e9f14dfab8a3988ebaec6735036"
+digest = "sha256:9cb27f49efa221be71eb1d97d58952895e7fd5e2b1e183692591f33550cfcb84"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:a054983a28b5f009aa7c4153752808faffe98dc127baf839b12a50b99cab55af"
+digest = "sha256:4ac289caf21a39e9c9210a9f9919a174bb3da96bc53c2cddb900e548e822b2d9"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:cef76f945e7706da47702adc4d9b28d64063e913db78ca61c0a9c253fada3e99"
+digest = "sha256:d4f9dfb1dc6877d386061ee3d309efb73a611d10c87130b38e1f82fe7930ee07"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:99299b4d51fc11c239d10d7cc2ee14ad388071e1a30808f118874370051f4d3b"
+digest = "sha256:331edf54ac27945bb786250e70c05e1e035bf90374ab85182ea9a2c82d7a2e4f"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:279f6176120dbc2a883a26203bf668bc9fcadea1c9e3888e6d484fd8fb3526ef"
+digest = "sha256:40ed6c109cf477b14f87601b8833d2b9e34ffa709927aaa410a0138d431c7755"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:ac8ff8fa3582cf00d51c2dd3942f51e5c466f692a5c1c3d97fe85182d8f44104"
+digest = "sha256:f382452af8492ec8387443776467fa0ee6a2a56dbc1ea573e36a58447e46e56d"
 

--- a/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-docs/tests/correctness/criteria.py
@@ -19,7 +19,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)

--- a/tasks/faucet-funded-transfer-docs/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer-docs/tests/quality/check.py
@@ -3,3 +3,7 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_trajectory_matches(
+    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
+)

--- a/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -19,5 +19,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")

--- a/tasks/faucet-funded-transfer-mcp/tests/quality/check.py
+++ b/tasks/faucet-funded-transfer-mcp/tests/quality/check.py
@@ -3,3 +3,5 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/set-fee-token-docs/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-docs/tests/correctness/criteria.py
@@ -15,7 +15,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)

--- a/tasks/set-fee-token-docs/tests/quality/check.py
+++ b/tasks/set-fee-token-docs/tests/quality/check.py
@@ -3,3 +3,7 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_trajectory_matches(
+    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
+)

--- a/tasks/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/set-fee-token-mcp/tests/correctness/criteria.py
@@ -15,5 +15,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")

--- a/tasks/set-fee-token-mcp/tests/quality/check.py
+++ b/tasks/set-fee-token-mcp/tests/quality/check.py
@@ -3,3 +3,5 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/correctness/criteria.py
@@ -30,7 +30,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)

--- a/tasks/stablecoin-dex-swap-docs/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap-docs/tests/quality/check.py
@@ -3,3 +3,7 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_trajectory_matches(
+    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
+)

--- a/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -30,5 +30,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")

--- a/tasks/stablecoin-dex-swap-mcp/tests/quality/check.py
+++ b/tasks/stablecoin-dex-swap-mcp/tests/quality/check.py
@@ -3,3 +3,5 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-docs/tests/correctness/criteria.py
@@ -19,7 +19,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)

--- a/tasks/transfer-with-memo-docs/tests/quality/check.py
+++ b/tasks/transfer-with-memo-docs/tests/quality/check.py
@@ -3,3 +3,7 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_trajectory_matches(
+    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
+)

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
@@ -31,7 +31,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_trajectory_matches(
-    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
-)

--- a/tasks/transfer-with-memo-fee-payer-docs/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer-docs/tests/quality/check.py
@@ -3,3 +3,7 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_trajectory_matches(
+    r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",
+)

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -31,5 +31,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")

--- a/tasks/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
+++ b/tasks/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
@@ -3,3 +3,5 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_mcp_tool_used("tempo")

--- a/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -19,5 +19,3 @@ rk.tempo_source_patterns(
     ]
 )
 rk.tempo_onchain_verifier()
-
-rk.tempo_mcp_tool_used("tempo")

--- a/tasks/transfer-with-memo-mcp/tests/quality/check.py
+++ b/tasks/transfer-with-memo-mcp/tests/quality/check.py
@@ -3,3 +3,5 @@ import tempo_bench_rewardkit  # noqa: F401
 
 rk.agent_turn_efficiency()
 rk.agent_token_efficiency()
+
+rk.tempo_mcp_tool_used("tempo")


### PR DESCRIPTION
## Summary

- moves docs and MCP usage checks out of correctness and into quality for generated profile tasks
- keeps profile checks limited to tasks with `metadata.profile = "docs"` or `metadata.profile = "mcp"`
- refreshes generated task digests after the criteria move

## Validation

- `npm run check:scripts`
- `npm run check:format`
- `npm run check:lint`
- `npm run check:generated`