### PR TITLE
fix: accept generic faucet funding implementations

### DIFF
--- a/shared/tempo/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/tempo/verifier/src/cases/faucet-funded-transfer.js
@@ -20,7 +20,7 @@ function beforeLog(left, right) {
 
 async function verify({ client, config, fromBlock }) {
   const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
-  const sender = privateKeyToAccount(config.faucetPrivateKey).address;
+  const fundedSender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
 
@@ -30,7 +30,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: sender,
+        from: fundedSender,
         to: config.recipient,
       },
       fromBlock,
@@ -45,7 +45,7 @@ async function verify({ client, config, fromBlock }) {
       event,
       args: {
         from: localnetFaucet,
-        to: sender,
+        to: fundedSender,
       },
       fromBlock,
       toBlock: match.blockNumber,
@@ -58,7 +58,7 @@ async function verify({ client, config, fromBlock }) {
       funding &&
       blockEvidence(match, {
         localnetFaucet,
-        fundedSender: sender,
+        fundedSender,
         fundingTransactionHash: funding.transactionHash,
       })
     );

--- a/tasks/tempo/_templates/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/faucet-funded-transfer/tests/correctness/criteria.py
@@ -6,7 +6,7 @@ rk.tempo_source_patterns(
     [
         {
             "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
+            "pattern": r"tempo_fundAddress|faucet\.fundSync|fundSync",
         },
         {
             "name": "source_reads_faucet_private_key",
@@ -14,7 +14,11 @@ rk.tempo_source_patterns(
         },
         {
             "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
+            "pattern": (
+                r"transferSync|transferWithMemo|"
+                r"functionName\s*:\s*[\"']transfer[\"']|"
+                r"name\s*:\s*[\"']transfer[\"']"
+            ),
         },
     ]
 )

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -59,15 +59,15 @@ digest = "sha256:4c53f3f2d41ae80228b6a3b49a1892f711dc3002c6899f5b2b493f8315dd489
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:9213019f62524a3ab5b72b07e41d1061fad681f3400e38000ebf6d17342d30db"
+digest = "sha256:0f305c4808ae370eea561970d252715b734e3b11343421a68d4fefcca390fa53"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:6fde090ab8886a745751dd3db21e780cd31e44a2562997f46d054670bb84f044"
+digest = "sha256:f901f43fc85357e81073c21456ecb66ce70165d64f3e353dea08e824ebb347ff"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:f82c1b5830a24430980dbf719402d88ae9ae5a44bf3fef2d59711b5209a42e20"
+digest = "sha256:f37e098abef965c37594a352e04a1e21ba7706638738bdfb77c472f5644e9e7c"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"

--- a/tasks/tempo/faucet-funded-transfer-base/tests/correctness/criteria.py
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/correctness/criteria.py
@@ -9,7 +9,7 @@ rk.tempo_source_patterns(
     [
         {
             "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
+            "pattern": r"tempo_fundAddress|faucet\.fundSync|fundSync",
         },
         {
             "name": "source_reads_faucet_private_key",
@@ -17,7 +17,11 @@ rk.tempo_source_patterns(
         },
         {
             "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
+            "pattern": (
+                r"transferSync|transferWithMemo|"
+                r"functionName\s*:\s*[\"']transfer[\"']|"
+                r"name\s*:\s*[\"']transfer[\"']"
+            ),
         },
     ]
 )

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -20,7 +20,7 @@ function beforeLog(left, right) {
 
 async function verify({ client, config, fromBlock }) {
   const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
-  const sender = privateKeyToAccount(config.faucetPrivateKey).address;
+  const fundedSender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
 
@@ -30,7 +30,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: sender,
+        from: fundedSender,
         to: config.recipient,
       },
       fromBlock,
@@ -45,7 +45,7 @@ async function verify({ client, config, fromBlock }) {
       event,
       args: {
         from: localnetFaucet,
-        to: sender,
+        to: fundedSender,
       },
       fromBlock,
       toBlock: match.blockNumber,
@@ -58,7 +58,7 @@ async function verify({ client, config, fromBlock }) {
       funding &&
       blockEvidence(match, {
         localnetFaucet,
-        fundedSender: sender,
+        fundedSender,
         fundingTransactionHash: funding.transactionHash,
       })
     );

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/correctness/criteria.py
@@ -9,7 +9,7 @@ rk.tempo_source_patterns(
     [
         {
             "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
+            "pattern": r"tempo_fundAddress|faucet\.fundSync|fundSync",
         },
         {
             "name": "source_reads_faucet_private_key",
@@ -17,7 +17,11 @@ rk.tempo_source_patterns(
         },
         {
             "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
+            "pattern": (
+                r"transferSync|transferWithMemo|"
+                r"functionName\s*:\s*[\"']transfer[\"']|"
+                r"name\s*:\s*[\"']transfer[\"']"
+            ),
         },
     ]
 )

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -20,7 +20,7 @@ function beforeLog(left, right) {
 
 async function verify({ client, config, fromBlock }) {
   const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
-  const sender = privateKeyToAccount(config.faucetPrivateKey).address;
+  const fundedSender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
 
@@ -30,7 +30,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: sender,
+        from: fundedSender,
         to: config.recipient,
       },
       fromBlock,
@@ -45,7 +45,7 @@ async function verify({ client, config, fromBlock }) {
       event,
       args: {
         from: localnetFaucet,
-        to: sender,
+        to: fundedSender,
       },
       fromBlock,
       toBlock: match.blockNumber,
@@ -58,7 +58,7 @@ async function verify({ client, config, fromBlock }) {
       funding &&
       blockEvidence(match, {
         localnetFaucet,
-        fundedSender: sender,
+        fundedSender,
         fundingTransactionHash: funding.transactionHash,
       })
     );

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -9,7 +9,7 @@ rk.tempo_source_patterns(
     [
         {
             "name": "source_calls_faucet_fund",
-            "pattern": r"faucet\.fundSync|fundSync",
+            "pattern": r"tempo_fundAddress|faucet\.fundSync|fundSync",
         },
         {
             "name": "source_reads_faucet_private_key",
@@ -17,7 +17,11 @@ rk.tempo_source_patterns(
         },
         {
             "name": "source_sends_transfer",
-            "pattern": r"transferSync|transferWithMemo",
+            "pattern": (
+                r"transferSync|transferWithMemo|"
+                r"functionName\s*:\s*[\"']transfer[\"']|"
+                r"name\s*:\s*[\"']transfer[\"']"
+            ),
         },
     ]
 )

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/cases/faucet-funded-transfer.js
@@ -20,7 +20,7 @@ function beforeLog(left, right) {
 
 async function verify({ client, config, fromBlock }) {
   const localnetFaucet = privateKeyToAccount(config.payerPrivateKey).address;
-  const sender = privateKeyToAccount(config.faucetPrivateKey).address;
+  const fundedSender = privateKeyToAccount(config.faucetPrivateKey).address;
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
 
@@ -30,7 +30,7 @@ async function verify({ client, config, fromBlock }) {
       address: config.token,
       event,
       args: {
-        from: sender,
+        from: fundedSender,
         to: config.recipient,
       },
       fromBlock,
@@ -45,7 +45,7 @@ async function verify({ client, config, fromBlock }) {
       event,
       args: {
         from: localnetFaucet,
-        to: sender,
+        to: fundedSender,
       },
       fromBlock,
       toBlock: match.blockNumber,
@@ -58,7 +58,7 @@ async function verify({ client, config, fromBlock }) {
       funding &&
       blockEvidence(match, {
         localnetFaucet,
-        fundedSender: sender,
+        fundedSender,
         fundingTransactionHash: funding.transactionHash,
       })
     );


### PR DESCRIPTION
## Motivation

The faucet-funded transfer task should validate that the faucet was used, without requiring submissions to call the `fundSync` helper specifically. Direct `tempo_fundAddress` usage should satisfy the source diagnostics when paired with a real on-chain faucet funding event.

## Changes

- Accept `tempo_fundAddress` in the faucet source-pattern check.
- Accept raw ERC20 `transfer` calls in the transfer source-pattern check.
- Clarify verifier variable names so the localnet faucet account and funded sender are distinct.
- Refresh generated faucet task variants and dataset digests.

## Validation

- `npm run dataset -- --tasks tasks/tempo`
- Regex smoke against the existing oracle solution and a prior raw-RPC artifact that called `tempo_fundAddress`.
- `npm run check:scripts`
- `npm run check:format`
- `npm run check:lint`
- `npm run check:generated`
- `npm run bench:local:oracle:dev -- --task-filter faucet-funded-transfer-base --concurrency 1` — reward 1.0, 0 exceptions
- `npm run bench:local:oracle:dev -- --task-filter faucet-funded-transfer-docs --concurrency 1` — reward 1.0, 0 exceptions
- `npm run bench:local:oracle:dev -- --task-filter faucet-funded-transfer-mcp --concurrency 1` — reward 1.0, 0 exceptions

Note: the existing on-chain verifier still requires observed faucet funding before the transfer. It does not grant credit for merely calling `tempo_fundAddress` without waiting for the returned funding transactions to land.
