### PR TITLE
docs: add MPP task readmes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,31 @@ When writing evals, you SHOULD follow the below principles:
 - Do not change weights of graders without explicit prompt -- in most cases the default is fine.
 - Write only the minimal set of graders/verifiers to ensure your implementation is accurate. Too many graders are hard to maintain and dilute signal.
 
+### Task README structure
+
+Each task directory should include a concise `README.md` for Harbor Hub display.
+Use this structure:
+
+```md
+# <Task Title>
+
+## Overview
+
+<One short paragraph describing what the agent must build.>
+
+## What the Task Tests
+
+- <Capability or integration being tested>
+- <Capability or integration being tested>
+```
+
+For MPP tasks, the README should summarize user-facing server behavior, payment
+method/currency expectations, and Tempo testnet behavior. Do not include
+implementation details such as environment variable names, `/app/out.json`
+schema, exact npm scripts, verifier internals, environment details,
+verification, or difficulty sections. Do not add extra requirements not present in
+`instruction.md` or `tests/`.
+
 ## Coding Style
 
 ### General guidelines

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -10,25 +10,25 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:eb865537f758ee1384b4f61d6a9878e3b9eb92c37dca2cf04f8edc8fb310ca54"
+digest = "sha256:e7416538b2645c314ac251442854bda3da2c58067fa4c0a84e00552c653153ca"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:43544a7c3c4a48a781885a405da3e7c0b7894920c00254486e0aa895e2930480"
+digest = "sha256:0ccef6bebf38b5f65f054a2154610fba0edba3ebda52be63e229a3961c6a0957"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:ab3e121cd6f6d2cc1d5493a2a90195d11adf16c4c16ced1c301b365608fe9cd3"
+digest = "sha256:1e8fcdc0c1801ff5f3a4ae8879c67f4d5ce54bdc1c43844eddd3db38daf34dfc"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:e8b995636cfbf9d2ecb1d34d345650febbe29097a2640674c9108633d34c13b6"
+digest = "sha256:3c1cb90e239920e25e82fe9811b45202617c8c66a48ea6f73acce9c591eb7359"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:6df4b47a688e1b801e54d5fc5efe77c894e65894e37ee95b4cadbca565029cf9"
+digest = "sha256:c20f692a0e6ba62a14310969cfd5dd50a82494b66c1e9a73aa93297eb94eda09"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:d651fe36f69da4d6549a21da8aa2d7da08d380411891fcf1e8e0c5cb9e798092"
+digest = "sha256:687ea023b11c13f8b3e720ed90e250eaad6d6bef43dfc4137b727a4bbd3f176f"
 

--- a/tasks/mpp/server-charge-and-session/README.md
+++ b/tasks/mpp/server-charge-and-session/README.md
@@ -1,0 +1,13 @@
+# MPP Charge and Session Server
+
+## Overview
+
+This task challenges agents to build a TypeScript MPP server that runs on Tempo
+testnet and exposes two paid JSON endpoints: one protected by an MPP charge and
+one protected by an MPP session payment.
+
+## What the Task Tests
+
+- TypeScript server setup
+- MPP charge and session integration
+- Charge-based and session-based Tempo testnet payments

--- a/tasks/mpp/server-charge-pathusd-usdc/README.md
+++ b/tasks/mpp/server-charge-pathusd-usdc/README.md
@@ -1,0 +1,14 @@
+# MPP Server With pathUSD and USDC
+
+## Overview
+
+This task challenges agents to build a TypeScript MPP server that runs on Tempo
+testnet, exposes one free JSON endpoint, and exposes one paid JSON endpoint that
+accepts pathUSD while advertising USDC as an accepted payment currency or option.
+
+## What the Task Tests
+
+- TypeScript server setup
+- MPP charge integration
+- pathUSD payment handling on Tempo testnet
+- Advertising USDC alongside the pathUSD paid endpoint

--- a/tasks/mpp/server-charge-pathusd/README.md
+++ b/tasks/mpp/server-charge-pathusd/README.md
@@ -1,0 +1,14 @@
+# MPP Server
+
+## Overview
+
+This task challenges agents to build a TypeScript MPP server that runs on Tempo
+testnet, accepts pathUSD, and exposes one free JSON endpoint plus one paid JSON
+endpoint protected by MPP.
+
+## What the Task Tests
+
+- TypeScript server setup
+- MPP charge integration
+- pathUSD payment handling on Tempo testnet
+- Returning JSON from both free and paid endpoints

--- a/tasks/mpp/server-discovery-endpoint/README.md
+++ b/tasks/mpp/server-discovery-endpoint/README.md
@@ -1,0 +1,14 @@
+# MPP Server Discovery Endpoint
+
+## Overview
+
+This task challenges agents to build a TypeScript MPP server that runs on Tempo
+testnet, exposes one paid JSON endpoint protected by an MPP charge, and publishes
+an OpenAPI discovery document with payment metadata for that route.
+
+## What the Task Tests
+
+- TypeScript server setup
+- MPP charge integration
+- OpenAPI discovery metadata for a paid endpoint
+- pathUSD payment handling on Tempo testnet

--- a/tasks/mpp/server-hono-charge-pathusd/README.md
+++ b/tasks/mpp/server-hono-charge-pathusd/README.md
@@ -1,0 +1,14 @@
+# Hono MPP Server
+
+## Overview
+
+This task challenges agents to build a Hono-based TypeScript MPP server that
+runs on Tempo testnet, accepts pathUSD, and exposes one free JSON endpoint plus
+one paid JSON endpoint.
+
+## What the Task Tests
+
+- Hono TypeScript server setup
+- Hono payment route integration
+- pathUSD payment handling on Tempo testnet
+- Returning JSON from both free and paid endpoints

--- a/tasks/mpp/server-x402-mpp-charges/README.md
+++ b/tasks/mpp/server-x402-mpp-charges/README.md
@@ -1,0 +1,14 @@
+# x402 and MPP Charge Server
+
+## Overview
+
+This task challenges agents to build a TypeScript server with two paid JSON
+endpoints: one protected by an MPP pathUSD charge on Tempo testnet and one that
+advertises an x402 USDC payment challenge.
+
+## What the Task Tests
+
+- TypeScript server setup
+- MPP pathUSD charge integration
+- x402 payment challenge metadata for a USDC route
+- Tempo testnet payment handling for the MPP route


### PR DESCRIPTION
## Motivation

MPP tasks should have concise Harbor Hub README summaries with consistent structure.

## Summary

- Add minimal README files for each MPP task
- Document the task README structure in AGENTS.md
- Refresh MPP task digests

## Key design considerations

- Keep README content user-facing and avoid implementation details, verifier internals, environment details, and difficulty sections
