### PR TITLE
fix: remove stale shellcheck sources path

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check:generated": "uv run python scripts/run_benchmark.py check-generated",
     "check:format": "uv run ruff format --check .",
     "check:lint": "uv run ruff check .",
-    "check:shell": "find shared sources -name '*.sh' -print0 | xargs -0 uv run shellcheck --severity=warning",
+    "check:shell": "find shared -name '*.sh' -exec uv run shellcheck --severity=warning {} +",
     "check:scripts": "uv run python -m compileall -q scripts",
     "test:results": "uv run python -m unittest discover -s scripts -p '*_test.py'",
     "clean": "uv run python scripts/run_benchmark.py clean",


### PR DESCRIPTION
## Motivation

`npm run check:shell` still referenced a historical `sources/` directory. Fresh clones no longer have that directory, so the command printed `find: sources: No such file or directory` even though the pipeline exited successfully.

## Summary

- Keep `check:shell` because `shared/` contains the synced shell sources for RewardKit and MPP harness scripts.
- Remove the stale `sources/` path from the shellcheck command.
- Use `find ... -exec` directly instead of piping through `xargs`.

## Key design considerations

- This keeps useful shell coverage for current shared harness scripts while dropping compatibility for a directory that no longer exists.

## Validation

- `npm run check:shell`