### PR TITLE
chore: add fast local oracle dev loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ npm run clean               # Remove job/cache output
 
 ```bash
 npm run bench:local:oracle       # Local Docker oracle validation
+npm run bench:local:oracle:dev   # Fast local Docker oracle iteration
+npm run bench:local:one          # Fast single-concurrency local oracle iteration
 npm run bench:local:agent:dev    # Local Docker agent smoke
 npm run bench:local:agent        # Full local Docker agent run
 npm run bench:daytona:oracle     # Daytona oracle validation
@@ -47,8 +49,12 @@ npm run bench:daytona:agent      # Full Daytona agent run
 Single task:
 
 ```bash
+npm run bench:local:one -- --task-filter tempo/transfer-with-memo-base
 npm run bench:daytona:agent:dev -- --task-filter transfer-with-memo-mcp --concurrency 1 --agent-concurrency 1
 ```
+
+Use `npm run sync` after changing shared/generated task assets. Use
+`npm run bench:local:oracle` for clean local oracle validation before PRs.
 
 MPP MVP:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Validate the Tempo oracle solutions locally:
 npm run bench:local:oracle
 ```
 
+Fast oracle loop for one task while editing:
+
+```bash
+npm run bench:local:one -- --task-filter tempo/transfer-with-memo-base
+```
+
+Fast oracle loop for multiple filtered tasks:
+
+```bash
+npm run bench:local:oracle:dev -- --task-filter "*-base"
+```
+
 Run a local agent smoke test:
 
 ```bash
@@ -87,12 +99,35 @@ npm run clean
 | Command | Runtime | Description |
 | ------- | ------- | ----------- |
 | `npm run bench:local:oracle` | Docker | Validate oracle solutions locally |
+| `npm run bench:local:oracle:dev` | Docker | Fast local oracle run; skips sync and reuses environment builds |
+| `npm run bench:local:one` | Docker | Fast one-concurrency local oracle run; pass `--task-filter` |
 | `npm run bench:local:agent:dev` | Docker | Local agent smoke run |
 | `npm run bench:local:agent` | Docker | Full local agent run |
 | `npm run bench:daytona:oracle` | Daytona | Validate oracle solutions remotely |
 | `npm run bench:daytona:agent:dev` | Daytona | Remote agent smoke run |
 | `npm run bench:daytona:agent` | Daytona | Full remote agent run |
 | `npm run bench:model` | Docker | Ad hoc local model run |
+
+## Dev Loop
+
+Use the dev oracle commands while iterating on one task:
+
+```bash
+npm run bench:local:one -- --task-filter tempo/transfer-with-memo-base
+```
+
+These commands use `local-oracle-dev`, skip generated asset sync, and avoid forced Docker rebuilds. Run `npm run sync` after changing shared/generated task assets. Run `npm run bench:local:oracle` before opening a PR for clean validation.
+
+Useful runner flags:
+
+```bash
+--no-sync               # skip sync-shared and harbor sync
+--no-force-build        # ask Harbor to reuse Docker builds
+--no-delete             # keep environments for debugging
+--disable-verification  # skip verifier execution
+--install-only          # run setup/install only
+--debug                 # enable Harbor debug logs
+```
 
 ## Environment
 

--- a/config/job.local.oracle.dev.yaml
+++ b/config/job.local.oracle.dev.yaml
@@ -1,0 +1,25 @@
+# Local Oracle dev job: fast single-task oracle iteration in local Docker.
+# Skips forced environment rebuilds; use bench:local:oracle for clean validation.
+job_name: tempo-bench-local-dev
+jobs_dir: jobs
+n_attempts: 1
+timeout_multiplier: 1.0
+n_concurrent_trials: 1
+quiet: false
+environment:
+  type: docker
+  force_build: false
+  delete: true
+verifier:
+  env:
+    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+agents:
+  - name: oracle
+datasets:
+  - path: tasks/tempo
+    task_names:
+      - "*-base"
+      - "*-docs"
+      - "*-mcp"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "bench": "node scripts/run-benchmark.ts local-agent",
     "bench:model": "node scripts/run-benchmark.ts model",
     "bench:local:oracle": "node scripts/run-benchmark.ts local-oracle",
+    "bench:local:oracle:dev": "node scripts/run-benchmark.ts local-oracle-dev --no-sync",
+    "bench:local:one": "node scripts/run-benchmark.ts local-oracle-dev --no-sync --concurrency 1",
     "bench:local:agent": "node scripts/run-benchmark.ts local-agent",
     "bench:local:agent:dev": "node scripts/run-benchmark.ts local-agent-dev",
     "bench:daytona:oracle": "node scripts/run-benchmark.ts daytona-oracle",

--- a/scripts/run-benchmark.ts
+++ b/scripts/run-benchmark.ts
@@ -36,6 +36,11 @@ type Options = {
   taskFilter?: string;
   nTasks?: string;
   tasks?: string;
+  noForceBuild?: boolean;
+  noDelete?: boolean;
+  disableVerification?: boolean;
+  installOnly?: boolean;
+  debug?: boolean;
   sync: boolean;
 };
 
@@ -43,6 +48,10 @@ const variants: Record<string, Variant> = {
   "local-oracle": {
     config: "config/job.local.oracle.yaml",
     prefix: "tempo-bench-oracle-local",
+  },
+  "local-oracle-dev": {
+    config: "config/job.local.oracle.dev.yaml",
+    prefix: "tempo-bench-oracle-dev-local",
   },
   "local-agent": {
     config: "config/job.local.agent.yaml",
@@ -87,6 +96,7 @@ Direct: node scripts/run-benchmark.ts <variant> [options]
 
 Variants:
   local-oracle       Oracle validation on local Docker
+  local-oracle-dev   Fast oracle iteration on local Docker
   local-agent        Full Claude Code matrix on local Docker
   local-agent-dev    One-attempt Claude Code smoke run on local Docker
   model              One local harness/model run over tasks
@@ -108,9 +118,14 @@ Options:
   --max-retries N         Retry transient trial/setup failures (default: 2 for Daytona runs)
   --agent NAME            Agent for the model variant (default: claude-code)
   --model NAME            Model for the model variant (default: haiku)
-  --task-filter GLOB      Include matching task names for model and Daytona config variants
+  --task-filter GLOB      Include matching task names for model and config variants
   --n-tasks N             Limit task count for the model variant
   --tasks PATH            Task dataset path for dataset/model variants (default: tasks/tempo)
+  --no-force-build        Ask Harbor to reuse Docker environment builds
+  --no-delete             Keep Harbor environments after the run for debugging
+  --disable-verification  Skip verifier execution
+  --install-only          Run agent setup/install only and skip verification
+  --debug                 Enable Harbor debug logging
   --no-sync               Skip task asset and dataset sync before running Harbor
 `);
 }
@@ -177,6 +192,16 @@ function parseArgs(argv: string[]): { variant?: string; options: Options } {
     } else if (arg === "--tasks") {
       options.tasks = readOptionValue(rest, i, arg);
       i += 1;
+    } else if (arg === "--no-force-build") {
+      options.noForceBuild = true;
+    } else if (arg === "--no-delete") {
+      options.noDelete = true;
+    } else if (arg === "--disable-verification") {
+      options.disableVerification = true;
+    } else if (arg === "--install-only") {
+      options.installOnly = true;
+    } else if (arg === "--debug") {
+      options.debug = true;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -425,6 +450,11 @@ try {
   if (options.agentConcurrency) {
     args.push("--n-concurrent-agents", options.agentConcurrency);
   }
+  if (options.noForceBuild) args.push("--no-force-build");
+  if (options.noDelete) args.push("--no-delete");
+  if (options.disableVerification) args.push("--disable-verification");
+  if (options.installOnly) args.push("--install-only");
+  if (options.debug) args.push("--debug");
   const maxRetries = options.maxRetries ?? (variant.needsDaytonaAuth ? "2" : undefined);
   if (maxRetries) args.push("--max-retries", maxRetries);
   process.env.TEMPO_DOCS_BUNDLE_PATH = variant.needsDaytonaAuth ? "" : docsBundle;


### PR DESCRIPTION
## Motivation

Local oracle iteration currently pays sync and forced Docker rebuild overhead that is unnecessary while editing one task.

## Summary

- Add a local oracle dev config that reuses Docker environment builds
- Add npm shortcuts for fast single-task and filtered oracle runs
- Pass through useful Harbor debug and environment lifecycle flags
- Document the fast dev-loop commands

## Key design considerations

- Keep the existing full local oracle command unchanged for clean validation
- Default the shortcut commands to skip generated asset sync, with docs pointing to `npm run sync` when shared assets change
