### PR TITLE
fix: restore tempo bench scoring

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -524,6 +524,7 @@ def apply_task_filter(
     for dataset in config.get("datasets", []):
         if dataset.get("path") in {"tasks", "tasks/tempo"}:
             dataset["task_names"] = filters
+            config["datasets"] = [dataset]
             return config
 
     msg = "Could not apply task filter to config"

--- a/shared/global/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/shared/global/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/shared/global/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/shared/global/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/shared/mpp/tests/test.sh
+++ b/shared/mpp/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/client-access-keys/tests/test.sh
+++ b/tasks/mpp/client-access-keys/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -10,37 +10,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:e601e8da8ce7edca3536c9aeab679bdaa999660debfbf369d413000c6d9c89a9"
+digest = "sha256:aab5003aeb949172a7ea252e6499a77f413f2b30c3e55862acdffa1a8efdf035"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:f9edab750422e6039894bbc2519c31940a3a2eef7bd99a78efbf224ed6079fa2"
+digest = "sha256:371db75aa2fc70b16222c8035574ca34b5e7ee6911faee32cfed82de8aa9a73c"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:c593030224370b3ea25f159726e4e80f74d552d2a29d9ca7af1f308348a50661"
+digest = "sha256:7dd58c6a35cd01d4f820af06aee1a9e1be7d6b25c5cc141e3d80cb8c9e01657b"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:ecc4a48f6b9f3a95f78b7a275aae5ba75cdd6fa73df3cd888943268195a0cb43"
+digest = "sha256:665080cb1701270c49f5068505c4058355189c3764db3266d3c7294b68ef7a53"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:ee4a70326ce09b7d27eddf0db27aa5c15de04bbb54637f25ee497093c1e57da9"
+digest = "sha256:22a8ccf2ed30950c94a344e306c1b5ba94cf606cb9c68db6c97a4dc6141e23cb"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:bcf3c0604c74c0ed1063babc160aaf86f36f99b11130651ed1c5438e609e7806"
+digest = "sha256:b50dee4ad3a8b4ffeed1709689fbe61963d53f61829b0826406bb2677a312b0d"
 
 [[tasks]]
 name = "tempo/mpp-client-access-keys"
-digest = "sha256:516171c29c165b4850de1dfb7194690bd7ea65fa8136378d9e2afd5479688df8"
+digest = "sha256:d1bd02a62436d34a531497f7ce07dcef81215b30b2142c44c816b86a2d9c3876"
 
 [[tasks]]
 name = "tempo/mpp-server-custom-payment-method"
-digest = "sha256:5d8da76f722907a6845aff1d277b93fd5ec398f27ee28075d1c13690067dc4f9"
+digest = "sha256:2c22ba18347cc2d34bfc6a857dccb0429e06261b2cea448f7428bf16c9e58125"
 
 [[tasks]]
 name = "tempo/mpp-server-mcp-pathusd"
-digest = "sha256:a7c4471ae713a2544249978dfc1eaf5eeb76c65f9b038cd89140ff4b276620b8"
+digest = "sha256:70870ae82c5ccd12caaff678aaf025d2be7095f137db7e194adb2731273a4f50"
 

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-charge-and-session/tests/test.sh
+++ b/tasks/mpp/server-charge-and-session/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-charge-pathusd-usdc/tests/test.sh
+++ b/tasks/mpp/server-charge-pathusd-usdc/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-charge-pathusd/tests/test.sh
+++ b/tasks/mpp/server-charge-pathusd/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-custom-payment-method/tests/test.sh
+++ b/tasks/mpp/server-custom-payment-method/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-discovery-endpoint/tests/test.sh
+++ b/tasks/mpp/server-discovery-endpoint/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-hono-charge-pathusd/tests/test.sh
+++ b/tasks/mpp/server-hono-charge-pathusd/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-mcp-pathusd/tests/test.sh
+++ b/tasks/mpp/server-mcp-pathusd/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,13 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.BUILD_SCRIPT,
-        name="package_has_build_script",
-    )
-    rk.file_contains_regex(
-        WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.RUN_SCRIPT,
-        name="package_has_run_script",
+        SourcePattern.EXAMPLE_SCRIPT,
+        name="package_has_example_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,6 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
+    EXAMPLE_SCRIPT = r'"example"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-x402-mpp-charges/tests/test.sh
+++ b/tasks/mpp/server-x402-mpp-charges/tests/test.sh
@@ -89,7 +89,8 @@ if ! "$REWARDKIT_PYTHON" -m pip install --quiet --no-cache-dir 'pympp[tempo]==0.
 fi
 
 run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
+  PYTHONPATH="$REWARDKIT_TESTS_DIR/support${PYTHONPATH:+:$PYTHONPATH}" \
+    "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
     --workspace "${TEMPO_BENCH_WORKSPACE:-/app}" \
     --output "$REWARDKIT_OUTPUT_FILE" \
     > "$LOG_DIR/rewardkit.stdout.txt" \

--- a/tasks/tempo/_templates/create-stablecoin-with-policy/instruction.md
+++ b/tasks/tempo/_templates/create-stablecoin-with-policy/instruction.md
@@ -5,8 +5,17 @@ creates a Tempo transfer policy, and links that policy to the new token.
 
 ## Parameters
 
-* Create the stablecoin with currency `TEMPO_STABLECOIN_CURRENCY`.
-* Create a TIP-403 policy of type `TEMPO_POLICY_TYPE` including `TEMPO_POLICY_ACCOUNT`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Stablecoin name | `TEMPO_STABLECOIN_NAME` | `Tempo Bench Policy USD` |
+| Stablecoin symbol | `TEMPO_STABLECOIN_SYMBOL` | `TBPUSD` |
+| Stablecoin currency | `TEMPO_STABLECOIN_CURRENCY` | `USD` |
+| Stablecoin salt | `TEMPO_STABLECOIN_SALT` | `0x0000000000000000000000000000000000000000000000000000000000000b01` |
+| Policy type | `TEMPO_POLICY_TYPE` | `blacklist` |
+| Policy account | `TEMPO_POLICY_ACCOUNT` | `0x1111111111111111111111111111111111111111` |
 
 <!-- tempobench_sync -->
 

--- a/tasks/tempo/_templates/faucet-funded-transfer/instruction.md
+++ b/tasks/tempo/_templates/faucet-funded-transfer/instruction.md
@@ -4,7 +4,14 @@ Build a minimal TypeScript project that funds a wallet with Tempo's faucet, then
 
 ## Parameters
 
-* Use `TEMPO_FAUCET_PRIVATE_KEY` for the wallet that calls the faucet.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.23` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Faucet wallet private key | `TEMPO_FAUCET_PRIVATE_KEY` | provided |
 
 <!-- tempobench_sync -->
 

--- a/tasks/tempo/_templates/set-fee-token/instruction.md
+++ b/tasks/tempo/_templates/set-fee-token/instruction.md
@@ -4,7 +4,11 @@ Build a minimal TypeScript project that sets the account's default Tempo fee tok
 
 ## Parameters
 
-* Use `TEMPO_FEE_TOKEN` as the fee token to set.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token to set | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 <!-- tempobench_sync -->
 

--- a/tasks/tempo/_templates/stablecoin-dex-swap/instruction.md
+++ b/tasks/tempo/_templates/stablecoin-dex-swap/instruction.md
@@ -4,7 +4,17 @@ Build a minimal TypeScript project that uses Tempo's Stablecoin DEX to execute a
 
 ## Parameters
 
-* Use `TEMPO_SWAP_TOKEN_IN` and `TEMPO_SWAP_TOKEN_OUT` for the swap pair.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Taker private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| DEX maker private key | `TEMPO_DEX_MAKER_PRIVATE_KEY` | provided |
+| Stablecoin DEX address | `TEMPO_STABLECOIN_DEX` | `0xdec0000000000000000000000000000000000000` |
+| Swap token in | `TEMPO_SWAP_TOKEN_IN` | `0x20c0000000000000000000000000000000000000` |
+| Swap token out | `TEMPO_SWAP_TOKEN_OUT` | `0x20c0000000000000000000000000000000000001` |
+| Swap amount in | `TEMPO_SWAP_AMOUNT_IN` | `100` |
+| Minimum amount out | `TEMPO_SWAP_MIN_AMOUNT_OUT` | `0` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
 
 <!-- tempobench_sync -->
 

--- a/tasks/tempo/_templates/transfer-with-memo-fee-payer/instruction.md
+++ b/tasks/tempo/_templates/transfer-with-memo-fee-payer/instruction.md
@@ -4,9 +4,17 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
-* Use `TEMPO_FEE_PAYER_PRIVATE_KEY` as the transaction fee payer.
-* Use `TEMPO_FEE_TOKEN` as the fee token.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.19` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-FEEPAYER-001` |
+| Fee payer private key | `TEMPO_FEE_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 <!-- tempobench_sync -->
 

--- a/tasks/tempo/_templates/transfer-with-memo/instruction.md
+++ b/tasks/tempo/_templates/transfer-with-memo/instruction.md
@@ -4,7 +4,15 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.17` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-EVAL-001` |
 
 <!-- tempobench_sync -->
 

--- a/tasks/tempo/create-stablecoin-with-policy-base/instruction.md
+++ b/tasks/tempo/create-stablecoin-with-policy-base/instruction.md
@@ -7,8 +7,17 @@ creates a Tempo transfer policy, and links that policy to the new token.
 
 ## Parameters
 
-* Create the stablecoin with currency `TEMPO_STABLECOIN_CURRENCY`.
-* Create a TIP-403 policy of type `TEMPO_POLICY_TYPE` including `TEMPO_POLICY_ACCOUNT`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Stablecoin name | `TEMPO_STABLECOIN_NAME` | `Tempo Bench Policy USD` |
+| Stablecoin symbol | `TEMPO_STABLECOIN_SYMBOL` | `TBPUSD` |
+| Stablecoin currency | `TEMPO_STABLECOIN_CURRENCY` | `USD` |
+| Stablecoin salt | `TEMPO_STABLECOIN_SALT` | `0x0000000000000000000000000000000000000000000000000000000000000b01` |
+| Policy type | `TEMPO_POLICY_TYPE` | `blacklist` |
+| Policy account | `TEMPO_POLICY_ACCOUNT` | `0x1111111111111111111111111111111111111111` |
 
 ## Execution Constraints
 

--- a/tasks/tempo/create-stablecoin-with-policy-docs/instruction.md
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/instruction.md
@@ -7,8 +7,17 @@ creates a Tempo transfer policy, and links that policy to the new token.
 
 ## Parameters
 
-* Create the stablecoin with currency `TEMPO_STABLECOIN_CURRENCY`.
-* Create a TIP-403 policy of type `TEMPO_POLICY_TYPE` including `TEMPO_POLICY_ACCOUNT`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Stablecoin name | `TEMPO_STABLECOIN_NAME` | `Tempo Bench Policy USD` |
+| Stablecoin symbol | `TEMPO_STABLECOIN_SYMBOL` | `TBPUSD` |
+| Stablecoin currency | `TEMPO_STABLECOIN_CURRENCY` | `USD` |
+| Stablecoin salt | `TEMPO_STABLECOIN_SALT` | `0x0000000000000000000000000000000000000000000000000000000000000b01` |
+| Policy type | `TEMPO_POLICY_TYPE` | `blacklist` |
+| Policy account | `TEMPO_POLICY_ACCOUNT` | `0x1111111111111111111111111111111111111111` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/instruction.md
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/instruction.md
@@ -7,8 +7,17 @@ creates a Tempo transfer policy, and links that policy to the new token.
 
 ## Parameters
 
-* Create the stablecoin with currency `TEMPO_STABLECOIN_CURRENCY`.
-* Create a TIP-403 policy of type `TEMPO_POLICY_TYPE` including `TEMPO_POLICY_ACCOUNT`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Stablecoin name | `TEMPO_STABLECOIN_NAME` | `Tempo Bench Policy USD` |
+| Stablecoin symbol | `TEMPO_STABLECOIN_SYMBOL` | `TBPUSD` |
+| Stablecoin currency | `TEMPO_STABLECOIN_CURRENCY` | `USD` |
+| Stablecoin salt | `TEMPO_STABLECOIN_SALT` | `0x0000000000000000000000000000000000000000000000000000000000000b01` |
+| Policy type | `TEMPO_POLICY_TYPE` | `blacklist` |
+| Policy account | `TEMPO_POLICY_ACCOUNT` | `0x1111111111111111111111111111111111111111` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -11,73 +11,73 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-base"
-digest = "sha256:a97a99006f5304ccaec8703f1797225aeab4b1f7c7a36214d0d6298fc40ce082"
+digest = "sha256:10e2c5e8098ff6efa3d2c492669a5b990d53c9aab11ca414065dbd48be0bf634"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:a0d97980cbf99b1a3714ebddbce0795acf25d9bd26e88e2619fee27ddcd18d2a"
+digest = "sha256:9b3757c365947c154b8b1b8f1a4ef85ee97891a0dbc390f2c29d9fd14f8ec6d2"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:1f7bae3c4ebd1031aca09ad0b52c954bf6fba02f4ccd1405fed04cc151014313"
+digest = "sha256:b08e8b1c8ccd9ceae5e9da0edf21636541dea99de4bb7dc87df7970b4a281167"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-base"
-digest = "sha256:b53ae4452661e081f2f37d5d1e595098be46cf0459d470adf89155883750efb0"
+digest = "sha256:106f614b28a448d43e4591fca33434212dec08ee8715bc0ff7d26f99c12149a7"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:728666a2a91cbac758bf8e9b3089cc52faa7b7c842b909af249d3f5181c8572e"
+digest = "sha256:643285d749cabedf42776208f55481ef5615b42fb5d6b7b566664a56bc1a9518"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:029167b7892c09a10e0edadec0c8517471479beee7e540ca79c15f59a375f49e"
+digest = "sha256:d5af3fbb6804afd3f5b8c8da198e03f2dfd0cdea01ace7a781e1cd06afc495cc"
 
 [[tasks]]
 name = "tempo/set-fee-token-base"
-digest = "sha256:e8122e8a238f78b767346c71847192c81428ab814c94bdf168a4eef0c2618ba3"
+digest = "sha256:79b2398d01bb17301243edc66e4571c13c772c019fad5cafb3141422874be30d"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:beda2f9c7af2027f524d25faa06fd612758e17506d8245e88bfef627a822b5d4"
+digest = "sha256:cb9b13c345ec440d19389383841485fdd98e1068d61b784f8c2790b547df63fc"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:bb45281327b2bd404ab2e8580abbf49250adafd3545b688465f1a1923a7538c1"
+digest = "sha256:7b1e9414517fc6f75ab8e12bb21e20ce6b922b83c23803f29f9b7babf2903585"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:52c0a552418163e58f4f0696438461d9bc38ffac0b6660e5678f4483969d1a6b"
+digest = "sha256:f2df1f33c46907ff9361b62933fb0fa4ebe4943e5abf7c8ba4f9fc1409549d39"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:966c8a05d62407c0947a9f2f4281b7333e02bfcbbe3bcb2e464a2eb8d932e970"
+digest = "sha256:f403f1b65b52c3d74e20689c87e4432bf5fad4f710b4bb6e1fb3685abeede453"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:019247a1231645bacccb58df20929790d8fcf296e0e0c8a1b5f3bdcd359cd13b"
+digest = "sha256:3b2d140f01b19a038a56904aabb04dd11010995d621f63a6d71bb112957b2475"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:6e5c3e6ae00b4067cc9688bd35503fcc5caaa4eb46d5477853c5899f23f6ec86"
+digest = "sha256:4fb82570f98a131228cabc0583968f3cd9e520aed359f424947b3874a202f05a"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:aa9fe514aaf9658517a3a1d8df61a8bfdaf365d1cea8d697bc47e1499581d6a6"
+digest = "sha256:06ddd4a1242003d197401fa724dcc04dd88e283752d8c34a6189731015c1228f"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:0c8cda711454e9752bb50d1dbd2b18c8aa5566137d5592b239b652991b9850bb"
+digest = "sha256:5f476b13379341f75c65da16789e0a92646b2972bc26b8d1eaa0088263a684ed"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:daf2e0d4722077d921fde420e83897e9dd8f2f64ff9441d444c46e3660ee57f8"
+digest = "sha256:72fdfe76d4d9289c219605d8887c9c8f3114411ff2861a6cc78858cd725b09eb"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:278b3196227d3a018777fa3e2d7c814057e462beb0274348cbdc93bd2e9a9cd0"
+digest = "sha256:a910da4c19a563832a31bb305bcdeb4a7dc75ad31b86875597b072646047b5e2"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:2ce33d605520160ec43223ff0f9e848a8bc50c0737332df33fe0200641315a18"
+digest = "sha256:21b871883f041eb5d78212675c0031981a0ef2482772a4f14d3aa38d5693756b"
 

--- a/tasks/tempo/faucet-funded-transfer-base/instruction.md
+++ b/tasks/tempo/faucet-funded-transfer-base/instruction.md
@@ -6,7 +6,14 @@ Build a minimal TypeScript project that funds a wallet with Tempo's faucet, then
 
 ## Parameters
 
-* Use `TEMPO_FAUCET_PRIVATE_KEY` for the wallet that calls the faucet.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.23` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Faucet wallet private key | `TEMPO_FAUCET_PRIVATE_KEY` | provided |
 
 ## Execution Constraints
 

--- a/tasks/tempo/faucet-funded-transfer-docs/instruction.md
+++ b/tasks/tempo/faucet-funded-transfer-docs/instruction.md
@@ -6,7 +6,14 @@ Build a minimal TypeScript project that funds a wallet with Tempo's faucet, then
 
 ## Parameters
 
-* Use `TEMPO_FAUCET_PRIVATE_KEY` for the wallet that calls the faucet.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.23` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Faucet wallet private key | `TEMPO_FAUCET_PRIVATE_KEY` | provided |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/faucet-funded-transfer-mcp/instruction.md
+++ b/tasks/tempo/faucet-funded-transfer-mcp/instruction.md
@@ -6,7 +6,14 @@ Build a minimal TypeScript project that funds a wallet with Tempo's faucet, then
 
 ## Parameters
 
-* Use `TEMPO_FAUCET_PRIVATE_KEY` for the wallet that calls the faucet.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.23` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Faucet wallet private key | `TEMPO_FAUCET_PRIVATE_KEY` | provided |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/set-fee-token-base/instruction.md
+++ b/tasks/tempo/set-fee-token-base/instruction.md
@@ -6,7 +6,11 @@ Build a minimal TypeScript project that sets the account's default Tempo fee tok
 
 ## Parameters
 
-* Use `TEMPO_FEE_TOKEN` as the fee token to set.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token to set | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 ## Execution Constraints
 

--- a/tasks/tempo/set-fee-token-docs/instruction.md
+++ b/tasks/tempo/set-fee-token-docs/instruction.md
@@ -6,7 +6,11 @@ Build a minimal TypeScript project that sets the account's default Tempo fee tok
 
 ## Parameters
 
-* Use `TEMPO_FEE_TOKEN` as the fee token to set.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token to set | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/set-fee-token-mcp/instruction.md
+++ b/tasks/tempo/set-fee-token-mcp/instruction.md
@@ -6,7 +6,11 @@ Build a minimal TypeScript project that sets the account's default Tempo fee tok
 
 ## Parameters
 
-* Use `TEMPO_FEE_TOKEN` as the fee token to set.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Fee token to set | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/stablecoin-dex-swap-base/instruction.md
+++ b/tasks/tempo/stablecoin-dex-swap-base/instruction.md
@@ -6,7 +6,17 @@ Build a minimal TypeScript project that uses Tempo's Stablecoin DEX to execute a
 
 ## Parameters
 
-* Use `TEMPO_SWAP_TOKEN_IN` and `TEMPO_SWAP_TOKEN_OUT` for the swap pair.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Taker private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| DEX maker private key | `TEMPO_DEX_MAKER_PRIVATE_KEY` | provided |
+| Stablecoin DEX address | `TEMPO_STABLECOIN_DEX` | `0xdec0000000000000000000000000000000000000` |
+| Swap token in | `TEMPO_SWAP_TOKEN_IN` | `0x20c0000000000000000000000000000000000000` |
+| Swap token out | `TEMPO_SWAP_TOKEN_OUT` | `0x20c0000000000000000000000000000000000001` |
+| Swap amount in | `TEMPO_SWAP_AMOUNT_IN` | `100` |
+| Minimum amount out | `TEMPO_SWAP_MIN_AMOUNT_OUT` | `0` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
 
 ## Execution Constraints
 

--- a/tasks/tempo/stablecoin-dex-swap-docs/instruction.md
+++ b/tasks/tempo/stablecoin-dex-swap-docs/instruction.md
@@ -6,7 +6,17 @@ Build a minimal TypeScript project that uses Tempo's Stablecoin DEX to execute a
 
 ## Parameters
 
-* Use `TEMPO_SWAP_TOKEN_IN` and `TEMPO_SWAP_TOKEN_OUT` for the swap pair.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Taker private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| DEX maker private key | `TEMPO_DEX_MAKER_PRIVATE_KEY` | provided |
+| Stablecoin DEX address | `TEMPO_STABLECOIN_DEX` | `0xdec0000000000000000000000000000000000000` |
+| Swap token in | `TEMPO_SWAP_TOKEN_IN` | `0x20c0000000000000000000000000000000000000` |
+| Swap token out | `TEMPO_SWAP_TOKEN_OUT` | `0x20c0000000000000000000000000000000000001` |
+| Swap amount in | `TEMPO_SWAP_AMOUNT_IN` | `100` |
+| Minimum amount out | `TEMPO_SWAP_MIN_AMOUNT_OUT` | `0` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/stablecoin-dex-swap-mcp/instruction.md
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/instruction.md
@@ -6,7 +6,17 @@ Build a minimal TypeScript project that uses Tempo's Stablecoin DEX to execute a
 
 ## Parameters
 
-* Use `TEMPO_SWAP_TOKEN_IN` and `TEMPO_SWAP_TOKEN_OUT` for the swap pair.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Taker private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| DEX maker private key | `TEMPO_DEX_MAKER_PRIVATE_KEY` | provided |
+| Stablecoin DEX address | `TEMPO_STABLECOIN_DEX` | `0xdec0000000000000000000000000000000000000` |
+| Swap token in | `TEMPO_SWAP_TOKEN_IN` | `0x20c0000000000000000000000000000000000000` |
+| Swap token out | `TEMPO_SWAP_TOKEN_OUT` | `0x20c0000000000000000000000000000000000001` |
+| Swap amount in | `TEMPO_SWAP_AMOUNT_IN` | `100` |
+| Minimum amount out | `TEMPO_SWAP_MIN_AMOUNT_OUT` | `0` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/transfer-with-memo-base/instruction.md
+++ b/tasks/tempo/transfer-with-memo-base/instruction.md
@@ -6,7 +6,15 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.17` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-EVAL-001` |
 
 ## Execution Constraints
 

--- a/tasks/tempo/transfer-with-memo-docs/instruction.md
+++ b/tasks/tempo/transfer-with-memo-docs/instruction.md
@@ -6,7 +6,15 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.17` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-EVAL-001` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/instruction.md
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/instruction.md
@@ -6,9 +6,17 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
-* Use `TEMPO_FEE_PAYER_PRIVATE_KEY` as the transaction fee payer.
-* Use `TEMPO_FEE_TOKEN` as the fee token.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.19` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-FEEPAYER-001` |
+| Fee payer private key | `TEMPO_FEE_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 ## Execution Constraints
 

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/instruction.md
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/instruction.md
@@ -6,9 +6,17 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
-* Use `TEMPO_FEE_PAYER_PRIVATE_KEY` as the transaction fee payer.
-* Use `TEMPO_FEE_TOKEN` as the fee token.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.19` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-FEEPAYER-001` |
+| Fee payer private key | `TEMPO_FEE_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/instruction.md
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/instruction.md
@@ -6,9 +6,17 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
-* Use `TEMPO_FEE_PAYER_PRIVATE_KEY` as the transaction fee payer.
-* Use `TEMPO_FEE_TOKEN` as the fee token.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.19` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-FEEPAYER-001` |
+| Fee payer private key | `TEMPO_FEE_PAYER_PRIVATE_KEY` | provided |
+| Fee token | `TEMPO_FEE_TOKEN` | `0x20c0000000000000000000000000000000000001` |
 
 ## Tempo Access Profile
 

--- a/tasks/tempo/transfer-with-memo-mcp/instruction.md
+++ b/tasks/tempo/transfer-with-memo-mcp/instruction.md
@@ -6,7 +6,15 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 
 ## Parameters
 
-* Read the transfer memo from `TEMPO_MEMO`.
+| Value | Env variable | Default |
+| --- | --- | --- |
+| RPC URL | `TEMPO_RPC_URL` | `http://tempo-localnet:8545` |
+| Payer private key | `TEMPO_PAYER_PRIVATE_KEY` | provided |
+| Token address | `TEMPO_TOKEN` | `0x20c0000000000000000000000000000000000001` |
+| Recipient address | `TEMPO_RECIPIENT` | `0x1111111111111111111111111111111111111111` |
+| Transfer amount | `TEMPO_AMOUNT` | `0.17` |
+| Token decimals | `TEMPO_DECIMALS` | `6` |
+| Transfer memo | `TEMPO_MEMO` | `TEMPO-EVAL-001` |
 
 ## Tempo Access Profile
 


### PR DESCRIPTION
## Motivation

Recent task contract drift caused benchmark runs to report binary zero even when oracle behavior was valid, and MPP verifier imports failed when support modules were loaded by RewardKit.

## Summary

- Align Tempo RewardKit project checks with the current `npm run example` task contract.
- Add the MPP verifier support directory to `PYTHONPATH` during RewardKit execution.
- Restrict focused task filters to the matched dataset so Tempo-only runs do not include MPP tasks.
- Clarify Tempo task prompts around required environment inputs and observable behavior, then regenerate variants and digests.

## Key design considerations

- Keep task prompts behavioral rather than prescribing exact import or API call shapes.
- Preserve generated task artifacts and dataset digests from the sync flow.
- Keep binary reward tied to objective verifier output, with RewardKit dimensions as diagnostics.
