### PR TITLE
fix: use api-key-only model auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ npm run bench:model -- --tasks tasks/mpp --task-filter tempo/mpp-server-charge-p
 
 ## Environment
 
-- `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` for Claude/RewardKit.
+- `ANTHROPIC_API_KEY` for Claude/RewardKit.
 - `DAYTONA_API_KEY` for Daytona, or `DAYTONA_JWT_TOKEN` plus
   `DAYTONA_ORGANIZATION_ID`.
 - `DAYTONA_TARGET` for optional Daytona target selection.

--- a/README.md
+++ b/README.md
@@ -255,10 +255,8 @@ Useful runner flags:
 
 | Variable | Used for |
 | -------- | -------- |
-| `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` | Claude Code and RewardKit LLM judging |
+| `ANTHROPIC_API_KEY` | Claude Code and RewardKit LLM judging |
 | `OPENAI_API_KEY` | Codex production agent auth |
-| `CODEX_AUTH_JSON_PATH` or `CODEX_FORCE_AUTH_JSON` | Optional Codex auth.json auth instead of `OPENAI_API_KEY` |
-| `OPENAI_BASE_URL` | Optional Codex OpenAI-compatible endpoint override |
 | `DAYTONA_API_KEY` | Daytona runs |
 | `DAYTONA_TARGET` | Optional Daytona target |
 

--- a/config/generated/job.daytona-agent-dev.yaml
+++ b/config/generated/job.daytona-agent-dev.yaml
@@ -20,7 +20,6 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: claude-code
@@ -28,7 +27,6 @@ agents:
   n_concurrent: 32
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
 datasets:
 - path: tasks/tempo
   task_names:

--- a/config/generated/job.daytona-agent.yaml
+++ b/config/generated/job.daytona-agent.yaml
@@ -20,7 +20,6 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: claude-code
@@ -28,7 +27,6 @@ agents:
   n_concurrent: 32
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
 datasets:
 - path: tasks/tempo
   task_names:

--- a/config/generated/job.daytona-oracle.yaml
+++ b/config/generated/job.daytona-oracle.yaml
@@ -20,7 +20,6 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: oracle

--- a/config/generated/job.local-agent-dev.yaml
+++ b/config/generated/job.local-agent-dev.yaml
@@ -17,14 +17,12 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: claude-code
   model_name: claude-haiku-4-5
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
 datasets:
 - path: tasks/tempo
   task_names:

--- a/config/generated/job.local-agent.yaml
+++ b/config/generated/job.local-agent.yaml
@@ -17,14 +17,12 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: claude-code
   model_name: claude-haiku-4-5
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
 datasets:
 - path: tasks/tempo
   task_names:

--- a/config/generated/job.local-oracle-dev.yaml
+++ b/config/generated/job.local-oracle-dev.yaml
@@ -17,7 +17,6 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: oracle

--- a/config/generated/job.local-oracle.yaml
+++ b/config/generated/job.local-oracle.yaml
@@ -17,7 +17,6 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 - name: oracle

--- a/config/job.yaml.j2
+++ b/config/job.yaml.j2
@@ -24,7 +24,6 @@ verifier:
     - "*.txt"
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
     REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
 agents:
 {% for agent in agents %}
@@ -41,12 +40,8 @@ agents:
 {% if agent.name != "oracle" %}
     env:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
 {% if agent.name == "codex" %}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
-      CODEX_AUTH_JSON_PATH: ${CODEX_AUTH_JSON_PATH:-}
-      CODEX_FORCE_AUTH_JSON: ${CODEX_FORCE_AUTH_JSON:-false}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/config/job.yaml.j2
+++ b/config/job.yaml.j2
@@ -46,7 +46,7 @@ agents:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       CODEX_AUTH_JSON_PATH: ${CODEX_AUTH_JSON_PATH:-}
-      CODEX_FORCE_AUTH_JSON: ${CODEX_FORCE_AUTH_JSON:-}
+      CODEX_FORCE_AUTH_JSON: ${CODEX_FORCE_AUTH_JSON:-false}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -188,22 +188,12 @@ def ensure_docs_bundle() -> str:
     return str(bundle_path)
 
 
-def require_any(names: list[str], message: str) -> None:
-    if not any(os.environ.get(name) for name in names):
-        raise RuntimeError(message)
-
-
 def preflight(variant: dict[str, Any], options: dict[str, Any]) -> None:
-    if os.environ.get("CLAUDE_FORCE_OAUTH") == "":
-        msg = "CLAUDE_FORCE_OAUTH is set but empty. Set it to 1/true or unset it."
-        raise RuntimeError(msg)
     effective_agent = options.get("agent") or variant.get("default_agent")
     needs_agent_auth = variant.get("needs_agent_auth") and effective_agent != "oracle"
-    if needs_agent_auth:
-        require_any(
-            ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
-            "Missing Claude Code and verifier judge auth: set ANTHROPIC_API_KEY "
-            "or ANTHROPIC_AUTH_TOKEN.",
+    if needs_agent_auth and not os.environ.get("ANTHROPIC_API_KEY"):
+        raise RuntimeError(
+            "Missing Claude Code and verifier judge auth: set ANTHROPIC_API_KEY."
         )
     if (
         variant.get("needs_daytona_auth")
@@ -221,12 +211,10 @@ def preflight(variant: dict[str, Any], options: dict[str, Any]) -> None:
 
 
 def preflight_production_agents(model_config: dict[str, Any]) -> None:
-    if any(model["agent"] == "codex" for model in model_config["models"]):
-        require_any(
-            ["OPENAI_API_KEY", "CODEX_AUTH_JSON_PATH", "CODEX_FORCE_AUTH_JSON"],
-            "Missing Codex auth: set OPENAI_API_KEY, CODEX_AUTH_JSON_PATH, "
-            "or CODEX_FORCE_AUTH_JSON.",
-        )
+    if any(model["agent"] == "codex" for model in model_config["models"]) and not (
+        os.environ.get("OPENAI_API_KEY")
+    ):
+        raise RuntimeError("Missing Codex auth: set OPENAI_API_KEY.")
 
 
 def task_path(options: dict[str, Any]) -> str:

--- a/shared/global/rewardkit/test.sh
+++ b/shared/global/rewardkit/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/shared/mpp/tests/test.sh
+++ b/shared/mpp/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/client-access-keys/tests/test.sh
+++ b/tasks/mpp/client-access-keys/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -10,37 +10,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:53bed50bd09d8246d4c1bc060196a9031dd2e13edd2d6ec33b96878167b9a01d"
+digest = "sha256:7c7d7c8ba263c242a4eaf884b78cf377247cacb67dda2be31c5f3ba8095f462b"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:3a46746e7af21aef67c61c3247011eb9e086f5eb542c2c771aefeea7b8442c29"
+digest = "sha256:36cad62b2ab4001902232cb5dca9539f860673cfffd526995d71cd54d7dc47ab"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:2b7419d4a63beb28b5e5bac9271f565278ee33e984c64e3323be03d48d1a009a"
+digest = "sha256:a774fda559da55035d278238d405b5896f5490cbf7c0a93d9ff5b520e2ce1770"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:6d1bec6057db0f7aa22ddb5a1412f6211f39386c420d50712dd511c150bbf2d3"
+digest = "sha256:ccee65846b1d32e2edd17ff1422741076992bf5fb8e04e56938c93c127a87168"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:45c98ace7a113f595bf92c0570c107db9b79be4decbae2faaf7ce93b9fb4733c"
+digest = "sha256:ee0f92fbed592ea962535dfdcf06c466ff92d52158bc4714a570a056ed36ef71"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:df2e3760175b06d6ecdbe802218d9a5baa088a97d31901528647664bd068bde8"
+digest = "sha256:ba6f228c4cf5dc27fd7696da3cc768ffbac1120024be66c2a1dcc06246089171"
 
 [[tasks]]
 name = "tempo/mpp-client-access-keys"
-digest = "sha256:45a5a1c2fb826fb64ab5c495c44497b198612c1f593110788f4de458f9bef56f"
+digest = "sha256:5fc4c59589c77f1697d996fa4efd6c7b8a501edf006e70e5721fcec5660f2aa4"
 
 [[tasks]]
 name = "tempo/mpp-server-custom-payment-method"
-digest = "sha256:b57f13b01c74395f2189485f18f1c9a66e053cce941a828e905619de7cde39b9"
+digest = "sha256:26cf63fd5dc4910dec2627bf80a511772e74b85f486ad5db3b3edd785991a77d"
 
 [[tasks]]
 name = "tempo/mpp-server-mcp-pathusd"
-digest = "sha256:598894688d876e0520526e03912417d6405f646dd9ff85ea5b6a14facd40bcd7"
+digest = "sha256:8e66ccaf883cdf4483586781d39ba2e168f8f81b84de8b73d5b98ce8d9899728"
 

--- a/tasks/mpp/server-charge-and-session/tests/test.sh
+++ b/tasks/mpp/server-charge-and-session/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-charge-pathusd-usdc/tests/test.sh
+++ b/tasks/mpp/server-charge-pathusd-usdc/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-charge-pathusd/tests/test.sh
+++ b/tasks/mpp/server-charge-pathusd/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-custom-payment-method/tests/test.sh
+++ b/tasks/mpp/server-custom-payment-method/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-discovery-endpoint/tests/test.sh
+++ b/tasks/mpp/server-discovery-endpoint/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-hono-charge-pathusd/tests/test.sh
+++ b/tasks/mpp/server-hono-charge-pathusd/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-mcp-pathusd/tests/test.sh
+++ b/tasks/mpp/server-mcp-pathusd/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/mpp/server-x402-mpp-charges/tests/test.sh
+++ b/tasks/mpp/server-x402-mpp-charges/tests/test.sh
@@ -27,9 +27,9 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] \
+if [ -z "${ANTHROPIC_API_KEY:-}" ] \
   && [ -f "${TEMPO_BENCH_TESTS_DIR:-/tests}/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -11,73 +11,73 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-base"
-digest = "sha256:daa67e3eba478951ab6e180e1ee349c523e8a324d6ea7d47deedc0f0cccb312d"
+digest = "sha256:f1df75cbdaff9c9d926084f99da412cf63463e934ff25d613d61f7c28d783132"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:f26cdc05626b6210d972d8dba48b5f324ef406403aca223ad10bbd94e8d4c4b0"
+digest = "sha256:2bc13dbe1556f95d908131cb25a64dbdd9b24e77eed7c0760c7e5055e11eca79"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:8cdeb85170e7430d44309ca684026cb6a9f3f38aec6f0af90c77efae21bfcadb"
+digest = "sha256:65e1dc66c0266fff3cf7b2d9b5938502c762132f588a4bfd6f579b0ca3bb5dc7"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-base"
-digest = "sha256:0309cd52ca2e22d1052b34678b12f23ba89342e74bb13ed4c2a0e225a380cccd"
+digest = "sha256:6e3c40c8f890dbad24ba910687a3c94e3543436af4861c47cea50f50a14f2f1f"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:62e1b539599028754bd1a32ca5c4c8600bc723fbc6f5f57080c3442d4a4aa9f2"
+digest = "sha256:252cd44f176fe4c91cc00eec5ce9b7a08be7f36aa011fe8bcb67f6a4a101567e"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:7f68d919fab21a6e142653ea021e16c35b3b0564cc48618df5cc35ae6e43af04"
+digest = "sha256:4a5823f35c7df7e709fbc02a66bb378325691039c34f4d78e71c7b45468e408e"
 
 [[tasks]]
 name = "tempo/set-fee-token-base"
-digest = "sha256:76da086608475946f69f7bdbcdad1342707d9460c964df4d253f0764e5daced5"
+digest = "sha256:92e3e7edec24864276e5abbc451e70a653eca02e55ee97c59ffe0b0cefad9939"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:1299fb4ba3bf1aed3f88b22b5b5d854876078bbb2e47bfd2dfea5226981ff4ab"
+digest = "sha256:33e081baeda01a8fb3ed5d129299f7e764c5ca5e39692efe6533d428ed206490"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:e5e3c6a12e1cd877d15a7ea89f206a0bad4544327dd193ebfdb3b2575503fcc1"
+digest = "sha256:f75cd46b7c26fff1557e4677ddb61607f85686bdaf5967c4ac247ae85134d2ff"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:50c603ab71b784c68887fa8c6b0a9f5727ab9d5ace6c300e9d349ae5d8480dff"
+digest = "sha256:350eca82956112921c933798dd8da5c905907727354845e52abf3b1b1dc2a012"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:289596ef90dfa88e249adc576eed5f75fa8b4c34dd9bc0f580d74eccf3b202b6"
+digest = "sha256:3922a32011a7c0d857cd49b015d6d8dd04394b2b292ab73a19eb45fa91c5842b"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:4b2f6213224ddcb624121bd459913bcb8bb0e73a25f94ab5837a74bc3d83516f"
+digest = "sha256:74b058b5532aba14db6982329fa4705761b23cc8ccb0aa42ca3c4676f89c6aea"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:bcf9a8074caf3553336a47e935286152ef1efe082fa7448d1f16c45a9e49902d"
+digest = "sha256:aa976c579e6f1146d8ea95683057b4fdec810724caba790f7f2c28c29b8cafcf"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:462953e1c7096aa338aa763d09cb7b4ecf7b54d2d134bb016ca9aea3310182ab"
+digest = "sha256:e70af713f8dd8da479cb7f26a2e8bbb08df9623fd039e699c804f621bbf28e3f"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:0e09cd3d1d87f7de9baf7bc34c8dd4bb3c94568359b5af2966287967568f6ef2"
+digest = "sha256:59251b985c4eb6164724b6f12e6b78ce24d3c653b9828c07cfeaf954762b1fb8"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:1f9b5c0012748ece41484cd3cfb2fc65774bded7c6ab9f0409217feee40efc35"
+digest = "sha256:04bb9e9a878ef843f7ee9cc1bc8ddea469f83f69ea521952f84014c8b03e8e4a"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:d503f52923018cba7772b651c37e171a1ea4c65e2085f2c99e7075dbca3fb39f"
+digest = "sha256:591ab987e6227836920ed8520bf119ec3a8471bb25d06eb043994b300f3a1999"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:43437f1352fa0df33b4368a16528e5c7a149a1ee6b69f63d662cc489c259e595"
+digest = "sha256:839e88f805ed3e2b27557692340b49816ba0a0240aba10427d6e0976770b36d6"
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/set-fee-token-base/tests/test.sh
+++ b/tasks/tempo/set-fee-token-base/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/set-fee-token-docs/tests/test.sh
+++ b/tasks/tempo/set-fee-token-docs/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/set-fee-token-mcp/tests/test.sh
+++ b/tasks/tempo/set-fee-token-mcp/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/transfer-with-memo-base/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-base/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/transfer-with-memo-docs/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-docs/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {

--- a/tasks/tempo/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/test.sh
@@ -78,8 +78,8 @@ skip_llm_quality() {
   printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
 }
 
-if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is not set.'
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
 fi
 
 write_binary_reward() {


### PR DESCRIPTION
## Motivation

Model auth should be API-key-only. Tempo Bench should not require or render alternate Codex auth-json/base-url variables or Claude OAuth/auth-token variables.

## Changes

- Remove `CODEX_AUTH_JSON_PATH`, `CODEX_FORCE_AUTH_JSON`, `OPENAI_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_FORCE_OAUTH` from docs, preflight checks, and Harbor job env rendering.
- Keep Codex production auth on `OPENAI_API_KEY`.
- Keep Claude Code and RewardKit judge auth on `ANTHROPIC_API_KEY`.
- Refresh generated job configs, task verifier scripts, and dataset digests from the shared templates.

## Validation

- `npm run dataset`
- `npm run dataset -- --tasks tasks/mpp`
- `npm run check:scripts`
- `npm run check:format`
- `npm run check:lint`
- `npm run check:shell`
- `npm run test:results`
- `npm run check:docs`
- `npm run check:generated`
- Stale auth-var scan found no checked-in references to `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_FORCE_OAUTH`, `CODEX_AUTH_JSON_PATH`, `CODEX_FORCE_AUTH_JSON`, or `OPENAI_BASE_URL`.
- Render assertion confirmed Codex agent env is exactly `ANTHROPIC_API_KEY` + `OPENAI_API_KEY`.