### PR TITLE
feat: add production benchmark flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Harbor outputs
 jobs/
+runs/
 
 # OS/editor noise
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -44,6 +44,92 @@ Run the MPP MVP task:
 npm run bench:model -- --tasks tasks/mpp --task-filter tempo/mpp-server-charge-pathusd
 ```
 
+## Running Development Benchmarks
+
+Development flows are for iteration and smoke testing. They keep attempts low and
+are intended to be filtered to one or a few tasks while changing task assets,
+verifiers, or agent setup.
+
+Local smoke run:
+
+```bash
+npm run bench:local:agent:dev -- --task-filter transfer-with-memo-mcp
+```
+
+Daytona smoke run:
+
+```bash
+npm run bench:daytona:agent:dev -- --task-filter transfer-with-memo-mcp --concurrency 1 --agent-concurrency 1
+```
+
+Useful development options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--task-filter GLOB` | Run only matching task names, e.g. `transfer-with-memo-mcp` |
+| `--concurrency N` | Override total concurrent trials |
+| `--agent-concurrency N` | Override concurrent agent executions |
+| `--max-retries N` | Retry transient trial/setup failures |
+| `--no-sync` | Skip generated asset and dataset sync before running |
+
+## Running Production Benchmarks
+
+Production runs execute the full Tempo task matrix on Daytona across the configured
+agent/model list. Raw Harbor output is written under `runs/<run_id>/harbor-job`, with
+run metadata in `runs/<run_id>/metadata.json`.
+
+Configure the model matrix in `config/models.production.yaml`:
+
+```yaml
+models:
+  - claude-haiku-4-5
+  - agent: codex
+    model_name: gpt-5
+```
+
+Run the production matrix:
+
+```bash
+npm run bench:production
+```
+
+Run a limited production check:
+
+```bash
+npm run bench:production -- --task-filter transfer-with-memo-mcp --concurrency 1 --agent-concurrency 1
+```
+
+View raw Harbor results:
+
+```bash
+uv run harbor view runs/<run_id>/harbor-job
+```
+
+Export CSV and JSON results for notebooks or external tools:
+
+```bash
+npm run results:export -- --job runs/<run_id>/harbor-job --run-id <run_id>
+```
+
+Production options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--models-config PATH` | Use a different production model matrix config |
+| `--task-filter GLOB` | Run a limited task subset for production validation |
+| `--concurrency N` | Override production `n_concurrent_trials` |
+| `--agent-concurrency N` | Override per-model `n_concurrent` from the model config |
+| `--max-retries N` | Override Daytona retry count, default `2` |
+| `--job-name NAME` | Use a custom production run id under `runs/` |
+
+Export outputs are written to `runs/<run_id>/exports/` by default:
+
+| File | Description |
+| ---- | ----------- |
+| `trials.csv` | One row per Harbor trial result |
+| `summary.csv` | Aggregates by model, agent, task, task family, and profile |
+| `summary.json` | Structured aggregate data and export metadata |
+
 ## Datasets
 
 | Dataset | Path | Description |
@@ -92,6 +178,7 @@ npm run clean
 | `npm run bench:daytona:oracle` | Daytona | Validate oracle solutions remotely |
 | `npm run bench:daytona:agent:dev` | Daytona | Remote agent smoke run |
 | `npm run bench:daytona:agent` | Daytona | Full remote agent run |
+| `npm run bench:production` | Daytona | Production multi-model matrix run |
 | `npm run bench:model` | Docker | Ad hoc local model run |
 
 ## Environment
@@ -99,6 +186,9 @@ npm run clean
 | Variable | Used for |
 | -------- | -------- |
 | `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` | Claude Code and RewardKit LLM judging |
+| `OPENAI_API_KEY` | Codex production agent auth |
+| `CODEX_AUTH_JSON_PATH` or `CODEX_FORCE_AUTH_JSON` | Optional Codex auth.json auth instead of `OPENAI_API_KEY` |
+| `OPENAI_BASE_URL` | Optional Codex OpenAI-compatible endpoint override |
 | `DAYTONA_API_KEY` | Daytona runs |
 | `DAYTONA_TARGET` | Optional Daytona target |
 

--- a/config/job.daytona.production.yaml.njk
+++ b/config/job.daytona.production.yaml.njk
@@ -1,0 +1,45 @@
+# Generated production Daytona job. Edit config/models.production.yaml for the model matrix.
+job_name: harbor-job
+jobs_dir: {{ jobsDir | dump }}
+n_attempts: 3
+timeout_multiplier: 1.0
+n_concurrent_trials: {{ nConcurrentTrials }}
+quiet: false
+environment:
+  type: daytona
+  force_build: false
+  delete: true
+  kwargs:
+    dind_image: docker:28.3.3-dind
+    connection_pool_maxsize: null
+verifier:
+  env:
+    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+agents:
+{% for model in models %}
+  - name: {{ model.agent | dump }}
+    model_name: {{ model.modelName | dump }}
+{% if model.nConcurrent %}
+    n_concurrent: {{ model.nConcurrent }}
+{% endif %}
+{% if model.concurrencyGroup %}
+    concurrency_group: {{ model.concurrencyGroup | dump }}
+{% endif %}
+    env:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+{% if model.agent == "codex" %}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+      CODEX_AUTH_JSON_PATH: ${CODEX_AUTH_JSON_PATH:-}
+      CODEX_FORCE_AUTH_JSON: ${CODEX_FORCE_AUTH_JSON:-}
+{% endif %}
+{% endfor %}
+datasets:
+  - path: tasks/tempo
+    task_names:
+      - "*-base"
+      - "*-docs"
+      - "*-mcp"

--- a/config/models.production.yaml
+++ b/config/models.production.yaml
@@ -1,0 +1,19 @@
+# Production model matrix for `npm run bench:production`.
+#
+# Supported forms:
+#   - claude-haiku-4-5
+#     Shorthand for:
+#       agent: claude-code
+#       model_name: claude-haiku-4-5
+#
+#   - agent: codex
+#     model_name: gpt-5
+#     Explicit agent/model entry. Optional fields:
+#       n_concurrent: 8
+#       concurrency_group: openai
+#
+# `--agent-concurrency N` overrides per-entry n_concurrent for the run.
+models:
+  - claude-haiku-4-5
+  - agent: codex
+    model_name: gpt-5

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,53 @@
     "": {
       "name": "tempo-bench",
       "version": "0.1.0",
+      "dependencies": {
+        "commander": "^15.0.0",
+        "csv-stringify": "^6.8.1",
+        "fast-glob": "^3.3.3",
+        "nunjucks": "^3.2.4",
+        "yaml": "^2.9.0"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
+        "@types/nunjucks": "^3.2.6",
+        "csv-parse": "^7.0.1",
         "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@types/node": {
@@ -20,6 +64,271 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.1.tgz",
+      "integrity": "sha512-+2z7Ar0APQ7Uu6fX4cn+pitRmxjZ1WPBcGmZFKmA74FCyi7Et/XZx8cjNQ5CjbZ4HCOxXCOpRBYvYH08Qa003A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
+      "integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nunjucks/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/typescript": {
@@ -42,6 +351,21 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,18 +16,30 @@
     "bench:daytona:oracle": "node scripts/run-benchmark.ts daytona-oracle",
     "bench:daytona:agent": "node scripts/run-benchmark.ts daytona-agent",
     "bench:daytona:agent:dev": "node scripts/run-benchmark.ts daytona-agent-dev",
+    "bench:production": "node scripts/run-benchmark.ts production-daytona",
+    "results:export": "node scripts/export-results.ts",
     "harbor:view": "uv run harbor view jobs",
-    "check": "npm run check:scripts && npm run check:format && npm run check:lint",
+    "check": "npm run check:scripts && npm run test:results && npm run check:format && npm run check:lint",
     "check:dataset": "node scripts/run-benchmark.ts check-dataset",
     "check:generated": "node scripts/run-benchmark.ts check-generated",
     "check:format": "uv run ruff format --check .",
     "check:lint": "uv run ruff check .",
     "check:scripts": "tsc --noEmit",
+    "test:results": "node --test scripts/export-results.test.ts",
     "clean": "node scripts/run-benchmark.ts clean",
     "clean:jobs": "node scripts/run-benchmark.ts clean-jobs"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "@types/nunjucks": "^3.2.6",
+    "csv-parse": "^7.0.1",
     "typescript": "^5.9.0"
+  },
+  "dependencies": {
+    "commander": "^15.0.0",
+    "csv-stringify": "^6.8.1",
+    "fast-glob": "^3.3.3",
+    "nunjucks": "^3.2.4",
+    "yaml": "^2.9.0"
   }
 }

--- a/scripts/export-results.test.ts
+++ b/scripts/export-results.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parse } from "csv-parse/sync";
+
+import { exportResults, parseTaskName, summarizeRows } from "./export-results.ts";
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "tempo-bench-export-"));
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function trial(overrides: Record<string, unknown>) {
+  return {
+    task_name: "transfer-with-memo-fee-payer-mcp",
+    trial_name: "trial-1",
+    task_checksum: "sha256:task",
+    agent_info: {
+      name: "claude-code",
+      model_info: {
+        name: "claude-haiku-4-5",
+      },
+    },
+    verifier_result: {
+      rewards: {
+        reward: 1,
+        correctness: 1,
+      },
+    },
+    agent_result: {
+      n_input_tokens: 10,
+      n_cache_tokens: 2,
+      n_output_tokens: 5,
+      cost_usd: 0.01,
+    },
+    started_at: "2026-07-07T10:00:00.000Z",
+    finished_at: "2026-07-07T10:01:00.000Z",
+    agent_execution: {
+      started_at: "2026-07-07T10:00:10.000Z",
+      finished_at: "2026-07-07T10:00:40.000Z",
+    },
+    ...overrides,
+  };
+}
+
+test("parseTaskName handles multi-hyphen task families", () => {
+  assert.deepEqual(parseTaskName("transfer-with-memo-fee-payer-mcp"), {
+    taskFamily: "transfer-with-memo-fee-payer",
+    profile: "mcp",
+  });
+  assert.deepEqual(parseTaskName("custom-task"), {
+    taskFamily: "custom-task",
+    profile: "unknown",
+  });
+});
+
+test("exportResults writes trial and summary CSV plus JSON", () => {
+  const root = tempDir();
+  const jobDir = path.join(root, "run-1", "harbor-job");
+  writeJson(path.join(root, "run-1", "metadata.json"), {
+    run_id: "run-1",
+    git_sha: "abc123",
+    docs_lock: { sha: "docs123" },
+  });
+  writeJson(path.join(jobDir, "trial-a", "result.json"), trial({ trial_name: "trial-a" }));
+  writeJson(
+    path.join(jobDir, "trial-b", "result.json"),
+    trial({
+      trial_name: "trial-b",
+      verifier_result: { rewards: { reward: 0, correctness: 0 } },
+      agent_result: {},
+    }),
+  );
+  writeJson(
+    path.join(jobDir, "trial-c", "result.json"),
+    trial({
+      trial_name: "trial-c",
+      task_name: "set-fee-token-base",
+      agent_info: {
+        name: "claude-code",
+        model_info: { name: "other-model" },
+      },
+      verifier_result: undefined,
+      exception_info: {
+        exception_type: "RuntimeError",
+        exception_message: "boom, with comma\nand newline",
+      },
+    }),
+  );
+
+  const result = exportResults({ jobDir });
+  assert.equal(result.runId, "run-1");
+  assert.equal(result.trials.length, 3);
+  assert.equal(result.summary.length, 2);
+  assert.equal(result.trials[0].attempt_index, 1);
+  assert.equal(result.trials[1].attempt_index, 2);
+  assert.equal(result.trials[0].git_sha, "abc123");
+  assert.equal(result.trials[0].docs_lock_sha, "docs123");
+  assert.equal(result.trials[0].duration_sec, 60);
+  assert.equal(result.trials[0].agent_execution_duration_sec, 30);
+
+  const trialsCsv = fs.readFileSync(path.join(result.outDir, "trials.csv"), "utf8");
+  assert.match(trialsCsv, /verifier_reward_correctness/);
+  assert.match(trialsCsv, /transfer-with-memo-fee-payer/);
+  const trialRecords = parse(trialsCsv, { columns: true }) as Record<string, string>[];
+  assert.equal(trialRecords.length, 3);
+  assert.equal(
+    trialRecords.find((record) => record.trial_name === "trial-c")?.exception_message,
+    "boom, with comma\nand newline",
+  );
+
+  const summaryCsv = fs.readFileSync(path.join(result.outDir, "summary.csv"), "utf8");
+  assert.match(summaryCsv, /pass_rate/);
+  assert.match(summaryCsv, /other-model/);
+
+  const summaryJson = JSON.parse(
+    fs.readFileSync(path.join(result.outDir, "summary.json"), "utf8"),
+  ) as { n_trials: number; reward_keys: string[] };
+  assert.equal(summaryJson.n_trials, 3);
+  assert.deepEqual(summaryJson.reward_keys, ["correctness", "reward"]);
+});
+
+test("summarizeRows groups by model, task, and profile", () => {
+  const root = tempDir();
+  const jobDir = path.join(root, "run-2", "harbor-job");
+  writeJson(path.join(jobDir, "a", "result.json"), trial({ trial_name: "a" }));
+  writeJson(
+    path.join(jobDir, "b", "result.json"),
+    trial({
+      trial_name: "b",
+      agent_info: { name: "claude-code", model_info: { name: "model-b" } },
+      verifier_result: { rewards: { reward: 0.5 } },
+      agent_result: {
+        n_input_tokens: 3,
+        n_cache_tokens: 1,
+        n_output_tokens: 2,
+        cost_usd: 0.02,
+      },
+    }),
+  );
+  const exported = exportResults({ jobDir, runId: "run-2" });
+  const summary = summarizeRows(exported.trials);
+
+  assert.equal(summary.length, 2);
+  assert.equal(summary.find((row) => row.model === "model-b")?.mean_reward, 0.5);
+  assert.equal(summary.find((row) => row.model === "model-b")?.input_tokens, 3);
+});

--- a/scripts/export-results.ts
+++ b/scripts/export-results.ts
@@ -1,0 +1,505 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Command } from "commander";
+import { stringify } from "csv-stringify/sync";
+import fg from "fast-glob";
+
+type JsonObject = Record<string, unknown>;
+type Numeric = number | "";
+
+export type ExportOptions = {
+  jobDir: string;
+  runId?: string;
+  outDir?: string;
+};
+
+export type TrialRow = {
+  run_id: string;
+  job_name: string;
+  trial_name: string;
+  task_name: string;
+  task_family: string;
+  profile: string;
+  agent: string;
+  model: string;
+  attempt_index: number;
+  reward: Numeric;
+  passed: boolean;
+  exception_type: string;
+  exception_message: string;
+  started_at: string;
+  finished_at: string;
+  duration_sec: Numeric;
+  environment_setup_duration_sec: Numeric;
+  agent_setup_duration_sec: Numeric;
+  agent_execution_duration_sec: Numeric;
+  verifier_duration_sec: Numeric;
+  input_tokens: Numeric;
+  cache_tokens: Numeric;
+  output_tokens: Numeric;
+  cost_usd: Numeric;
+  task_checksum: string;
+  git_sha: string;
+  docs_lock_sha: string;
+  result_path: string;
+  rewards: Record<string, number>;
+};
+
+type SummaryRow = {
+  run_id: string;
+  job_name: string;
+  model: string;
+  agent: string;
+  task_name: string;
+  task_family: string;
+  profile: string;
+  n_trials: number;
+  n_passed: number;
+  pass_rate: number;
+  n_errors: number;
+  mean_reward: Numeric;
+  input_tokens: number;
+  cache_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+};
+
+type Metadata = {
+  run_id?: string;
+  git_sha?: string | null;
+  docs_lock?: { sha?: string };
+};
+
+type ExportContext = {
+  runId: string;
+  jobName: string;
+  gitSha: string;
+  docsLockSha: string;
+};
+
+const PROFILES = ["base", "docs", "mcp"] as const;
+
+const TRIAL_COLUMNS = [
+  "run_id",
+  "job_name",
+  "trial_name",
+  "task_name",
+  "task_family",
+  "profile",
+  "agent",
+  "model",
+  "attempt_index",
+  "reward",
+  "passed",
+  "exception_type",
+  "exception_message",
+  "started_at",
+  "finished_at",
+  "duration_sec",
+  "environment_setup_duration_sec",
+  "agent_setup_duration_sec",
+  "agent_execution_duration_sec",
+  "verifier_duration_sec",
+  "input_tokens",
+  "cache_tokens",
+  "output_tokens",
+  "cost_usd",
+  "task_checksum",
+  "git_sha",
+  "docs_lock_sha",
+  "result_path",
+] as const;
+
+const SUMMARY_COLUMNS = [
+  "run_id",
+  "job_name",
+  "model",
+  "agent",
+  "task_name",
+  "task_family",
+  "profile",
+  "n_trials",
+  "n_passed",
+  "pass_rate",
+  "n_errors",
+  "mean_reward",
+  "input_tokens",
+  "cache_tokens",
+  "output_tokens",
+  "cost_usd",
+] as const;
+
+function readJson<T extends JsonObject = JsonObject>(filePath: string): T | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function readMetadata(jobDir: string): Metadata {
+  return readJson<Metadata>(path.join(path.dirname(jobDir), "metadata.json")) ?? {};
+}
+
+function commandOutput(command: string, args: string[]): string {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function docsLockSha(): string {
+  return readJson(path.join("config", "tempo-docs.lock.json"))?.sha?.toString() ?? "";
+}
+
+function defaultRunId(jobDir: string, metadata: Metadata): string {
+  if (metadata.run_id) return metadata.run_id;
+  return path.basename(jobDir) === "harbor-job"
+    ? path.basename(path.dirname(jobDir))
+    : path.basename(jobDir);
+}
+
+function defaultOutDir(jobDir: string): string {
+  return path.basename(jobDir) === "harbor-job"
+    ? path.join(path.dirname(jobDir), "exports")
+    : path.join(jobDir, "exports");
+}
+
+function buildContext(jobDir: string, runId: string, metadata: Metadata): ExportContext {
+  return {
+    runId,
+    jobName: path.basename(jobDir),
+    gitSha: metadata.git_sha ?? commandOutput("git", ["rev-parse", "HEAD"]),
+    docsLockSha: metadata.docs_lock?.sha ?? docsLockSha(),
+  };
+}
+
+function resultFiles(root: string): string[] {
+  return fg
+    .sync("**/result.json", {
+      absolute: true,
+      cwd: root,
+      ignore: ["**/exports/**"],
+      onlyFiles: true,
+    })
+    .sort();
+}
+
+export function parseTaskName(taskName: string): { taskFamily: string; profile: string } {
+  for (const profile of PROFILES) {
+    const suffix = `-${profile}`;
+    if (taskName.endsWith(suffix)) {
+      return { taskFamily: taskName.slice(0, -suffix.length), profile };
+    }
+  }
+  return { taskFamily: taskName, profile: "unknown" };
+}
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : {};
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function durationSec(timing: unknown): Numeric {
+  const object = asObject(timing);
+  const startedAt = asString(object.started_at);
+  const finishedAt = asString(object.finished_at);
+  if (!startedAt || !finishedAt) return "";
+
+  const started = Date.parse(startedAt);
+  const finished = Date.parse(finishedAt);
+  if (!Number.isFinite(started) || !Number.isFinite(finished)) return "";
+  return Math.max((finished - started) / 1000, 0);
+}
+
+function tokenTotals(result: JsonObject): {
+  input: Numeric;
+  cache: Numeric;
+  output: Numeric;
+  cost: Numeric;
+} {
+  const contexts = collectAgentContexts(result);
+  return {
+    input: sumOptional(contexts, "n_input_tokens"),
+    cache: sumOptional(contexts, "n_cache_tokens"),
+    output: sumOptional(contexts, "n_output_tokens"),
+    cost: sumOptional(contexts, "cost_usd"),
+  };
+}
+
+function collectAgentContexts(result: JsonObject): JsonObject[] {
+  const contexts: JsonObject[] = [];
+  const agentResult = asObject(result.agent_result);
+  if (Object.keys(agentResult).length > 0) contexts.push(agentResult);
+
+  for (const step of Array.isArray(result.step_results) ? result.step_results : []) {
+    const stepAgentResult = asObject(asObject(step).agent_result);
+    if (Object.keys(stepAgentResult).length > 0) contexts.push(stepAgentResult);
+  }
+  return contexts;
+}
+
+function sumOptional(objects: JsonObject[], key: string): Numeric {
+  let total = 0;
+  let found = false;
+  for (const object of objects) {
+    const value = asNumber(object[key]);
+    if (value === undefined) continue;
+    total += value;
+    found = true;
+  }
+  return found ? total : "";
+}
+
+function extractRewards(result: JsonObject): Record<string, number> {
+  const rawRewards = asObject(asObject(result.verifier_result).rewards);
+  return Object.fromEntries(
+    Object.entries(rawRewards).flatMap(([key, value]) => {
+      const numberValue = asNumber(value);
+      return numberValue === undefined ? [] : [[key, numberValue]];
+    }),
+  );
+}
+
+function primaryReward(rewards: Record<string, number>): Numeric {
+  if (typeof rewards.reward === "number") return rewards.reward;
+  if (typeof rewards.score === "number") return rewards.score;
+  const values = Object.values(rewards);
+  return values.length === 1 ? values[0] : "";
+}
+
+function parseTrialResult(filePath: string, context: ExportContext): TrialRow | undefined {
+  const result = readJson(filePath);
+  if (!result || typeof result.task_name !== "string" || typeof result.trial_name !== "string") {
+    return undefined;
+  }
+
+  const agentInfo = asObject(result.agent_info);
+  const modelInfo = asObject(agentInfo.model_info);
+  const exceptionInfo = asObject(result.exception_info);
+  const task = parseTaskName(result.task_name);
+  const rewards = extractRewards(result);
+  const reward = primaryReward(rewards);
+  const tokens = tokenTotals(result);
+
+  return {
+    run_id: context.runId,
+    job_name: context.jobName,
+    trial_name: result.trial_name,
+    task_name: result.task_name,
+    task_family: task.taskFamily,
+    profile: task.profile,
+    agent: asString(agentInfo.name),
+    model: asString(modelInfo.name),
+    attempt_index: 0,
+    reward,
+    passed: typeof reward === "number" && reward >= 1,
+    exception_type: asString(exceptionInfo.exception_type),
+    exception_message: asString(exceptionInfo.exception_message),
+    started_at: asString(result.started_at),
+    finished_at: asString(result.finished_at),
+    duration_sec: durationSec({
+      started_at: result.started_at,
+      finished_at: result.finished_at,
+    }),
+    environment_setup_duration_sec: durationSec(result.environment_setup),
+    agent_setup_duration_sec: durationSec(result.agent_setup),
+    agent_execution_duration_sec: durationSec(result.agent_execution),
+    verifier_duration_sec: durationSec(result.verifier),
+    input_tokens: tokens.input,
+    cache_tokens: tokens.cache,
+    output_tokens: tokens.output,
+    cost_usd: tokens.cost,
+    task_checksum: asString(result.task_checksum),
+    git_sha: context.gitSha,
+    docs_lock_sha: context.docsLockSha,
+    result_path: filePath,
+    rewards,
+  };
+}
+
+function assignAttemptIndexes(rows: TrialRow[]): TrialRow[] {
+  const counts = new Map<string, number>();
+  return rows
+    .sort((a, b) => a.trial_name.localeCompare(b.trial_name))
+    .map((row) => {
+      const key = [row.task_name, row.agent, row.model].join("\0");
+      const attemptIndex = (counts.get(key) ?? 0) + 1;
+      counts.set(key, attemptIndex);
+      return { ...row, attempt_index: attemptIndex };
+    });
+}
+
+function rewardColumns(rows: TrialRow[]): string[] {
+  return [...new Set(rows.flatMap((row) => Object.keys(row.rewards)))]
+    .sort()
+    .map((key) => `verifier_reward_${key}`);
+}
+
+function trialCsvRows(rows: TrialRow[]): Record<string, unknown>[] {
+  return rows.map(({ rewards, ...row }) => ({
+    ...row,
+    ...Object.fromEntries(
+      Object.entries(rewards).map(([key, value]) => [`verifier_reward_${key}`, value]),
+    ),
+  }));
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, unknown>[]) {
+  fs.writeFileSync(filePath, stringify(rows, { columns, header: true }));
+}
+
+function sumNumbers(values: Numeric[]): number {
+  let sum = 0;
+  for (const value of values) {
+    if (typeof value === "number") sum += value;
+  }
+  return sum;
+}
+
+function groupRows(rows: TrialRow[]): Map<string, TrialRow[]> {
+  const groups = new Map<string, TrialRow[]>();
+  for (const row of rows) {
+    const key = [row.model, row.agent, row.task_name, row.task_family, row.profile].join("\0");
+    groups.set(key, [...(groups.get(key) ?? []), row]);
+  }
+  return groups;
+}
+
+export function summarizeRows(rows: TrialRow[]): SummaryRow[] {
+  return [...groupRows(rows).values()]
+    .map((group) => summarizeGroup(group))
+    .sort((a, b) =>
+      [a.model, a.task_name, a.profile].join("\0").localeCompare(
+        [b.model, b.task_name, b.profile].join("\0"),
+      ),
+    );
+}
+
+function summarizeGroup(group: TrialRow[]): SummaryRow {
+  const first = group[0];
+  const rewards = group
+    .map((row) => row.reward)
+    .filter((value): value is number => typeof value === "number");
+  const nPassed = group.filter((row) => row.passed).length;
+
+  return {
+    run_id: first.run_id,
+    job_name: first.job_name,
+    model: first.model,
+    agent: first.agent,
+    task_name: first.task_name,
+    task_family: first.task_family,
+    profile: first.profile,
+    n_trials: group.length,
+    n_passed: nPassed,
+    pass_rate: group.length === 0 ? 0 : nPassed / group.length,
+    n_errors: group.filter((row) => row.exception_type).length,
+    mean_reward:
+      rewards.length === 0
+        ? ""
+        : rewards.reduce((sum, value) => sum + value, 0) / rewards.length,
+    input_tokens: sumNumbers(group.map((row) => row.input_tokens)),
+    cache_tokens: sumNumbers(group.map((row) => row.cache_tokens)),
+    output_tokens: sumNumbers(group.map((row) => row.output_tokens)),
+    cost_usd: sumNumbers(group.map((row) => row.cost_usd)),
+  };
+}
+
+export function exportResults(options: ExportOptions): {
+  runId: string;
+  outDir: string;
+  trials: TrialRow[];
+  summary: SummaryRow[];
+} {
+  const jobDir = path.resolve(options.jobDir);
+  if (!fs.existsSync(jobDir)) {
+    throw new Error(`Job directory not found: ${jobDir}`);
+  }
+
+  const metadata = readMetadata(jobDir);
+  const runId = options.runId ?? defaultRunId(jobDir, metadata);
+  const outDir = path.resolve(options.outDir ?? defaultOutDir(jobDir));
+  const context = buildContext(jobDir, runId, metadata);
+  const trials = assignAttemptIndexes(
+    resultFiles(jobDir)
+      .map((filePath) => parseTrialResult(filePath, context))
+      .filter((row): row is TrialRow => row !== undefined),
+  );
+  const summary = summarizeRows(trials);
+
+  fs.mkdirSync(outDir, { recursive: true });
+  writeCsv(
+    path.join(outDir, "trials.csv"),
+    [...TRIAL_COLUMNS, ...rewardColumns(trials)],
+    trialCsvRows(trials),
+  );
+  writeCsv(path.join(outDir, "summary.csv"), [...SUMMARY_COLUMNS], summary);
+  writeSummaryJson(path.join(outDir, "summary.json"), jobDir, runId, trials, summary);
+
+  return { runId, outDir, trials, summary };
+}
+
+function writeSummaryJson(
+  filePath: string,
+  jobDir: string,
+  runId: string,
+  trials: TrialRow[],
+  summary: SummaryRow[],
+) {
+  fs.writeFileSync(
+    filePath,
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        run_id: runId,
+        job_dir: jobDir,
+        exported_at: new Date().toISOString(),
+        n_trials: trials.length,
+        reward_keys: [...new Set(trials.flatMap((row) => Object.keys(row.rewards)))].sort(),
+        summary,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function cliOptions(argv: string[]): ExportOptions {
+  const program = new Command()
+    .name("results:export")
+    .description("Export Harbor trial results to CSV and JSON.")
+    .requiredOption("--job <path>", "Harbor job directory, for example runs/<run_id>/harbor-job")
+    .option("--run-id <name>", "Run id to write into exports")
+    .option("--out-dir <path>", "Output directory, defaults to runs/<run_id>/exports")
+    .showHelpAfterError();
+
+  program.parse(argv);
+  const options = program.opts<{ job: string; runId?: string; outDir?: string }>();
+  return {
+    jobDir: options.job,
+    runId: options.runId,
+    outDir: options.outDir,
+  };
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFile) {
+  try {
+    const result = exportResults(cliOptions(process.argv));
+    console.log(`Exported ${result.trials.length} trials to ${result.outDir}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/run-benchmark.ts
+++ b/scripts/run-benchmark.ts
@@ -5,8 +5,11 @@
 // Harbor config to use it. Do not commit that staged tree or copy its files
 // back into tasks/.
 import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 type DocsLock = {
   schemaVersion: number;
@@ -22,12 +25,14 @@ type Variant = {
   defaultModel?: string;
   needsAgentAuth?: boolean;
   needsDaytonaAuth?: boolean;
+  production?: boolean;
 };
 
 type Options = {
   envFile?: string;
   help?: boolean;
   jobName?: string;
+  modelsConfig?: string;
   concurrency?: string;
   agentConcurrency?: string;
   maxRetries?: string;
@@ -37,6 +42,21 @@ type Options = {
   nTasks?: string;
   tasks?: string;
   sync: boolean;
+};
+
+type ProductionModel = {
+  agent: string;
+  modelName: string;
+  nConcurrent?: string;
+  concurrencyGroup?: string;
+};
+
+type ProductionModelConfig = {
+  models: ProductionModel[];
+};
+
+type ProductionModelsFile = {
+  models?: unknown[];
 };
 
 const variants: Record<string, Variant> = {
@@ -78,6 +98,12 @@ const variants: Record<string, Variant> = {
     needsAgentAuth: true,
     needsDaytonaAuth: true,
   },
+  "production-daytona": {
+    prefix: "tempo-bench-production",
+    needsAgentAuth: true,
+    needsDaytonaAuth: true,
+    production: true,
+  },
 };
 
 function usage() {
@@ -93,6 +119,7 @@ Variants:
   daytona-oracle     Oracle validation on Daytona
   daytona-agent      Full Claude Code matrix on Daytona
   daytona-agent-dev  One-attempt Claude Code smoke run on Daytona
+  production-daytona Production Daytona run over configured models
   sync               Sync generated task assets only
   dataset            Sync generated task assets and Harbor dataset digests
   check-dataset      Verify dataset digests are fresh
@@ -103,6 +130,7 @@ Variants:
 Options:
   --env-file PATH          Load env file for Harbor and preflight checks (default: .env when present)
   --job-name NAME          Override generated job name
+  --models-config PATH     Production model matrix config (default: config/models.production.yaml)
   --concurrency N         Override n_concurrent_trials
   --agent-concurrency N   Override per-agent n_concurrent
   --max-retries N         Retry transient trial/setup failures (default: 2 for Daytona runs)
@@ -152,6 +180,9 @@ function parseArgs(argv: string[]): { variant?: string; options: Options } {
       i += 1;
     } else if (arg === "--job-name") {
       options.jobName = readOptionValue(rest, i, arg);
+      i += 1;
+    } else if (arg === "--models-config") {
+      options.modelsConfig = readOptionValue(rest, i, arg);
       i += 1;
     } else if (arg === "--concurrency") {
       options.concurrency = readPositiveInteger(readOptionValue(rest, i, arg), arg);
@@ -226,6 +257,24 @@ function run(command: string, args: string[]) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 
+function runStatus(command: string, args: string[]): number {
+  const result = spawnSync(command, args, {
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+function runOutput(command: string, args: string[]): string | undefined {
+  const result = spawnSync(command, args, {
+    env: process.env,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return undefined;
+  return result.stdout.trim() || undefined;
+}
+
 function readDocsLock(): DocsLock {
   const lockPath = path.join("config", "tempo-docs.lock.json");
   const lock = JSON.parse(fs.readFileSync(lockPath, "utf8")) as DocsLock;
@@ -277,6 +326,15 @@ function preflight(variant: Variant) {
   }
 }
 
+function preflightProductionAgents(modelConfig: ProductionModelConfig) {
+  if (modelConfig.models.some((model) => model.agent === "codex")) {
+    requireAny(
+      ["OPENAI_API_KEY", "CODEX_AUTH_JSON_PATH", "CODEX_FORCE_AUTH_JSON"],
+      "Missing Codex auth: set OPENAI_API_KEY, CODEX_AUTH_JSON_PATH, or CODEX_FORCE_AUTH_JSON.",
+    );
+  }
+}
+
 function taskPath(options: Options): string {
   return options.tasks ?? "tasks/tempo";
 }
@@ -284,6 +342,165 @@ function taskPath(options: Options): string {
 function syncDataset(options: Options) {
   run("node", ["scripts/sync-shared.mjs"]);
   run("uv", ["run", "harbor", "sync", taskPath(options)]);
+}
+
+function parseModelConfig(filePath: string, agentConcurrency?: string): ProductionModelConfig {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Production model config not found: ${filePath}`);
+  }
+
+  const YAML = require("yaml") as typeof import("yaml");
+  const parsed = YAML.parse(fs.readFileSync(filePath, "utf8")) as ProductionModelsFile;
+  const rawModels = Array.isArray(parsed?.models) ? parsed.models : [];
+  const models = rawModels.map((model, index) =>
+    normalizeProductionModel(model, index, filePath, agentConcurrency),
+  );
+  if (models.length === 0) {
+    throw new Error(`No production models configured in ${filePath}`);
+  }
+  return { models };
+}
+
+function normalizeProductionModel(
+  value: unknown,
+  index: number,
+  filePath: string,
+  agentConcurrency?: string,
+): ProductionModel {
+  if (typeof value === "string") {
+    return {
+      agent: "claude-code",
+      modelName: value,
+      nConcurrent: agentConcurrency,
+    };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid model entry ${index + 1} in ${filePath}`);
+  }
+
+  const entry = value as Record<string, unknown>;
+  const modelName = stringField(entry, "model_name") ?? stringField(entry, "model");
+  if (!modelName) {
+    throw new Error(`Missing model_name for model entry ${index + 1} in ${filePath}`);
+  }
+  const nConcurrent = stringField(entry, "n_concurrent");
+  return {
+    agent: stringField(entry, "agent") ?? stringField(entry, "agent_name") ?? "claude-code",
+    modelName,
+    nConcurrent: agentConcurrency ?? validateOptionalPositiveInteger(nConcurrent, "n_concurrent"),
+    concurrencyGroup: stringField(entry, "concurrency_group"),
+  };
+}
+
+function stringField(object: Record<string, unknown>, key: string): string | undefined {
+  const value = object[key];
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
+function validateOptionalPositiveInteger(value: string | undefined, option: string) {
+  return value === undefined ? undefined : readPositiveInteger(value, option);
+}
+
+function productionRunRoot(runId: string): string {
+  return path.join("runs", runId);
+}
+
+function productionJobDir(runId: string): string {
+  return path.join(productionRunRoot(runId), "harbor-job");
+}
+
+function writeProductionMetadata(runId: string, metadata: Record<string, unknown>) {
+  const runRoot = productionRunRoot(runId);
+  fs.mkdirSync(runRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(runRoot, "metadata.json"),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+}
+
+function buildProductionConfig(
+  runId: string,
+  modelConfig: ProductionModelConfig,
+  options: Options,
+): string {
+  const stagingRoot = path.join(".cache", "harbor-production", runId);
+  const stagedConfig = path.join(stagingRoot, "job.daytona.production.yaml");
+  const templatePath = path.join("config", "job.daytona.production.yaml.njk");
+  fs.rmSync(stagingRoot, { recursive: true, force: true });
+  fs.mkdirSync(stagingRoot, { recursive: true });
+
+  const nunjucks = require("nunjucks") as typeof import("nunjucks");
+  const YAML = require("yaml") as typeof import("yaml");
+  const environment = new nunjucks.Environment(undefined, {
+    autoescape: false,
+    trimBlocks: true,
+    lstripBlocks: true,
+  });
+  environment.addFilter("dump", (value: unknown) => JSON.stringify(value));
+  const rendered = environment.renderString(fs.readFileSync(templatePath, "utf8"), {
+    jobsDir: productionRunRoot(runId),
+    models: modelConfig.models,
+    nConcurrentTrials: options.concurrency ?? "32",
+  });
+  YAML.parse(rendered);
+  fs.writeFileSync(stagedConfig, rendered);
+  return stagedConfig;
+}
+
+function runProductionVariant(
+  runId: string,
+  options: Options,
+  docsBundle: string,
+): never {
+  const modelsConfigPath = options.modelsConfig ?? "config/models.production.yaml";
+  const modelConfig = parseModelConfig(modelsConfigPath, options.agentConcurrency);
+  preflightProductionAgents(modelConfig);
+  const productionConfig = buildProductionConfig(runId, modelConfig, options);
+  const config = stageDaytonaConfig(productionConfig, runId, docsBundle, options.taskFilter);
+  const maxRetries = options.maxRetries ?? "2";
+  const startedAt = new Date().toISOString();
+  const metadata = {
+    schema_version: 1,
+    run_id: runId,
+    started_at: startedAt,
+    finished_at: null,
+    status: "running",
+    harbor_job_dir: productionJobDir(runId),
+    models_config: modelsConfigPath,
+    models: modelConfig.models.map((model) => ({
+      agent: model.agent,
+      model_name: model.modelName,
+      n_concurrent: model.nConcurrent ?? null,
+      concurrency_group: model.concurrencyGroup ?? null,
+    })),
+    task_dataset_path: "tasks/tempo",
+    task_filter: options.taskFilter ?? null,
+    n_attempts: 3,
+    n_concurrent_trials: options.concurrency ?? "32",
+    max_retries: maxRetries,
+    docs_lock: readDocsLock(),
+    docs_bundle: docsBundle,
+    git_sha: runOutput("git", ["rev-parse", "HEAD"]) ?? null,
+    git_branch: runOutput("git", ["branch", "--show-current"]) ?? null,
+    harbor_version: runOutput("uv", ["run", "harbor", "--version"]) ?? null,
+  };
+
+  writeProductionMetadata(runId, metadata);
+  const args = ["run", "harbor", "run", "-c", config];
+  if (options.envFile) args.push("--env-file", options.envFile);
+  args.push("--max-retries", maxRetries);
+  process.env.TEMPO_DOCS_BUNDLE_PATH = "";
+  args.push("-y");
+
+  const status = runStatus("uv", args);
+  writeProductionMetadata(runId, {
+    ...metadata,
+    finished_at: new Date().toISOString(),
+    status: status === 0 ? "completed" : "failed",
+    exit_status: status,
+  });
+  process.exit(status);
 }
 
 function applyTaskFilter(config: string, taskFilter?: string): string {
@@ -389,6 +606,7 @@ try {
     fs.rmSync("jobs", { recursive: true, force: true });
     fs.rmSync(path.join(".cache", "harbor-daytona"), { recursive: true, force: true });
     fs.rmSync(path.join(".cache", "harbor-config"), { recursive: true, force: true });
+    fs.rmSync(path.join(".cache", "harbor-production"), { recursive: true, force: true });
     fs.mkdirSync("jobs", { recursive: true });
     process.exit(0);
   }
@@ -406,6 +624,10 @@ try {
 
   const runId = options.jobName ?? `${variant.prefix}-${timestamp()}`;
   const args = ["run", "harbor", "run"];
+  if (variant.production) {
+    runProductionVariant(runId, options, docsBundle);
+  }
+
   if (variant.config) {
     const config = variant.needsDaytonaAuth
       ? stageDaytonaConfig(variant.config, runId, docsBundle, options.taskFilter)


### PR DESCRIPTION
## Motivation

Separate fast development benchmark runs from durable production benchmark runs that can compare multiple agent/model configurations and export results for later analysis.

## Summary

- Add a production Daytona benchmark flow backed by a YAML model matrix and rendered Harbor job template
- Persist production run metadata and raw Harbor output under ignored `runs/`
- Add CSV/JSON result export tooling with fixture coverage
- Document development vs production benchmark commands and options

## Key design considerations

- Keep Harbor raw job output as the canonical source while producing notebook-friendly exports
- Use YAML parsing and templating instead of hand-built generated configs
- Support both shorthand Claude Code model entries and explicit agent/model entries such as Codex