### PR TITLE
Verify policy account updates

### DIFF
--- a/shared/verifier/src/cases/create-stablecoin-with-policy.js
+++ b/shared/verifier/src/cases/create-stablecoin-with-policy.js
@@ -23,6 +23,17 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
+function sameHex(left, right) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
 async function verify({ client, config, fromBlock }) {
   const admin = privateKeyToAccount(config.payerPrivateKey).address;
   const expectedPolicyType = POLICY_TYPES[config.policyType];
@@ -58,7 +69,8 @@ async function verify({ client, config, fromBlock }) {
         log.args.name === config.stablecoinName &&
         log.args.symbol === config.stablecoinSymbol &&
         log.args.currency === config.stablecoinCurrency &&
-        sameAddress(log.args.admin, admin),
+        sameAddress(log.args.admin, admin) &&
+        sameHex(log.args.salt, config.stablecoinSalt),
     );
 
     if (!tokenLog) {
@@ -105,7 +117,12 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: latestBlock,
     });
-    const linkLog = linkLogs[0];
+    const linkLog = linkLogs.find(
+      (log) =>
+        beforeLog(tokenLog, log) &&
+        beforeLog(policyLog, log) &&
+        beforeLog(policyAccountLog, log),
+    );
     if (linkLog) {
       return {
         token: tokenLog.args.token,

--- a/shared/verifier/src/cases/create-stablecoin-with-policy.js
+++ b/shared/verifier/src/cases/create-stablecoin-with-policy.js
@@ -39,6 +39,11 @@ async function verify({ client, config, fromBlock }) {
   const transferPolicyUpdate = parseAbiItem(
     "event TransferPolicyUpdate(address indexed updater, uint64 indexed newPolicyId)",
   );
+  const policyAccountUpdated = parseAbiItem(
+    config.policyType === "whitelist"
+      ? "event WhitelistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool allowed)"
+      : "event BlacklistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool restricted)",
+  );
 
   return waitForEvidence(config, async () => {
     const latestBlock = await client.getBlockNumber();
@@ -72,6 +77,24 @@ async function verify({ client, config, fromBlock }) {
       return null;
     }
 
+    const policyAccountLogs = await client.getLogs({
+      address: config.tip403Registry,
+      event: policyAccountUpdated,
+      args: {
+        policyId: policyLog.args.policyId,
+        updater: admin,
+        account: config.policyAccount,
+      },
+      fromBlock,
+      toBlock: latestBlock,
+    });
+    const policyAccountLog = policyAccountLogs.find((log) =>
+      config.policyType === "whitelist" ? log.args.allowed : log.args.restricted,
+    );
+    if (!policyAccountLog) {
+      return null;
+    }
+
     const linkLogs = await client.getLogs({
       address: tokenLog.args.token,
       event: transferPolicyUpdate,
@@ -87,8 +110,10 @@ async function verify({ client, config, fromBlock }) {
       return {
         token: tokenLog.args.token,
         policyId: policyLog.args.policyId.toString(),
+        policyAccount: config.policyAccount,
         tokenTransactionHash: tokenLog.transactionHash,
         policyTransactionHash: policyLog.transactionHash,
+        policyAccountTransactionHash: policyAccountLog.transactionHash,
         linkTransactionHash: linkLog.transactionHash,
       };
     }

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
@@ -23,6 +23,17 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
+function sameHex(left, right) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
 async function verify({ client, config, fromBlock }) {
   const admin = privateKeyToAccount(config.payerPrivateKey).address;
   const expectedPolicyType = POLICY_TYPES[config.policyType];
@@ -58,7 +69,8 @@ async function verify({ client, config, fromBlock }) {
         log.args.name === config.stablecoinName &&
         log.args.symbol === config.stablecoinSymbol &&
         log.args.currency === config.stablecoinCurrency &&
-        sameAddress(log.args.admin, admin),
+        sameAddress(log.args.admin, admin) &&
+        sameHex(log.args.salt, config.stablecoinSalt),
     );
 
     if (!tokenLog) {
@@ -105,7 +117,12 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: latestBlock,
     });
-    const linkLog = linkLogs[0];
+    const linkLog = linkLogs.find(
+      (log) =>
+        beforeLog(tokenLog, log) &&
+        beforeLog(policyLog, log) &&
+        beforeLog(policyAccountLog, log),
+    );
     if (linkLog) {
       return {
         token: tokenLog.args.token,

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
@@ -39,6 +39,11 @@ async function verify({ client, config, fromBlock }) {
   const transferPolicyUpdate = parseAbiItem(
     "event TransferPolicyUpdate(address indexed updater, uint64 indexed newPolicyId)",
   );
+  const policyAccountUpdated = parseAbiItem(
+    config.policyType === "whitelist"
+      ? "event WhitelistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool allowed)"
+      : "event BlacklistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool restricted)",
+  );
 
   return waitForEvidence(config, async () => {
     const latestBlock = await client.getBlockNumber();
@@ -72,6 +77,24 @@ async function verify({ client, config, fromBlock }) {
       return null;
     }
 
+    const policyAccountLogs = await client.getLogs({
+      address: config.tip403Registry,
+      event: policyAccountUpdated,
+      args: {
+        policyId: policyLog.args.policyId,
+        updater: admin,
+        account: config.policyAccount,
+      },
+      fromBlock,
+      toBlock: latestBlock,
+    });
+    const policyAccountLog = policyAccountLogs.find((log) =>
+      config.policyType === "whitelist" ? log.args.allowed : log.args.restricted,
+    );
+    if (!policyAccountLog) {
+      return null;
+    }
+
     const linkLogs = await client.getLogs({
       address: tokenLog.args.token,
       event: transferPolicyUpdate,
@@ -87,8 +110,10 @@ async function verify({ client, config, fromBlock }) {
       return {
         token: tokenLog.args.token,
         policyId: policyLog.args.policyId.toString(),
+        policyAccount: config.policyAccount,
         tokenTransactionHash: tokenLog.transactionHash,
         policyTransactionHash: policyLog.transactionHash,
+        policyAccountTransactionHash: policyAccountLog.transactionHash,
         linkTransactionHash: linkLog.transactionHash,
       };
     }

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
@@ -23,6 +23,17 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
+function sameHex(left, right) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
 async function verify({ client, config, fromBlock }) {
   const admin = privateKeyToAccount(config.payerPrivateKey).address;
   const expectedPolicyType = POLICY_TYPES[config.policyType];
@@ -58,7 +69,8 @@ async function verify({ client, config, fromBlock }) {
         log.args.name === config.stablecoinName &&
         log.args.symbol === config.stablecoinSymbol &&
         log.args.currency === config.stablecoinCurrency &&
-        sameAddress(log.args.admin, admin),
+        sameAddress(log.args.admin, admin) &&
+        sameHex(log.args.salt, config.stablecoinSalt),
     );
 
     if (!tokenLog) {
@@ -105,7 +117,12 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: latestBlock,
     });
-    const linkLog = linkLogs[0];
+    const linkLog = linkLogs.find(
+      (log) =>
+        beforeLog(tokenLog, log) &&
+        beforeLog(policyLog, log) &&
+        beforeLog(policyAccountLog, log),
+    );
     if (linkLog) {
       return {
         token: tokenLog.args.token,

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
@@ -39,6 +39,11 @@ async function verify({ client, config, fromBlock }) {
   const transferPolicyUpdate = parseAbiItem(
     "event TransferPolicyUpdate(address indexed updater, uint64 indexed newPolicyId)",
   );
+  const policyAccountUpdated = parseAbiItem(
+    config.policyType === "whitelist"
+      ? "event WhitelistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool allowed)"
+      : "event BlacklistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool restricted)",
+  );
 
   return waitForEvidence(config, async () => {
     const latestBlock = await client.getBlockNumber();
@@ -72,6 +77,24 @@ async function verify({ client, config, fromBlock }) {
       return null;
     }
 
+    const policyAccountLogs = await client.getLogs({
+      address: config.tip403Registry,
+      event: policyAccountUpdated,
+      args: {
+        policyId: policyLog.args.policyId,
+        updater: admin,
+        account: config.policyAccount,
+      },
+      fromBlock,
+      toBlock: latestBlock,
+    });
+    const policyAccountLog = policyAccountLogs.find((log) =>
+      config.policyType === "whitelist" ? log.args.allowed : log.args.restricted,
+    );
+    if (!policyAccountLog) {
+      return null;
+    }
+
     const linkLogs = await client.getLogs({
       address: tokenLog.args.token,
       event: transferPolicyUpdate,
@@ -87,8 +110,10 @@ async function verify({ client, config, fromBlock }) {
       return {
         token: tokenLog.args.token,
         policyId: policyLog.args.policyId.toString(),
+        policyAccount: config.policyAccount,
         tokenTransactionHash: tokenLog.transactionHash,
         policyTransactionHash: policyLog.transactionHash,
+        policyAccountTransactionHash: policyAccountLog.transactionHash,
         linkTransactionHash: linkLog.transactionHash,
       };
     }

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
@@ -23,6 +23,17 @@ function runtimeEnv(config) {
   };
 }
 
+function beforeLog(left, right) {
+  return (
+    left.blockNumber < right.blockNumber ||
+    (left.blockNumber === right.blockNumber && left.logIndex < right.logIndex)
+  );
+}
+
+function sameHex(left, right) {
+  return left?.toLowerCase() === right?.toLowerCase();
+}
+
 async function verify({ client, config, fromBlock }) {
   const admin = privateKeyToAccount(config.payerPrivateKey).address;
   const expectedPolicyType = POLICY_TYPES[config.policyType];
@@ -58,7 +69,8 @@ async function verify({ client, config, fromBlock }) {
         log.args.name === config.stablecoinName &&
         log.args.symbol === config.stablecoinSymbol &&
         log.args.currency === config.stablecoinCurrency &&
-        sameAddress(log.args.admin, admin),
+        sameAddress(log.args.admin, admin) &&
+        sameHex(log.args.salt, config.stablecoinSalt),
     );
 
     if (!tokenLog) {
@@ -105,7 +117,12 @@ async function verify({ client, config, fromBlock }) {
       fromBlock,
       toBlock: latestBlock,
     });
-    const linkLog = linkLogs[0];
+    const linkLog = linkLogs.find(
+      (log) =>
+        beforeLog(tokenLog, log) &&
+        beforeLog(policyLog, log) &&
+        beforeLog(policyAccountLog, log),
+    );
     if (linkLog) {
       return {
         token: tokenLog.args.token,

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/cases/create-stablecoin-with-policy.js
@@ -39,6 +39,11 @@ async function verify({ client, config, fromBlock }) {
   const transferPolicyUpdate = parseAbiItem(
     "event TransferPolicyUpdate(address indexed updater, uint64 indexed newPolicyId)",
   );
+  const policyAccountUpdated = parseAbiItem(
+    config.policyType === "whitelist"
+      ? "event WhitelistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool allowed)"
+      : "event BlacklistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool restricted)",
+  );
 
   return waitForEvidence(config, async () => {
     const latestBlock = await client.getBlockNumber();
@@ -72,6 +77,24 @@ async function verify({ client, config, fromBlock }) {
       return null;
     }
 
+    const policyAccountLogs = await client.getLogs({
+      address: config.tip403Registry,
+      event: policyAccountUpdated,
+      args: {
+        policyId: policyLog.args.policyId,
+        updater: admin,
+        account: config.policyAccount,
+      },
+      fromBlock,
+      toBlock: latestBlock,
+    });
+    const policyAccountLog = policyAccountLogs.find((log) =>
+      config.policyType === "whitelist" ? log.args.allowed : log.args.restricted,
+    );
+    if (!policyAccountLog) {
+      return null;
+    }
+
     const linkLogs = await client.getLogs({
       address: tokenLog.args.token,
       event: transferPolicyUpdate,
@@ -87,8 +110,10 @@ async function verify({ client, config, fromBlock }) {
       return {
         token: tokenLog.args.token,
         policyId: policyLog.args.policyId.toString(),
+        policyAccount: config.policyAccount,
         tokenTransactionHash: tokenLog.transactionHash,
         policyTransactionHash: policyLog.transactionHash,
+        policyAccountTransactionHash: policyAccountLog.transactionHash,
         linkTransactionHash: linkLog.transactionHash,
       };
     }

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -47,15 +47,15 @@ digest = "sha256:b9aa1925e5f77007574cff60c52aaa2b903097870dda5d81c8efce94b4680d8
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:550e38d1791283e3375ee6f60327533c7a1df10b2b3f2201ea8d514a83f1e747"
+digest = "sha256:e4c339b6723dc38e1c05cff0119b26e7c7c05db64a75574fa3c1cd628e9dc511"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:3f7804ee13da4a50b48425669dcec4ab2ee3fb86ed4dee4941f359ab1d4f864a"
+digest = "sha256:1eadf6d7ae3cdfd38f4f47bcbb23a98f99ea03b7832ca60a52f2da7177d56db6"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:10a0ed06cc9574bc70ad3a3124290208cce0bf010eedfd5aadd4d8123dc6c11f"
+digest = "sha256:a03d26d9f6f06a75cb49005deb6c1a5cd86f7304c4a8af02d45ffa2349174c5f"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"


### PR DESCRIPTION
## Summary

Tightens the create-stablecoin-with-policy verifier so it validates that the created TIP-403 policy includes the expected account.

## Changes

- Require the policy account update event for the created policy ID.
- Check `WhitelistUpdated.allowed` or `BlacklistUpdated.restricted` according to `TEMPO_POLICY_TYPE`.
- Include policy account evidence in verifier details.
- Refresh generated task verifier copies and dataset digests for the policy task variants.

## Validation

- `npm run check`
- `npm run check:generated`
- `npm run bench:local:oracle -- --task-filter tempo/create-stablecoin-with-policy-base --n-tasks 1`