### PR TITLE
Verify faucet funding transfer

### DIFF
--- a/shared/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/verifier/src/cases/faucet-funded-transfer.js
@@ -11,6 +11,13 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
   const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
@@ -43,7 +50,9 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: match.blockNumber,
     });
-    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+    const funding = fundingLogs.find(
+      (log) => log.args.value >= expectedValue && beforeLog(log, match),
+    );
 
     return (
       funding &&

--- a/shared/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/verifier/src/cases/faucet-funded-transfer.js
@@ -1,17 +1,21 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
-const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    ...defaultRuntimeEnv(config),
+    TEMPO_RPC_URL: config.rpcUrl,
+    TEMPO_TOKEN: config.token,
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
+    TEMPO_RECIPIENT: config.recipient,
+    TEMPO_AMOUNT: config.amount,
+    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 
 async function verify({ client, config, fromBlock }) {
+  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -30,7 +34,28 @@ async function verify({ client, config, fromBlock }) {
     });
 
     const match = logs.find((log) => log.args.value === expectedValue);
-    return match && blockEvidence(match, { fundedSender: sender });
+    if (!match) return null;
+
+    const fundingLogs = await client.getLogs({
+      address: config.token,
+      event,
+      args: {
+        from: faucet,
+        to: sender,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
+    });
+    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+
+    return (
+      funding &&
+      blockEvidence(match, {
+        faucet,
+        fundedSender: sender,
+        fundingTransactionHash: funding.transactionHash,
+      })
+    );
   }, "no matching faucet-funded transfer event observed");
 }
 

--- a/shared/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/verifier/src/cases/faucet-funded-transfer.js
@@ -1,16 +1,13 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
+const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    TEMPO_RPC_URL: config.rpcUrl,
-    TEMPO_TOKEN: config.token,
+    ...defaultRuntimeEnv(config),
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
-    TEMPO_RECIPIENT: config.recipient,
-    TEMPO_AMOUNT: config.amount,
-    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 

--- a/shared/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/verifier/src/cases/faucet-funded-transfer.js
@@ -19,7 +19,7 @@ function beforeLog(left, right) {
 }
 
 async function verify({ client, config, fromBlock }) {
-  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
+  const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -44,7 +44,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: faucet,
+        from: localnetFaucet,
         to: sender,
       },
       fromBlock,
@@ -57,7 +57,7 @@ async function verify({ client, config, fromBlock }) {
     return (
       funding &&
       blockEvidence(match, {
-        faucet,
+        localnetFaucet,
         fundedSender: sender,
         fundingTransactionHash: funding.transactionHash,
       })

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -59,15 +59,15 @@ digest = "sha256:10a0ed06cc9574bc70ad3a3124290208cce0bf010eedfd5aadd4d8123dc6c11
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:7ae3a5483ca8ba741c13f2aefbb1a6b6868922b9efb05d765d07fa7fcdcc40be"
+digest = "sha256:23a1855449ca6b2e8e87ed5ab2d47f78906db02acca87f17f6d8b263db8546a8"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:d10b572ed7c7e8b789125380c384873c7e5fc04b7341a5e77b809374a94d4dd1"
+digest = "sha256:3218c04c7d72d5c6f3e903d19057954efafc31a73d8315da7946b74ed4a0f961"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:18e32d7bef830914120a0a5f702fa43f3e8fb4f464e17e367b85f2c427dc9b48"
+digest = "sha256:8b3daf5c9a20a85ea672417b29f2f53614ebbc8b48a4b08208c15ecf3c2debe4"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -11,6 +11,13 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
   const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
@@ -43,7 +50,9 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: match.blockNumber,
     });
-    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+    const funding = fundingLogs.find(
+      (log) => log.args.value >= expectedValue && beforeLog(log, match),
+    );
 
     return (
       funding &&

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -1,17 +1,21 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
-const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    ...defaultRuntimeEnv(config),
+    TEMPO_RPC_URL: config.rpcUrl,
+    TEMPO_TOKEN: config.token,
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
+    TEMPO_RECIPIENT: config.recipient,
+    TEMPO_AMOUNT: config.amount,
+    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 
 async function verify({ client, config, fromBlock }) {
+  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -30,7 +34,28 @@ async function verify({ client, config, fromBlock }) {
     });
 
     const match = logs.find((log) => log.args.value === expectedValue);
-    return match && blockEvidence(match, { fundedSender: sender });
+    if (!match) return null;
+
+    const fundingLogs = await client.getLogs({
+      address: config.token,
+      event,
+      args: {
+        from: faucet,
+        to: sender,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
+    });
+    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+
+    return (
+      funding &&
+      blockEvidence(match, {
+        faucet,
+        fundedSender: sender,
+        fundingTransactionHash: funding.transactionHash,
+      })
+    );
   }, "no matching faucet-funded transfer event observed");
 }
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -1,16 +1,13 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
+const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    TEMPO_RPC_URL: config.rpcUrl,
-    TEMPO_TOKEN: config.token,
+    ...defaultRuntimeEnv(config),
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
-    TEMPO_RECIPIENT: config.recipient,
-    TEMPO_AMOUNT: config.amount,
-    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -19,7 +19,7 @@ function beforeLog(left, right) {
 }
 
 async function verify({ client, config, fromBlock }) {
-  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
+  const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -44,7 +44,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: faucet,
+        from: localnetFaucet,
         to: sender,
       },
       fromBlock,
@@ -57,7 +57,7 @@ async function verify({ client, config, fromBlock }) {
     return (
       funding &&
       blockEvidence(match, {
-        faucet,
+        localnetFaucet,
         fundedSender: sender,
         fundingTransactionHash: funding.transactionHash,
       })

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -11,6 +11,13 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
   const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
@@ -43,7 +50,9 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: match.blockNumber,
     });
-    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+    const funding = fundingLogs.find(
+      (log) => log.args.value >= expectedValue && beforeLog(log, match),
+    );
 
     return (
       funding &&

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -1,17 +1,21 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
-const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    ...defaultRuntimeEnv(config),
+    TEMPO_RPC_URL: config.rpcUrl,
+    TEMPO_TOKEN: config.token,
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
+    TEMPO_RECIPIENT: config.recipient,
+    TEMPO_AMOUNT: config.amount,
+    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 
 async function verify({ client, config, fromBlock }) {
+  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -30,7 +34,28 @@ async function verify({ client, config, fromBlock }) {
     });
 
     const match = logs.find((log) => log.args.value === expectedValue);
-    return match && blockEvidence(match, { fundedSender: sender });
+    if (!match) return null;
+
+    const fundingLogs = await client.getLogs({
+      address: config.token,
+      event,
+      args: {
+        from: faucet,
+        to: sender,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
+    });
+    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+
+    return (
+      funding &&
+      blockEvidence(match, {
+        faucet,
+        fundedSender: sender,
+        fundingTransactionHash: funding.transactionHash,
+      })
+    );
   }, "no matching faucet-funded transfer event observed");
 }
 

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -1,16 +1,13 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
+const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    TEMPO_RPC_URL: config.rpcUrl,
-    TEMPO_TOKEN: config.token,
+    ...defaultRuntimeEnv(config),
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
-    TEMPO_RECIPIENT: config.recipient,
-    TEMPO_AMOUNT: config.amount,
-    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -19,7 +19,7 @@ function beforeLog(left, right) {
 }
 
 async function verify({ client, config, fromBlock }) {
-  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
+  const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -44,7 +44,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: faucet,
+        from: localnetFaucet,
         to: sender,
       },
       fromBlock,
@@ -57,7 +57,7 @@ async function verify({ client, config, fromBlock }) {
     return (
       funding &&
       blockEvidence(match, {
-        faucet,
+        localnetFaucet,
         fundedSender: sender,
         fundingTransactionHash: funding.transactionHash,
       })

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -11,6 +11,13 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
   const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
@@ -43,7 +50,9 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: match.blockNumber,
     });
-    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+    const funding = fundingLogs.find(
+      (log) => log.args.value >= expectedValue && beforeLog(log, match),
+    );
 
     return (
       funding &&

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -1,17 +1,21 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
-const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    ...defaultRuntimeEnv(config),
+    TEMPO_RPC_URL: config.rpcUrl,
+    TEMPO_TOKEN: config.token,
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
+    TEMPO_RECIPIENT: config.recipient,
+    TEMPO_AMOUNT: config.amount,
+    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 
 async function verify({ client, config, fromBlock }) {
+  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -30,7 +34,28 @@ async function verify({ client, config, fromBlock }) {
     });
 
     const match = logs.find((log) => log.args.value === expectedValue);
-    return match && blockEvidence(match, { fundedSender: sender });
+    if (!match) return null;
+
+    const fundingLogs = await client.getLogs({
+      address: config.token,
+      event,
+      args: {
+        from: faucet,
+        to: sender,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
+    });
+    const funding = fundingLogs.find((log) => log.args.value >= expectedValue);
+
+    return (
+      funding &&
+      blockEvidence(match, {
+        faucet,
+        fundedSender: sender,
+        fundingTransactionHash: funding.transactionHash,
+      })
+    );
   }, "no matching faucet-funded transfer event observed");
 }
 

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -1,16 +1,13 @@
 // SYNCED FROM shared/verifier/src/cases/faucet-funded-transfer.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
+const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
 
 function runtimeEnv(config) {
   return {
-    TEMPO_RPC_URL: config.rpcUrl,
-    TEMPO_TOKEN: config.token,
+    ...defaultRuntimeEnv(config),
     TEMPO_FAUCET_PRIVATE_KEY: config.faucetPrivateKey,
-    TEMPO_RECIPIENT: config.recipient,
-    TEMPO_AMOUNT: config.amount,
-    TEMPO_DECIMALS: String(config.decimals),
   };
 }
 

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -19,7 +19,7 @@ function beforeLog(left, right) {
 }
 
 async function verify({ client, config, fromBlock }) {
-  const faucet = privateKeyToAccount(config.payerPrivateKey).address;
+  const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
   const sender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
@@ -44,7 +44,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: faucet,
+        from: localnetFaucet,
         to: sender,
       },
       fromBlock,
@@ -57,7 +57,7 @@ async function verify({ client, config, fromBlock }) {
     return (
       funding &&
       blockEvidence(match, {
-        faucet,
+        localnetFaucet,
         fundedSender: sender,
         fundingTransactionHash: funding.transactionHash,
       })


### PR DESCRIPTION
## Summary

Tightens the faucet-funded transfer task verifier so the task requires the faucet funding step, not only the final outgoing transfer.

## Changes

- Pass only the faucet task's prompt-listed runtime environment to submissions.
- Verify a faucet-source funding transfer into the faucet wallet before accepting the wallet's transfer to the recipient.
- Refresh generated task verifier copies and dataset digests for the faucet task variants.

## Validation

- `npm run check`
- `npm run check:generated`
- `npm run bench:local:oracle -- --task-filter tempo/faucet-funded-transfer-base --n-tasks 1`