### PR TITLE
Verify DEX swap maker and amount

### DIFF
--- a/shared/verifier/src/cases/stablecoin-dex-swap.js
+++ b/shared/verifier/src/cases/stablecoin-dex-swap.js
@@ -1,5 +1,5 @@
 // SYNCED FROM shared/verifier/src/cases/stablecoin-dex-swap.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-const { parseAbiItem } = require("viem");
+const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
 const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
@@ -16,10 +16,22 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
+  const maker = privateKeyToAccount(config.dexMakerPrivateKey).address;
   const taker = privateKeyToAccount(config.payerPrivateKey).address;
+  const expectedAmount = parseUnits(config.swapAmountIn, config.decimals);
   const event = parseAbiItem(
     "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)",
+  );
+  const orderPlaced = parseAbiItem(
+    "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)",
   );
 
   return waitForEvidence(config, async () => {
@@ -27,16 +39,40 @@ async function verify({ client, config, fromBlock }) {
     const logs = await client.getLogs({
       address: config.stablecoinDex,
       event,
-      args: { taker },
+      args: { maker, taker },
       fromBlock,
       toBlock: latestBlock,
     });
 
-    const match = logs[0];
-    return match && blockEvidence(match, {
-      orderId: match.args.orderId.toString(),
-      amountFilled: match.args.amountFilled.toString(),
+    const match = logs.find((log) => log.args.amountFilled === expectedAmount);
+    if (!match) return null;
+
+    const orderLogs = await client.getLogs({
+      address: config.stablecoinDex,
+      event: orderPlaced,
+      args: {
+        orderId: match.args.orderId,
+        maker,
+        token: config.swapTokenOut,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
     });
+    const order = orderLogs.find(
+      (log) => log.args.amount >= expectedAmount && !log.args.isBid && beforeLog(log, match),
+    );
+
+    return (
+      order &&
+      blockEvidence(match, {
+        maker,
+        orderId: match.args.orderId.toString(),
+        orderPlacedTransactionHash: order.transactionHash,
+        orderIsBid: order.args.isBid,
+        orderToken: order.args.token,
+        amountFilled: match.args.amountFilled.toString(),
+      })
+    );
   }, "no matching Stablecoin DEX OrderFilled event observed");
 }
 

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -71,13 +71,13 @@ digest = "sha256:18e32d7bef830914120a0a5f702fa43f3e8fb4f464e17e367b85f2c427dc9b4
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:0cbf5ab54d7d8123ef2954a20ec8cad81ed71dabaa497a4cb9f3663187f891f1"
+digest = "sha256:40515963a0496b1339568a940c1c87274a2d78a935c94c803ce523a8684af989"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:3baa8e50b02e7ae58bdde74ae9de56020c36e8e4dbd779e5428d1392ff401890"
+digest = "sha256:e505b154661536cd68533c4b684cbc07a564f96325c616367cc68922ff10f94f"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:09c335c698b95a7da69b9034e66b9356c290873f2498804eee5325fad57d36f0"
+digest = "sha256:c73fc0b7889098022b0ebea9e60d2dd2e32a5bc6382b64cd731d372ac029175a"
 

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/cases/stablecoin-dex-swap.js
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/cases/stablecoin-dex-swap.js
@@ -1,5 +1,5 @@
 // SYNCED FROM shared/verifier/src/cases/stablecoin-dex-swap.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-const { parseAbiItem } = require("viem");
+const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
 const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
@@ -16,10 +16,22 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
+  const maker = privateKeyToAccount(config.dexMakerPrivateKey).address;
   const taker = privateKeyToAccount(config.payerPrivateKey).address;
+  const expectedAmount = parseUnits(config.swapAmountIn, config.decimals);
   const event = parseAbiItem(
     "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)",
+  );
+  const orderPlaced = parseAbiItem(
+    "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)",
   );
 
   return waitForEvidence(config, async () => {
@@ -27,16 +39,40 @@ async function verify({ client, config, fromBlock }) {
     const logs = await client.getLogs({
       address: config.stablecoinDex,
       event,
-      args: { taker },
+      args: { maker, taker },
       fromBlock,
       toBlock: latestBlock,
     });
 
-    const match = logs[0];
-    return match && blockEvidence(match, {
-      orderId: match.args.orderId.toString(),
-      amountFilled: match.args.amountFilled.toString(),
+    const match = logs.find((log) => log.args.amountFilled === expectedAmount);
+    if (!match) return null;
+
+    const orderLogs = await client.getLogs({
+      address: config.stablecoinDex,
+      event: orderPlaced,
+      args: {
+        orderId: match.args.orderId,
+        maker,
+        token: config.swapTokenOut,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
     });
+    const order = orderLogs.find(
+      (log) => log.args.amount >= expectedAmount && !log.args.isBid && beforeLog(log, match),
+    );
+
+    return (
+      order &&
+      blockEvidence(match, {
+        maker,
+        orderId: match.args.orderId.toString(),
+        orderPlacedTransactionHash: order.transactionHash,
+        orderIsBid: order.args.isBid,
+        orderToken: order.args.token,
+        amountFilled: match.args.amountFilled.toString(),
+      })
+    );
   }, "no matching Stablecoin DEX OrderFilled event observed");
 }
 

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/cases/stablecoin-dex-swap.js
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/cases/stablecoin-dex-swap.js
@@ -1,5 +1,5 @@
 // SYNCED FROM shared/verifier/src/cases/stablecoin-dex-swap.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-const { parseAbiItem } = require("viem");
+const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
 const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
@@ -16,10 +16,22 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
+  const maker = privateKeyToAccount(config.dexMakerPrivateKey).address;
   const taker = privateKeyToAccount(config.payerPrivateKey).address;
+  const expectedAmount = parseUnits(config.swapAmountIn, config.decimals);
   const event = parseAbiItem(
     "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)",
+  );
+  const orderPlaced = parseAbiItem(
+    "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)",
   );
 
   return waitForEvidence(config, async () => {
@@ -27,16 +39,40 @@ async function verify({ client, config, fromBlock }) {
     const logs = await client.getLogs({
       address: config.stablecoinDex,
       event,
-      args: { taker },
+      args: { maker, taker },
       fromBlock,
       toBlock: latestBlock,
     });
 
-    const match = logs[0];
-    return match && blockEvidence(match, {
-      orderId: match.args.orderId.toString(),
-      amountFilled: match.args.amountFilled.toString(),
+    const match = logs.find((log) => log.args.amountFilled === expectedAmount);
+    if (!match) return null;
+
+    const orderLogs = await client.getLogs({
+      address: config.stablecoinDex,
+      event: orderPlaced,
+      args: {
+        orderId: match.args.orderId,
+        maker,
+        token: config.swapTokenOut,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
     });
+    const order = orderLogs.find(
+      (log) => log.args.amount >= expectedAmount && !log.args.isBid && beforeLog(log, match),
+    );
+
+    return (
+      order &&
+      blockEvidence(match, {
+        maker,
+        orderId: match.args.orderId.toString(),
+        orderPlacedTransactionHash: order.transactionHash,
+        orderIsBid: order.args.isBid,
+        orderToken: order.args.token,
+        amountFilled: match.args.amountFilled.toString(),
+      })
+    );
   }, "no matching Stablecoin DEX OrderFilled event observed");
 }
 

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/cases/stablecoin-dex-swap.js
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/cases/stablecoin-dex-swap.js
@@ -1,5 +1,5 @@
 // SYNCED FROM shared/verifier/src/cases/stablecoin-dex-swap.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-const { parseAbiItem } = require("viem");
+const { parseAbiItem, parseUnits } = require("viem");
 const { privateKeyToAccount } = require("viem/accounts");
 const { defaultRuntimeEnv } = require("../submission");
 const { blockEvidence, waitForEvidence } = require("../tempo");
@@ -16,10 +16,22 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
 async function verify({ client, config, fromBlock }) {
+  const maker = privateKeyToAccount(config.dexMakerPrivateKey).address;
   const taker = privateKeyToAccount(config.payerPrivateKey).address;
+  const expectedAmount = parseUnits(config.swapAmountIn, config.decimals);
   const event = parseAbiItem(
     "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)",
+  );
+  const orderPlaced = parseAbiItem(
+    "event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)",
   );
 
   return waitForEvidence(config, async () => {
@@ -27,16 +39,40 @@ async function verify({ client, config, fromBlock }) {
     const logs = await client.getLogs({
       address: config.stablecoinDex,
       event,
-      args: { taker },
+      args: { maker, taker },
       fromBlock,
       toBlock: latestBlock,
     });
 
-    const match = logs[0];
-    return match && blockEvidence(match, {
-      orderId: match.args.orderId.toString(),
-      amountFilled: match.args.amountFilled.toString(),
+    const match = logs.find((log) => log.args.amountFilled === expectedAmount);
+    if (!match) return null;
+
+    const orderLogs = await client.getLogs({
+      address: config.stablecoinDex,
+      event: orderPlaced,
+      args: {
+        orderId: match.args.orderId,
+        maker,
+        token: config.swapTokenOut,
+      },
+      fromBlock,
+      toBlock: match.blockNumber,
     });
+    const order = orderLogs.find(
+      (log) => log.args.amount >= expectedAmount && !log.args.isBid && beforeLog(log, match),
+    );
+
+    return (
+      order &&
+      blockEvidence(match, {
+        maker,
+        orderId: match.args.orderId.toString(),
+        orderPlacedTransactionHash: order.transactionHash,
+        orderIsBid: order.args.isBid,
+        orderToken: order.args.token,
+        amountFilled: match.args.amountFilled.toString(),
+      })
+    );
   }, "no matching Stablecoin DEX OrderFilled event observed");
 }
 


### PR DESCRIPTION
## Summary

Tightens the Stablecoin DEX swap verifier so it validates more of the requested swap semantics instead of accepting any taker fill.

## Changes

- Require the `OrderFilled` event to come from the expected maker derived from `TEMPO_DEX_MAKER_PRIVATE_KEY`.
- Require `amountFilled` to match `TEMPO_SWAP_AMOUNT_IN` parsed with `TEMPO_DECIMALS`.
- Refresh generated task verifier copies and dataset digests for the DEX swap variants.

## Validation

- `npm run check`
- `npm run check:generated`
- `npm run bench:local:oracle -- --task-filter tempo/stablecoin-dex-swap-base --n-tasks 1`