### PR TITLE
Add Claude Opus to benchmark matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ rewriting the Harbor config to point at that staged tree.
 | Dataset | `tasks/dataset.toml` |
 | Task | `tasks/*/task.toml`, `instruction.md`, `environment/`, `tests/`, `solution/` |
 | Job | `config/job.*.yaml` |
-| Agent | `oracle` or `claude-code` in the job config |
+| Agent | `oracle` or `claude-code` model entries in the job config |
 | Environment | Local Docker or Daytona DinD |
 | Verifier | `tasks/*/tests/test.sh` plus shared verifier code copied from `shared/` |
 | Score | `/logs/verifier/reward.json` with `{"reward": 0|1}` |
@@ -71,14 +71,15 @@ the independent build/run/onchain verifier result.
 | Command | Config | Runtime | Attempts | Purpose |
 | --- | --- | --- | ---: | --- |
 | `npm run bench:local:oracle` | `config/job.local.oracle.yaml` | Docker | 1 | Validate all oracle solutions locally. |
-| `npm run bench:local:agent` | `config/job.local.agent.yaml` | Docker | 3 | Full local Claude Code suite. |
-| `npm run bench:local:agent:dev` | `config/job.local.agent.dev.yaml` | Docker | 1 | Local smoke run across the suite. |
+| `npm run bench:local:agent` | `config/job.local.agent.yaml` | Docker | 3 | Full local Claude Code model suite. |
+| `npm run bench:local:agent:dev` | `config/job.local.agent.dev.yaml` | Docker | 1 | Local model smoke run across the suite. |
 | `npm run bench:daytona:oracle` | `config/job.daytona.oracle.yaml` | Daytona | 1 | Validate all oracle solutions remotely. |
-| `npm run bench:daytona:agent` | `config/job.daytona.agent.yaml` | Daytona | 3 | Full remote Claude Code suite. |
-| `npm run bench:daytona:agent:dev` | `config/job.daytona.agent.dev.yaml` | Daytona | 1 | Remote smoke run across the suite. |
+| `npm run bench:daytona:agent` | `config/job.daytona.agent.yaml` | Daytona | 3 | Full remote Claude Code model suite. |
+| `npm run bench:daytona:agent:dev` | `config/job.daytona.agent.dev.yaml` | Daytona | 1 | Remote model smoke run across the suite. |
 
-The config-backed jobs include all 18 tasks by default: 6 base tasks, 6 docs
-tasks, and 6 MCP tasks.
+The config-backed agent jobs include all 18 tasks by default: 6 base tasks, 6
+docs tasks, and 6 MCP tasks. Harbor runs each task against each configured
+Claude Code model entry, currently `claude-haiku-4-5` and `claude-opus-4-8`.
 
 Use the generic model runner for one-off local runs:
 

--- a/config/job.daytona.agent.dev.yaml
+++ b/config/job.daytona.agent.dev.yaml
@@ -1,4 +1,4 @@
-# Daytona Agent dev job: one-attempt Claude Code smoke run on Daytona DinD for fast remote iteration.
+# Daytona Agent dev job: one-attempt Claude Code model smoke run on Daytona DinD for fast remote iteration.
 # Keep this config thin. scripts/run-benchmark.ts copies tasks into a temporary
 # dereferenced .cache/harbor-daytona/<job>/tasks tree before invoking Harbor.
 # Do not materialize task symlinks in tasks/ to fix Daytona upload issues; update
@@ -25,12 +25,18 @@ verifier:
 agents:
   - name: claude-code
     model_name: claude-haiku-4-5
+    concurrency_group: claude-code
     n_concurrent: 32
-    env:
+    env: &claude_code_env
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       CLAUDE_FORCE_OAUTH: ${CLAUDE_FORCE_OAUTH:-false}
+  - name: claude-code
+    model_name: claude-opus-4-8
+    concurrency_group: claude-code
+    n_concurrent: 32
+    env: *claude_code_env
 datasets:
   - path: tasks
     task_names:

--- a/config/job.daytona.agent.yaml
+++ b/config/job.daytona.agent.yaml
@@ -1,4 +1,4 @@
-# Daytona Agent job: runs the full Claude Code benchmark matrix on Daytona DinD, three attempts per task.
+# Daytona Agent job: runs the full Claude Code model benchmark matrix on Daytona DinD, three attempts per task.
 # Keep this config thin. scripts/run-benchmark.ts copies tasks into a temporary
 # dereferenced .cache/harbor-daytona/<job>/tasks tree before invoking Harbor.
 # Do not materialize task symlinks in tasks/ to fix Daytona upload issues; update
@@ -24,12 +24,18 @@ verifier:
 agents:
   - name: claude-code
     model_name: claude-haiku-4-5
+    concurrency_group: claude-code
     n_concurrent: 32
-    env:
+    env: &claude_code_env
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       CLAUDE_FORCE_OAUTH: ${CLAUDE_FORCE_OAUTH:-false}
+  - name: claude-code
+    model_name: claude-opus-4-8
+    concurrency_group: claude-code
+    n_concurrent: 32
+    env: *claude_code_env
 datasets:
   - path: tasks
     task_names:

--- a/config/job.local.agent.dev.yaml
+++ b/config/job.local.agent.dev.yaml
@@ -1,4 +1,4 @@
-# Local Agent dev job: one-attempt Claude Code smoke run in local Docker.
+# Local Agent dev job: one-attempt Claude Code model smoke run in local Docker.
 job_name: tempo-bench-agents-dev-local
 jobs_dir: jobs
 n_attempts: 1
@@ -17,11 +17,18 @@ verifier:
 agents:
   - name: claude-code
     model_name: claude-haiku-4-5
-    env:
+    concurrency_group: claude-code
+    n_concurrent: 4
+    env: &claude_code_env
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       CLAUDE_FORCE_OAUTH: ${CLAUDE_FORCE_OAUTH:-false}
+  - name: claude-code
+    model_name: claude-opus-4-8
+    concurrency_group: claude-code
+    n_concurrent: 4
+    env: *claude_code_env
 datasets:
   - path: tasks
     task_names:

--- a/config/job.local.agent.yaml
+++ b/config/job.local.agent.yaml
@@ -1,4 +1,4 @@
-# Local Agent job: runs the full Claude Code benchmark matrix in local Docker.
+# Local Agent job: runs the full Claude Code model benchmark matrix in local Docker.
 job_name: tempo-bench-agents-local
 jobs_dir: jobs
 n_attempts: 3
@@ -17,11 +17,18 @@ verifier:
 agents:
   - name: claude-code
     model_name: claude-haiku-4-5
-    env:
+    concurrency_group: claude-code
+    n_concurrent: 4
+    env: &claude_code_env
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       CLAUDE_FORCE_OAUTH: ${CLAUDE_FORCE_OAUTH:-false}
+  - name: claude-code
+    model_name: claude-opus-4-8
+    concurrency_group: claude-code
+    n_concurrent: 4
+    env: *claude_code_env
 datasets:
   - path: tasks
     task_names:


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-8` as a second `claude-code` model entry across local and Daytona agent jobs.
- Share the Claude Code concurrency group and environment wiring with the existing Haiku entry.
- Update the README to describe the model matrix behavior and expanded trial count semantics.

## Validation

- Harbor `JobConfig` validation for all edited agent configs
- `npm run check`
