### PR TITLE
Use built-in turn count reward

### DIFF
--- a/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/shared/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/shared/rewardkit/quality/check.py
+++ b/shared/rewardkit/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -10,37 +10,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:e4d8371af1159afd4003f301864b2bd75d14f3bfa80efc2da712d6529cc9a3d8"
+digest = "sha256:9736e2bfe68e54e5c6101e5b64a7e16ffd1ddb07617bb721ef5453917cc6cf99"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:103aa2ac815a821b8270ef92d27244725fb3024950a888ae0682069a01e3412d"
+digest = "sha256:33bb84841a02047e682eec7744db946c1fb383472297dfc3cb0398f7bf96ed48"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:f68745b66c8c8824e3163452f1f7efb6d8ad1eb35c42c087b44ff6df49280f41"
+digest = "sha256:68f19d232ca6b0b4aa8578af88fe9024a45219e6887e5c80d77cb6a71bb5d09c"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:7faf1ed06f59fd03ea7ad71ee0a104f2e7503034f47ccca20878a8f21c33e457"
+digest = "sha256:c825136baf15e53621e6fad013f5c98655314bd77950712d5e3ba6e5677d354c"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:a230ce6f9efdfdc9b896a0e3761a279202b9ceb5e622f53e369f16e6588bd8c7"
+digest = "sha256:7cbb10326973abd7c4178dbf07fbb686fef658f8b5ca1722042d13f45afdf734"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:04ac5ee1598fe615bd22d7bec65a0d13a0f3e6707f4ae9a0937158cd743f8779"
+digest = "sha256:4f52d1aa2143d6d0d844223f031bc0cdd5d5eb4f9e0a3571e412bfdf076fff7d"
 
 [[tasks]]
 name = "tempo/mpp-client-access-keys"
-digest = "sha256:722ec8a45df7de6e91349be8e6ef5e54867b0d7953e1887e688e3d64fa2c8253"
+digest = "sha256:da08d142832d28a374b7be5b7c891ac715e95e339e73f0200733fea2c057af41"
 
 [[tasks]]
 name = "tempo/mpp-server-custom-payment-method"
-digest = "sha256:2ae7a6dd90642b384baff202fe0bfca200a44db5a95a0aa8e27840ad4ad98140"
+digest = "sha256:166faeb7621d600b32fecc22a50c331c8c886abaa1fef0cb43df54d436c58370"
 
 [[tasks]]
 name = "tempo/mpp-server-mcp-pathusd"
-digest = "sha256:929e7d0cd547f0556be613615f0cff5e5feef3256b89bc5b6299064f1dc82681"
+digest = "sha256:b1e86ff1c02fbbaf1391ac74a457af16da21377eae8b14058b6478925e29ac7d"
 

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/__init__.py
@@ -2,7 +2,6 @@
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 from .criteria import (
     agent_token_efficiency,
-    agent_turn_efficiency,
     tempo_mcp_tool_used,
     tempo_onchain_verifier,
     tempo_source_patterns,
@@ -12,7 +11,6 @@ from .criteria import (
 
 __all__ = [
     "agent_token_efficiency",
-    "agent_turn_efficiency",
     "tempo_mcp_tool_used",
     "tempo_onchain_verifier",
     "tempo_source_patterns",

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/criteria.py
@@ -272,36 +272,6 @@ def tempo_mcp_tool_used(_workspace: Path, server_name: str = "tempo") -> bool:
 
 
 @criterion(shared=True)
-def agent_turn_efficiency(
-    _workspace: Path,
-    cutoffs_env: str = "TEMPO_BENCH_TURNS_SCORE_CUTOFFS",
-    default_cutoffs: str = "20=1.0,40=0.8,60=0.5,80=0.2,*=0.0",
-) -> float:
-    raw_cutoffs = os.environ.get(
-        cutoffs_env,
-        default_cutoffs,
-    )
-    path = _trajectory_path()
-    if path is None:
-        _merge_efficiency(
-            "turns",
-            {"score": 0.0, "turn_count": None, "cutoffs": raw_cutoffs},
-        )
-        return 0.0
-
-    trajectory = json.loads(path.read_text(encoding="utf-8"))
-    turn_count = sum(
-        1 for step in trajectory.get("steps", []) if step.get("source") == "agent"
-    )
-    score = _score_by_cutoff(turn_count, raw_cutoffs)
-    _merge_efficiency(
-        "turns",
-        {"score": score, "turn_count": turn_count, "cutoffs": raw_cutoffs},
-    )
-    return score
-
-
-@criterion(shared=True)
 def agent_token_efficiency(
     _workspace: Path,
     cutoffs_env: str = "TEMPO_BENCH_TOKENS_SCORE_CUTOFFS",

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/quality/check.py
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/quality/check.py
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/quality/check.py
@@ -1,10 +1,23 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/quality/check.py
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/quality/check.py
@@ -1,9 +1,22 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_mcp_tool_used("tempo")

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -11,73 +11,73 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-base"
-digest = "sha256:aeebb175c621fba375f88ec7ec3be454a0f989a7f20d7ae0d9a9eade41793b8d"
+digest = "sha256:e7b41a899a691a83e2a3f83e158f39b31ed0b0bdb2e58a8b16d44b66b3e0a5a1"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:6a6922df71c0335c1755f1307061518b95a874de29656aa0405407d4e3cd9d8f"
+digest = "sha256:54d3d599669ec43fe32609c55ff63480bbe5a40aa55385f9c9427f4700ac6e9a"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:a260d56f0bed3acc32f54b24597b79059c27befc3541cfba9d390f8dfed627e6"
+digest = "sha256:ef9046244574325ed5dfdec80c3a6024154b041a542211d5d2e6da3ec484a062"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-base"
-digest = "sha256:d5ac1914ff70aaa6f9ec1675917443de18cb5d270cd654e6692fe287058562a4"
+digest = "sha256:b1ef80fd0289033eacefbd9b8f0e9d31800fc8aec238b4775f9803ca339792fc"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:3257dc5810df33a146575d1aeae00266a67189da1e437efd5cb7a15bec75d86e"
+digest = "sha256:77b27e28927594496c1b35d1aaa8a0399d8fbf10bd634ea60f486569a3a008ab"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:8e77cd50699fcdc4edf5f6e6e645e2913ad23f86bac1e6a7e52b6825954de0ca"
+digest = "sha256:275e65eca5e474336246b12bfc3542570dbd5099aed5bf0e7fd2f65aa3266ef6"
 
 [[tasks]]
 name = "tempo/set-fee-token-base"
-digest = "sha256:54315fd2423a2a9dd69d65980ffe056b2de19fb6dc6f93f8ff54293ef18f161c"
+digest = "sha256:52e61c0f45eb68cb4e1059b5db9b3cfdc4be52baa0dd8e3017aeb7635e751a2f"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:3e8d0b8e9dbe4b77b34dace7ac705c7f92a74380a15d1b0ced0cbc8a4aa4dd57"
+digest = "sha256:283ba5e5de21aa3722965ee99719aceefd02f0565d08214d8f5acd1d82d53cdb"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:b9aa1925e5f77007574cff60c52aaa2b903097870dda5d81c8efce94b4680d88"
+digest = "sha256:f4bd89f84625cc0295fb454a049c5c6206a95142bc871ca918e58423b949f505"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:e4c339b6723dc38e1c05cff0119b26e7c7c05db64a75574fa3c1cd628e9dc511"
+digest = "sha256:a994d720d2c1a79cb9925ae302e54eb30e741c9c9bf48bee77f47db46986aaef"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:1eadf6d7ae3cdfd38f4f47bcbb23a98f99ea03b7832ca60a52f2da7177d56db6"
+digest = "sha256:d4ea5b390ff3306236b8f71db53103cb796be5e56b557defc58c07593f12379b"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:a03d26d9f6f06a75cb49005deb6c1a5cd86f7304c4a8af02d45ffa2349174c5f"
+digest = "sha256:ef5dccd6387be3f7e6668dafa3828d23393bd15fdead639563d77adfc78d0f34"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:23a1855449ca6b2e8e87ed5ab2d47f78906db02acca87f17f6d8b263db8546a8"
+digest = "sha256:0084795d39f3518c63bdfe4bc1e07f6ecb8cf464711058865dcb42491636a8cc"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:3218c04c7d72d5c6f3e903d19057954efafc31a73d8315da7946b74ed4a0f961"
+digest = "sha256:b235e13daf84731a32360cb6003e5088688ffca224a75ecc19257acaa3a49d7b"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:8b3daf5c9a20a85ea672417b29f2f53614ebbc8b48a4b08208c15ecf3c2debe4"
+digest = "sha256:0853a67c8dd3a9488d2d85f2ef08d21c454f9edfbf7405b9e633409765132871"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:40515963a0496b1339568a940c1c87274a2d78a935c94c803ce523a8684af989"
+digest = "sha256:f34ddca2798eb983df579e5f08191957231ceda6650cff72ba021de4acac44fe"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:e505b154661536cd68533c4b684cbc07a564f96325c616367cc68922ff10f94f"
+digest = "sha256:1ef531ef5df0e2c9bea07f969f33b16d5307889876e303c0a6af0411469760d2"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:c73fc0b7889098022b0ebea9e60d2dd2e32a5bc6382b64cd731d372ac029175a"
+digest = "sha256:1b2885c1376b04db09a18fc59772e555e54a593042331b271e6b1396dd1d4223"
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/quality/check.py
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/quality/check.py
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/quality/check.py
@@ -1,10 +1,23 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/quality/check.py
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/quality/check.py
@@ -1,9 +1,22 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_mcp_tool_used("tempo")

--- a/tasks/tempo/set-fee-token-base/tests/quality/check.py
+++ b/tasks/tempo/set-fee-token-base/tests/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/tempo/set-fee-token-docs/tests/quality/check.py
+++ b/tasks/tempo/set-fee-token-docs/tests/quality/check.py
@@ -1,10 +1,23 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",

--- a/tasks/tempo/set-fee-token-mcp/tests/quality/check.py
+++ b/tasks/tempo/set-fee-token-mcp/tests/quality/check.py
@@ -1,9 +1,22 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_mcp_tool_used("tempo")

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/quality/check.py
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/quality/check.py
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/quality/check.py
@@ -1,10 +1,23 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/quality/check.py
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/quality/check.py
@@ -1,9 +1,22 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_mcp_tool_used("tempo")

--- a/tasks/tempo/transfer-with-memo-base/tests/quality/check.py
+++ b/tasks/tempo/transfer-with-memo-base/tests/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/tempo/transfer-with-memo-docs/tests/quality/check.py
+++ b/tasks/tempo/transfer-with-memo-docs/tests/quality/check.py
@@ -1,10 +1,23 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/quality/check.py
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/quality/check.py
@@ -1,7 +1,20 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/quality/check.py
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/quality/check.py
@@ -1,10 +1,23 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_trajectory_matches(
     r"tempo-docs:3000/developers|/developers/llms\.txt|/developers/llms-full\.txt|/developers/docs/.*\.md|TEMPO_DOCS_URL",

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
@@ -1,9 +1,22 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_mcp_tool_used("tempo")

--- a/tasks/tempo/transfer-with-memo-mcp/tests/quality/check.py
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/quality/check.py
@@ -1,9 +1,22 @@
 # SYNCED FROM shared/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 import rewardkit as rk
-import tempo_bench_rewardkit  # noqa: F401
+from tempo_bench_rewardkit.common.checks import (
+    TokenEfficiencyConfig,
+    register_token_efficiency_check,
+)
 
-rk.agent_turn_efficiency()
-rk.agent_token_efficiency()
+rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
+register_token_efficiency_check(
+    TokenEfficiencyConfig(
+        thresholds=[
+            [250000, 1.0],
+            [500000, 0.8],
+            [1000000, 0.5],
+            [1500000, 0.2],
+            ["*", 0.0],
+        ],
+    )
+)
 
 rk.tempo_mcp_tool_used("tempo")


### PR DESCRIPTION
## Summary

- Replace the Tempo shared quality check's local `agent_turn_efficiency` wrapper with RewardKit's built-in `trajectory_turn_count`.
- Keep Tempo pointed at Harbor's agent trace path, `/logs/agent/trajectory.json`, so it counts the saved Tempo agent trajectory.
- Use the same shared helper style as MPP for token efficiency: `register_token_efficiency_check(TokenEfficiencyConfig(thresholds=[...]))`.
- Sync generated `tasks/tempo` quality checks, task-local rewardkit package copies, refreshed Tempo dataset digests, and the MPP dataset digests affected by the shared harness update.

## Notes

The branch is rebased on the latest `main`. The duplicate local turn-count criterion/export is removed from the shared rewardkit package; task checks use the built-in turn criterion directly.

## Validation

- `npm run check`
- `npm run check:generated`
- `npm run check:dataset -- --tasks tasks/mpp`