### PR TITLE
fix: add Tempo verifier exception artifacts

### DIFF
--- a/shared/global/rewardkit/test.sh
+++ b/shared/global/rewardkit/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/shared/global/rewardkit/verify-tempo.sh
+++ b/shared/global/rewardkit/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/shared/tempo/verifier/src/config.js
+++ b/shared/tempo/verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/shared/tempo/verifier/src/index.js
+++ b/shared/tempo/verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/shared/tempo/verifier/src/logs.js
+++ b/shared/tempo/verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -11,73 +11,73 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-base"
-digest = "sha256:f739da6e675b5dc662c280cb7b430234eb8ef445241e82c77d883b0cd903778f"
+digest = "sha256:a97a99006f5304ccaec8703f1797225aeab4b1f7c7a36214d0d6298fc40ce082"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:f6686b83aecd73e736528e74c4c1fddf30e75ca78087c5abfbfd53b9cd07efe9"
+digest = "sha256:a0d97980cbf99b1a3714ebddbce0795acf25d9bd26e88e2619fee27ddcd18d2a"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:384e4b648452308c58478054818a630428111b7f636f4bad716d25e79ed3b987"
+digest = "sha256:1f7bae3c4ebd1031aca09ad0b52c954bf6fba02f4ccd1405fed04cc151014313"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-base"
-digest = "sha256:6eabf42befb75525dff9dc9f30954f2406133ab9c1d55693aba3fa40cba84801"
+digest = "sha256:b53ae4452661e081f2f37d5d1e595098be46cf0459d470adf89155883750efb0"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:1081ec9030d68259bdd1991adabbabfe16d7c73d7d81986b4aa6a0b813f3b660"
+digest = "sha256:728666a2a91cbac758bf8e9b3089cc52faa7b7c842b909af249d3f5181c8572e"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:eddd53bcd0d6665c7638d0fb040d2b8d8de525feffc667e0c3f0b365655a2440"
+digest = "sha256:029167b7892c09a10e0edadec0c8517471479beee7e540ca79c15f59a375f49e"
 
 [[tasks]]
 name = "tempo/set-fee-token-base"
-digest = "sha256:de402b36c485a42ea26aaf16cff4fa3d08a237e39fe17535bb7424867ab97343"
+digest = "sha256:e8122e8a238f78b767346c71847192c81428ab814c94bdf168a4eef0c2618ba3"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:0e20a50185db8fc168ce6b5d9ce0557db04bc424e6ba8eb0ddf86662258a4c64"
+digest = "sha256:beda2f9c7af2027f524d25faa06fd612758e17506d8245e88bfef627a822b5d4"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:dc046d45cdf3573b3d7f3dcb046777340683e05ccfa4e0a2427436083f2cdc07"
+digest = "sha256:bb45281327b2bd404ab2e8580abbf49250adafd3545b688465f1a1923a7538c1"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:ed0138a473554befc38ab0f69efdfb44b8ab7efca66b092bb793c698731d8bad"
+digest = "sha256:52c0a552418163e58f4f0696438461d9bc38ffac0b6660e5678f4483969d1a6b"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:a5efc803104f84b2a04ac4073d9f7a9ae02e179dbfd2e72ba7331a118aeccc39"
+digest = "sha256:966c8a05d62407c0947a9f2f4281b7333e02bfcbbe3bcb2e464a2eb8d932e970"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:4b7fe897a34d122d05fd735569838f214701284f24b80427f6584e69f55d0f74"
+digest = "sha256:019247a1231645bacccb58df20929790d8fcf296e0e0c8a1b5f3bdcd359cd13b"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:a0e4360e2106cbda7b13fbcf5ad288842420f2cccba510d1d3ac20087f7982e1"
+digest = "sha256:6e5c3e6ae00b4067cc9688bd35503fcc5caaa4eb46d5477853c5899f23f6ec86"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:8e4d4e4461c68c18f5a17a26a9abf6be69258939fc360471b2b4f91343ad2d82"
+digest = "sha256:aa9fe514aaf9658517a3a1d8df61a8bfdaf365d1cea8d697bc47e1499581d6a6"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:a9e08f8be5b766221bd80a0308d0cce9ccb7bee7bcccd0d966e151113dbbba2d"
+digest = "sha256:0c8cda711454e9752bb50d1dbd2b18c8aa5566137d5592b239b652991b9850bb"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:ae910cf293b31e23c726527dc77da00661132ff4765e32eedf195c214da59a1d"
+digest = "sha256:daf2e0d4722077d921fde420e83897e9dd8f2f64ff9441d444c46e3660ee57f8"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:d3d3303b40326b4a8853778bd83922c0b6f473f032280eb7049c89f50142ba89"
+digest = "sha256:278b3196227d3a018777fa3e2d7c814057e462beb0274348cbdc93bd2e9a9cd0"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:5ca7f51a451080cc14a6cea13eee761c58b7bd21a4c261defa917f03e531e279"
+digest = "sha256:2ce33d605520160ec43223ff0f9e848a8bc50c0737332df33fe0200641315a18"
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/faucet-funded-transfer-base/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/set-fee-token-base/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/set-fee-token-base/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/set-fee-token-base/tests/test.sh
+++ b/tasks/tempo/set-fee-token-base/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/set-fee-token-docs/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/set-fee-token-docs/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/set-fee-token-docs/tests/test.sh
+++ b/tasks/tempo/set-fee-token-docs/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/set-fee-token-mcp/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/set-fee-token-mcp/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/set-fee-token-mcp/tests/test.sh
+++ b/tasks/tempo/set-fee-token-mcp/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/transfer-with-memo-base/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/transfer-with-memo-base/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/transfer-with-memo-base/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-base/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/transfer-with-memo-docs/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/transfer-with-memo-docs/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/transfer-with-memo-docs/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-docs/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi

--- a/tasks/tempo/transfer-with-memo-mcp/tests/correctness/verify-tempo.sh
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/correctness/verify-tempo.sh
@@ -3,12 +3,30 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 INTERNAL_REWARD="$LOG_DIR/tempo-bench-reward.json"
 SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 VERIFIER="/tests/node_modules/@tempo-bench/verifier/bin/tempo-bench-verify.js"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 rm -f "$INTERNAL_REWARD" "$SCORES_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo verifier failed before producing a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 cd /tests || exit 1
 npm install --silent \
@@ -18,6 +36,12 @@ INSTALL_STATUS=$?
 printf '{"command":"npm","args":["install","--silent"],"status":%d}\n' \
   "$INSTALL_STATUS" > "$LOG_DIR/verifier-npm-install.status.json"
 if [ "$INSTALL_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "verifier-npm-install" \
+    "npm install --silent exited $INSTALL_STATUS" \
+    "$LOG_DIR/verifier-npm-install.stdout.txt" \
+    "$LOG_DIR/verifier-npm-install.stderr.txt" \
+    "$LOG_DIR/verifier-npm-install.status.json"
   exit "$INSTALL_STATUS"
 fi
 
@@ -29,10 +53,22 @@ GRADER_STATUS=$?
 printf '{"command":"node","args":["%s"],"status":%d}\n' \
   "$VERIFIER" "$GRADER_STATUS" > "$LOG_DIR/grader.status.json"
 if [ "$GRADER_STATUS" -ne 0 ]; then
+  write_exception_artifact \
+    "grader" \
+    "node verifier exited $GRADER_STATUS" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit "$GRADER_STATUS"
 fi
 if [ ! -f "$INTERNAL_REWARD" ]; then
   printf 'missing internal reward file: %s\n' "$INTERNAL_REWARD" >&2
+  write_exception_artifact \
+    "grader" \
+    "missing internal reward file: $INTERNAL_REWARD" \
+    "$LOG_DIR/grader.stdout.txt" \
+    "$LOG_DIR/grader.stderr.txt" \
+    "$LOG_DIR/grader.status.json"
   exit 1
 fi
 

--- a/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/config.js
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/config.js
@@ -21,6 +21,7 @@ function readConfig() {
     caseId: env("TEMPO_BENCH_CASE", "transfer-with-memo"),
     workspace: env("TEMPO_BENCH_WORKSPACE", "/app"),
     logDir: env("TEMPO_BENCH_LOG_DIR", "/logs/verifier"),
+    artifactDir: env("TEMPO_BENCH_ARTIFACT_DIR", "/logs/artifacts"),
     rpcUrl: requiredEnv("TEMPO_RPC_URL"),
     token: requiredEnv("TEMPO_TOKEN"),
     feeToken: env("TEMPO_FEE_TOKEN", env("TEMPO_TOKEN")),

--- a/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/index.js
@@ -1,6 +1,6 @@
 // SYNCED FROM shared/tempo/verifier/src/index.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { readConfig, redactedConfig } = require("./config");
-const { writeJson, writeReward } = require("./logs");
+const { writeException, writeJson, writeReward } = require("./logs");
 const { assertSubmissionShape, runStep } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
@@ -100,7 +100,9 @@ async function main() {
     });
     writeReward(config, { reward: 1, ...scores });
   } catch (error) {
-    writeJson(config, "details.json", failureDetails(config, error, context, scores));
+    const details = failureDetails(config, error, context, scores);
+    writeJson(config, "details.json", details);
+    writeException(config, details);
     writeReward(config, { reward: 0, ...scores });
   }
 }

--- a/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/logs.js
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/logs.js
@@ -6,6 +6,10 @@ function ensureLogDir(config) {
   fs.mkdirSync(config.logDir, { recursive: true });
 }
 
+function ensureArtifactDir(config) {
+  fs.mkdirSync(config.artifactDir, { recursive: true });
+}
+
 function writeJson(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), `${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +18,35 @@ function writeJson(config, fileName, value) {
 function writeText(config, fileName, value) {
   ensureLogDir(config);
   fs.writeFileSync(path.join(config.logDir, fileName), value || "");
+}
+
+function writeArtifactText(config, fileName, value) {
+  ensureArtifactDir(config);
+  fs.writeFileSync(path.join(config.artifactDir, fileName), value || "");
+}
+
+function formatException(details) {
+  const lines = [
+    "Tempo verifier scored correctness 0.",
+    `phase: ${details.phase || "unknown"}`,
+    `reason: ${details.reason || "unknown"}`,
+    `expected: ${details.expected || "unknown"}`,
+    `observed: ${details.observed || "unknown"}`,
+    `scores: ${JSON.stringify(details.scores || {})}`,
+    "",
+    "logs:",
+  ];
+
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+  for (const log of logs) {
+    lines.push(`- /logs/verifier/${log}`);
+  }
+  lines.push("- /logs/verifier/details.json");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeException(config, details) {
+  writeArtifactText(config, "exception.txt", formatException(details));
 }
 
 function writeReward(config, scores) {
@@ -28,7 +61,10 @@ function writeReward(config, scores) {
 }
 
 module.exports = {
+  ensureArtifactDir,
   ensureLogDir,
+  writeArtifactText,
+  writeException,
   writeJson,
   writeReward,
   writeText,

--- a/tasks/tempo/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/test.sh
@@ -3,10 +3,11 @@
 set -u
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
+ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/tmp/tempo-bench-rewardkit}"
 REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
 REWARD_FILE="$LOG_DIR/reward.json"
@@ -15,6 +16,23 @@ REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
 TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
 rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
+rm -f "$ARTIFACT_DIR/exception.txt"
+
+write_exception_artifact() {
+  phase="$1"
+  reason="$2"
+  shift 2
+
+  {
+    printf 'Tempo task verifier could not produce a passing correctness score.\n'
+    printf 'phase: %s\n' "$phase"
+    printf 'reason: %s\n' "$reason"
+    printf '\nlogs:\n'
+    for log_file in "$@"; do
+      printf -- '- %s\n' "$log_file"
+    done
+  } > "$ARTIFACT_DIR/exception.txt"
+}
 
 skip_llm_quality() {
   reason="$1"
@@ -30,7 +48,7 @@ if [ -z "${ANTHROPIC_API_KEY:-}${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -f "$TESTS_DIR/
 fi
 
 write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" <<'PY'
+  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -38,7 +56,10 @@ from pathlib import Path
 details_path = Path(sys.argv[1])
 tempo_scores_path = Path(sys.argv[2])
 reward_path = Path(sys.argv[3])
+exception_path = Path(sys.argv[4])
 reward = 0
+details = None
+scores = None
 
 def score_of(value):
     if isinstance(value, dict):
@@ -47,18 +68,49 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def write_exception(reason):
+    exception_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "Tempo task verifier produced reward 0.",
+        f"reason: {reason}",
+        "",
+        "logs:",
+        f"- {details_path}",
+        f"- {tempo_scores_path}",
+    ]
+
+    if details:
+        lines.append("")
+        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
+
+    if scores:
+        lines.append("")
+        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
+
+    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+if tempo_scores_path.exists():
+    with tempo_scores_path.open(encoding="utf-8") as scores_file:
+        scores = json.load(scores_file)
+
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
     reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
-elif tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
+elif scores is not None:
     reward = 1 if int(scores.get("reward", 0)) == 1 else 0
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
     reward_file.write("\n")
+
+if reward == 0:
+    if details_path.exists():
+        write_exception("RewardKit correctness score was below 1.")
+    elif tempo_scores_path.exists():
+        write_exception("Tempo onchain verifier reward was below 1.")
+    else:
+        write_exception("No RewardKit details or Tempo score file was available.")
 PY
 }
 
@@ -70,6 +122,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! python3 -m venv "$REWARDKIT_VENV" \
     > "$LOG_DIR/rewardkit-venv.stdout.txt" \
     2> "$LOG_DIR/rewardkit-venv.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-venv" \
+      "python3 -m venv failed" \
+      "$LOG_DIR/rewardkit-venv.stdout.txt" \
+      "$LOG_DIR/rewardkit-venv.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -77,6 +134,11 @@ if [ ! -x "$REWARDKIT_PYTHON" ]; then
   if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'harbor-rewardkit==0.1.7' \
     > "$LOG_DIR/rewardkit-install.stdout.txt" \
     2> "$LOG_DIR/rewardkit-install.stderr.txt"; then
+    write_exception_artifact \
+      "rewardkit-install" \
+      "harbor-rewardkit install failed" \
+      "$LOG_DIR/rewardkit-install.stdout.txt" \
+      "$LOG_DIR/rewardkit-install.stderr.txt"
     write_zero_reward
     exit 0
   fi
@@ -96,10 +158,21 @@ if ! run_rewardkit; then
     skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
     rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
     if ! run_rewardkit; then
+      write_exception_artifact \
+        "rewardkit" \
+        "RewardKit failed after disabling the LLM quality reward" \
+        "$LOG_DIR/rewardkit.stdout.txt" \
+        "$LOG_DIR/rewardkit.stderr.txt" \
+        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
       write_binary_reward || write_zero_reward
       exit 0
     fi
   else
+    write_exception_artifact \
+      "rewardkit" \
+      "RewardKit failed" \
+      "$LOG_DIR/rewardkit.stdout.txt" \
+      "$LOG_DIR/rewardkit.stderr.txt"
     write_binary_reward || write_zero_reward
     exit 0
   fi


### PR DESCRIPTION
## Motivation

Tempo correctness failures can return a zero reward without a collected exception artifact, making it harder to identify why a trial failed from Harbor results.

## Summary

- Write `/logs/artifacts/exception.txt` for Tempo verifier setup failures, RewardKit correctness failures, and scored onchain verifier failures.
- Include concise failure context and pointers to existing verifier logs and score files.
- Sync generated Tempo task assets and refresh Tempo dataset digests.

## Key design considerations

- Keep verifier exit behavior unchanged so scored failures still produce reward 0 instead of trial exceptions.
- Use Harbor's zero-configuration artifact directory for collection across supported environments.
- Keep `exception.txt` concise and leave detailed diagnostics in existing JSON and stdout/stderr logs.