### PR TITLE
fix: align Tempo eval script and weighted rewards

### DIFF
--- a/config/tasks.yaml
+++ b/config/tasks.yaml
@@ -78,9 +78,9 @@ execution_constraints: |
   ## Execution Constraints
 
   - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-  - Use that localnet RPC endpoint for all example and self-check commands.
+  - Use that localnet RPC endpoint for all eval and self-check commands.
   - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-  - Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+  - Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 # Generated task profiles (in addition to the implicit base profile). For
 # each generated task, `env` and `mcp_servers` are applied to task.toml,

--- a/shared/global/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/shared/global/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/shared/global/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/shared/global/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/shared/global/rewardkit/test.sh
+++ b/shared/global/rewardkit/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/shared/tempo/verifier/src/index.js
+++ b/shared/tempo/verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -10,37 +10,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:6b595c2c9eceaac1d29e7ec2c8d5bcec41c2a4e888436fcc45bd5b43f0e453f5"
+digest = "sha256:c5c054be4056dd64357fd18f5d41cddb5fb0ceb62376976809f855e8b77feb78"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:d6399b208a6a7d9ec900ddfc12e2e457e4c2e2c1b77c38847274fc9f212b740e"
+digest = "sha256:816288dc4d8813c3f02093fcb3181009b0bb1e02cf9fca06a4c71ebf3c3c9168"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:76be8f572296559cdb362a425d03501731a5ca38ec117764940858484fd9367e"
+digest = "sha256:91271b33fe0bade684938b4268bb66de2639fc20641f4310c58bc6ec46d34458"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:295cabfaf7e056eafa96d58468aa888bc261a2ed4caee5876111ab3c1c24c004"
+digest = "sha256:5d2c7c1a8204db8884eeb8af406a8c88758c847e65536980c8d339bbdef51435"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:78537d19bf1d1257d4174e8605e3cb64b95edbe41a662011fff4a26b6dca4ee8"
+digest = "sha256:6db1bc6e2aca3fcb03ff42655bbf797653cc8c99c95f9cf9468696e01f24cb35"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:163835b7c88a6419a5d12e1e4c6ea661a42a704a8eb7f9b5e44ee8f3a1566d2e"
+digest = "sha256:50a11869498ff01118d6889214837e7f2569be6d6032323920c528bd2d250ba2"
 
 [[tasks]]
 name = "tempo/mpp-client-access-keys"
-digest = "sha256:5b4781d5efc1e91e4f3f1cca7f9e991d704136926495c7815dd1bc72300796ab"
+digest = "sha256:3ceafb6171da8faedcaad5d475052abd38fad0677580c597270013d8884fbcf9"
 
 [[tasks]]
 name = "tempo/mpp-server-custom-payment-method"
-digest = "sha256:2ecee66c3d6946a2b4af6ce67511914eba313f8521124875aa9113ce096a3e9d"
+digest = "sha256:e8b390e77d943d9d422260d0b25884a86931b6e577edad950c192ae2b35e7bd2"
 
 [[tasks]]
 name = "tempo/mpp-server-mcp-pathusd"
-digest = "sha256:943358b5af3058d5aff1e7f04ccce8d10f4f475594ead7f60ed6a3e03e2a42b6"
+digest = "sha256:20f82121d71652c40879be1aaf983dd2c2175854d51bcf8981f35d8e78bfd0c2"
 

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -23,8 +23,8 @@ def register_tempo_typescript_project() -> None:
     rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
-        SourcePattern.EXAMPLE_SCRIPT,
-        name="package_has_example_script",
+        SourcePattern.EVAL_SCRIPT,
+        name="package_has_eval_script",
     )
     rk.file_contains_regex(
         WorkspaceFile.SOURCE_INDEX,

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/constants.py
@@ -49,7 +49,7 @@ class SourcePattern(StrEnum):
     """Regex patterns for lightweight source and contract checks."""
 
     BUILD_SCRIPT = r'"build"\s*:'
-    EXAMPLE_SCRIPT = r'"example"\s*:'
+    EVAL_SCRIPT = r'"eval"\s*:'
     RUN_SCRIPT = r'"run"\s*:'
     SERVE_SCRIPT = r'"serve"\s*:'
     MCP_SDK_DEPENDENCY = r'"@modelcontextprotocol/sdk"\s*:'

--- a/tasks/tempo/README.md
+++ b/tasks/tempo/README.md
@@ -33,9 +33,11 @@ Each generated task is Harbor-native and self-contained:
 - `tests/correctness/` contains the task's RewardKit criteria plus the e2e
   command criterion. `tests/quality/` contains non-binary turn/token
   efficiency checks and the Claude Haiku LLM judge. `tests/test.sh` writes
-  Harbor's primary `/logs/verifier/reward.json` as a single binary `reward`
-  key from the independent Tempo verifier's build/run/onchain result;
-  RewardKit correctness and quality dimensions are diagnostic.
+  Harbor's primary `/logs/verifier/reward.json` from the RewardKit
+  correctness score, gated by the independent Tempo onchain verifier. A task
+  receives zero reward unless `tempo_onchain_verifier` passes; after that,
+  static correctness criteria contribute weighted partial credit instead of
+  requiring every criterion to pass. Quality dimensions remain diagnostic.
   `tests/tempo-bench-verifier/` is a minimal copied verifier package for the
   selected `TEMPO_BENCH_CASE`.
 - `solution/` contains the oracle solution used for sanity checks.

--- a/tasks/tempo/_templates/create-stablecoin-with-policy/instruction.md
+++ b/tasks/tempo/_templates/create-stablecoin-with-policy/instruction.md
@@ -23,4 +23,4 @@ Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/_templates/create-stablecoin-with-policy/solution/package.json
+++ b/tasks/tempo/_templates/create-stablecoin-with-policy/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/_templates/faucet-funded-transfer/instruction.md
+++ b/tasks/tempo/_templates/faucet-funded-transfer/instruction.md
@@ -19,4 +19,4 @@ Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/_templates/faucet-funded-transfer/solution/package.json
+++ b/tasks/tempo/_templates/faucet-funded-transfer/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/_templates/set-fee-token/instruction.md
+++ b/tasks/tempo/_templates/set-fee-token/instruction.md
@@ -16,4 +16,4 @@ Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/_templates/set-fee-token/solution/package.json
+++ b/tasks/tempo/_templates/set-fee-token/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/_templates/stablecoin-dex-swap/instruction.md
+++ b/tasks/tempo/_templates/stablecoin-dex-swap/instruction.md
@@ -22,4 +22,4 @@ Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/_templates/stablecoin-dex-swap/solution/package.json
+++ b/tasks/tempo/_templates/stablecoin-dex-swap/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/_templates/transfer-with-memo-fee-payer/instruction.md
+++ b/tasks/tempo/_templates/transfer-with-memo-fee-payer/instruction.md
@@ -22,4 +22,4 @@ Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/_templates/transfer-with-memo-fee-payer/solution/package.json
+++ b/tasks/tempo/_templates/transfer-with-memo-fee-payer/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/_templates/transfer-with-memo/instruction.md
+++ b/tasks/tempo/_templates/transfer-with-memo/instruction.md
@@ -20,4 +20,4 @@ Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/_templates/transfer-with-memo/solution/package.json
+++ b/tasks/tempo/_templates/transfer-with-memo/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/create-stablecoin-with-policy-base/instruction.md
+++ b/tasks/tempo/create-stablecoin-with-policy-base/instruction.md
@@ -22,12 +22,12 @@ creates a Tempo transfer policy, and links that policy to the new token.
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/create-stablecoin-with-policy-base/solution/package.json
+++ b/tasks/tempo/create-stablecoin-with-policy-base/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/create-stablecoin-with-policy-docs/instruction.md
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/instruction.md
@@ -26,12 +26,12 @@ Tempo docs are available through the local docs service at `TEMPO_DOCS_URL` (htt
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/create-stablecoin-with-policy-docs/solution/package.json
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/instruction.md
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/instruction.md
@@ -26,12 +26,12 @@ The official Tempo MCP server is configured as `tempo`. Use it if your agent run
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/solution/package.json
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -11,73 +11,73 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-base"
-digest = "sha256:a3c5bb65b9ee7a5205b54aa6b8c6bd27dd57a51660f88ade8984ca24d17e6842"
+digest = "sha256:836bf9c3ccff992625ed54f598058af80e60143412e9443193aba09572018bf3"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:df617ae2f32367b08659a1ed176050ac9c7a68265df9cb39926e9cd7b096e605"
+digest = "sha256:b59a8220edf364fa81fdbe1baa9dc8ff5ac5240841225b2375c37a37d6e8773e"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:570775c60181e7682e64864995a06943cdfb2a501dfe73466f34c48d22e784a2"
+digest = "sha256:8925e44fe472a29235fb5a1070d197838cd726c677b8148c94ef3182169d5615"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-base"
-digest = "sha256:38b0053be4c74cb2d144d7933177307ad6be5056f428710b3299c1f48a956e9c"
+digest = "sha256:48b38719871c88942352c089123976cc9d7dc6951b4292b57e30f4ecd87cd137"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:2b404ebb5efa8552454116e259a299f6ae5f7c1331cf6e30e7d15a1d52bbcca4"
+digest = "sha256:7b442bdee44cfa6b574af37f497ffbe585d36d7f02a24461f54d2fc1b65e893f"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:0281ffc593291b8fec7d540b2c8c7c9b4ee3b12d5c499192869ed99829ed653e"
+digest = "sha256:e02310bb8fac4cb0ac753a9beb8e85dafc10238d48f8c7e850883effb051a6e2"
 
 [[tasks]]
 name = "tempo/set-fee-token-base"
-digest = "sha256:b5f2cd5f331290e5a0ee95416dd8f1b6b03494b0f9bd0e54b323f383bdd9f77e"
+digest = "sha256:62b2aa0f04d21650d97af3a2c9ec46a7d8718ff4ba9a234c8cd261f9a810167e"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:204c4aa0e1cb318fa18f4384edb4a3a377f69a2f68a27856c0e08607202f359a"
+digest = "sha256:bd449bde0d835b979d7fa163d17d0a3e0b3aaf9054b6ad749d65e9767c75c278"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:c13234882ca13bf469f8a03afd922e87a458615e0690cd728caf1a49f3e2a8f3"
+digest = "sha256:64ea36c88bb7b64e1d58bf879eb55813de68aeec433ed3ee314862414dc70202"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:9baf3151308a6cccd35565bceb98309a2f6fb33067a4a5989ad912c148e3bdcf"
+digest = "sha256:444bc3bf3acf4aa4d7b37e0849cb54f4f058f6d9c8b7d6b5b726bbeddf8b7e65"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:894bab61a83d321671ed1b0c06cd083ef00e892035f63158b254912773ab502d"
+digest = "sha256:cf917a8dac0013cd7a3970f0f6e781033bfbe29247ec420f93c2b56f80be2324"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:af3e1affb793a9b9df6f1f7d1f639b40b10802cbbdbc442fbff542a4dc8e04c4"
+digest = "sha256:4a93aa8cb28e0b6599b0ce99a8bc46bde08804ad7893de44d4e8f54e0a67543c"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:83541cabddb031ffba8cd2cd73efc0c0b8be83dd8ad5d13eef7f618185839b48"
+digest = "sha256:ab9cdd94e8c9c07cd44330d8c835893526bbd7bfbbfbc6dcb3b8d155fdfef8a1"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:93cd842719f4ed7ad751d782a8a186bd0bc4350cae5a181fca5456f8dfa8c690"
+digest = "sha256:c1a3fd507b8bb2556ccf51e030605cfb81c244392a141e53a87cb8c909c8180d"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:eb63ae80b1e8497a11e4544ddbadf8383ebbbae32ff53217987e4edd38e0f5a9"
+digest = "sha256:66696109fd08d86040776935fd2f505056fc45950574fec5c82540e9a6b88aa1"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:4c433ff4c3265fd1040c393ac15c34fcb7dd698e19b3a6ea104a844960bfa93a"
+digest = "sha256:5b9ff1db070421d8879872684dfe56a1abe163f4ccf0a743efe429069ac09121"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:5aab7fa38840dbe0ee1d4a837fb74c705a15c8684ed27554f82c380a7835938c"
+digest = "sha256:ff48ce26675c475a89b6bcde2aef08f1b371dfba77294588a77df62c54776466"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:63d33dfca02666425fc6b00692fa469e5a6935255d4243b78b9d00aa3943f640"
+digest = "sha256:5cd48fbd3786ea61d4bb15f3c1fee695445ca9123d6ad7c9640ef4356059e1d5"
 

--- a/tasks/tempo/faucet-funded-transfer-base/instruction.md
+++ b/tasks/tempo/faucet-funded-transfer-base/instruction.md
@@ -18,12 +18,12 @@ Build a minimal TypeScript project that funds a wallet with Tempo's faucet, then
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/faucet-funded-transfer-base/solution/package.json
+++ b/tasks/tempo/faucet-funded-transfer-base/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/faucet-funded-transfer-base/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/faucet-funded-transfer-docs/instruction.md
+++ b/tasks/tempo/faucet-funded-transfer-docs/instruction.md
@@ -22,12 +22,12 @@ Tempo docs are available through the local docs service at `TEMPO_DOCS_URL` (htt
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/faucet-funded-transfer-docs/solution/package.json
+++ b/tasks/tempo/faucet-funded-transfer-docs/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/faucet-funded-transfer-mcp/instruction.md
+++ b/tasks/tempo/faucet-funded-transfer-mcp/instruction.md
@@ -22,12 +22,12 @@ The official Tempo MCP server is configured as `tempo`. Use it if your agent run
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/faucet-funded-transfer-mcp/solution/package.json
+++ b/tasks/tempo/faucet-funded-transfer-mcp/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/set-fee-token-base/instruction.md
+++ b/tasks/tempo/set-fee-token-base/instruction.md
@@ -15,12 +15,12 @@ Build a minimal TypeScript project that sets the account's default Tempo fee tok
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/set-fee-token-base/solution/package.json
+++ b/tasks/tempo/set-fee-token-base/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/set-fee-token-base/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/set-fee-token-base/tests/test.sh
+++ b/tasks/tempo/set-fee-token-base/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/set-fee-token-docs/instruction.md
+++ b/tasks/tempo/set-fee-token-docs/instruction.md
@@ -19,12 +19,12 @@ Tempo docs are available through the local docs service at `TEMPO_DOCS_URL` (htt
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/set-fee-token-docs/solution/package.json
+++ b/tasks/tempo/set-fee-token-docs/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/set-fee-token-docs/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/set-fee-token-docs/tests/test.sh
+++ b/tasks/tempo/set-fee-token-docs/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/set-fee-token-mcp/instruction.md
+++ b/tasks/tempo/set-fee-token-mcp/instruction.md
@@ -19,12 +19,12 @@ The official Tempo MCP server is configured as `tempo`. Use it if your agent run
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/set-fee-token-mcp/solution/package.json
+++ b/tasks/tempo/set-fee-token-mcp/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/set-fee-token-mcp/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/set-fee-token-mcp/tests/test.sh
+++ b/tasks/tempo/set-fee-token-mcp/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/stablecoin-dex-swap-base/instruction.md
+++ b/tasks/tempo/stablecoin-dex-swap-base/instruction.md
@@ -21,12 +21,12 @@ Build a minimal TypeScript project that uses Tempo's Stablecoin DEX to execute a
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/stablecoin-dex-swap-base/solution/package.json
+++ b/tasks/tempo/stablecoin-dex-swap-base/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/stablecoin-dex-swap-docs/instruction.md
+++ b/tasks/tempo/stablecoin-dex-swap-docs/instruction.md
@@ -25,12 +25,12 @@ Tempo docs are available through the local docs service at `TEMPO_DOCS_URL` (htt
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/stablecoin-dex-swap-docs/solution/package.json
+++ b/tasks/tempo/stablecoin-dex-swap-docs/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/stablecoin-dex-swap-mcp/instruction.md
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/instruction.md
@@ -25,12 +25,12 @@ The official Tempo MCP server is configured as `tempo`. Use it if your agent run
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/stablecoin-dex-swap-mcp/solution/package.json
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/transfer-with-memo-base/instruction.md
+++ b/tasks/tempo/transfer-with-memo-base/instruction.md
@@ -19,12 +19,12 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/transfer-with-memo-base/solution/package.json
+++ b/tasks/tempo/transfer-with-memo-base/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-base/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/transfer-with-memo-base/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-base/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/transfer-with-memo-docs/instruction.md
+++ b/tasks/tempo/transfer-with-memo-docs/instruction.md
@@ -23,12 +23,12 @@ Tempo docs are available through the local docs service at `TEMPO_DOCS_URL` (htt
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/transfer-with-memo-docs/solution/package.json
+++ b/tasks/tempo/transfer-with-memo-docs/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-docs/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/transfer-with-memo-docs/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-docs/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/instruction.md
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/instruction.md
@@ -21,12 +21,12 @@ Build a minimal TypeScript project that sends a Tempo stablecoin payment with a 
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/solution/package.json
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/instruction.md
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/instruction.md
@@ -25,12 +25,12 @@ Tempo docs are available through the local docs service at `TEMPO_DOCS_URL` (htt
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/solution/package.json
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/instruction.md
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/instruction.md
@@ -25,12 +25,12 @@ The official Tempo MCP server is configured as `tempo`. Use it if your agent run
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/solution/package.json
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:

--- a/tasks/tempo/transfer-with-memo-mcp/instruction.md
+++ b/tasks/tempo/transfer-with-memo-mcp/instruction.md
@@ -23,12 +23,12 @@ The official Tempo MCP server is configured as `tempo`. Use it if your agent run
 ## Execution Constraints
 
 - `TEMPO_RPC_URL` is already set to the Tempo localnet RPC endpoint (`http://tempo-localnet:8545`).
-- Use that localnet RPC endpoint for all example and self-check commands.
+- Use that localnet RPC endpoint for all eval and self-check commands.
 - Do not hard-code or call public Tempo RPC endpoints such as Moderato/testnet.
-- Do not run live testnet smoke tests; local example checks must use the provided environment variables.
+- Do not run live testnet smoke tests; local eval checks must use the provided environment variables.
 
 Requirements:
 
 * Put the submission directly in `/app`.
 * Put the runtime source in `src/index.ts`.
-* The script should be runnable by `npm run example`
+* The script should be runnable by `npm run eval`

--- a/tasks/tempo/transfer-with-memo-mcp/solution/package.json
+++ b/tasks/tempo/transfer-with-memo-mcp/solution/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "example": "tsx src/index.ts"
+    "eval": "tsx src/index.ts"
   },
   "dependencies": {
     "@types/node": "^22.15.30",

--- a/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/index.js
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/tempo-bench-verifier/src/index.js
@@ -66,19 +66,19 @@ async function main() {
     };
     runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
     context = {
-      phase: "submission-example",
-      expected: "npm run example exits 0",
+      phase: "submission-eval",
+      expected: "npm run eval exits 0",
       logs: [
-        "submission-example.stdout.txt",
-        "submission-example.stderr.txt",
-        "submission-example.status.json",
+        "submission-eval.stdout.txt",
+        "submission-eval.stderr.txt",
+        "submission-eval.status.json",
       ],
     };
     runStep(
       config,
-      "submission-example",
+      "submission-eval",
       "npm",
-      ["run", "example"],
+      ["run", "eval"],
       verifier.runtimeEnv(config),
     );
     scores.build = 1;

--- a/tasks/tempo/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/test.sh
@@ -103,6 +103,18 @@ def score_of(value):
         return min((score_of(item) for item in value), default=0.0)
     return float(value or 0)
 
+def criterion_passed(value, name):
+    if isinstance(value, dict):
+        if value.get("name") == name:
+            raw = value.get("raw", value.get("value", 0))
+            if isinstance(raw, bool):
+                return raw
+            return float(value.get("value", raw or 0)) > 0
+        return any(criterion_passed(item, name) for item in value.get("criteria", []))
+    if isinstance(value, list):
+        return any(criterion_passed(item, name) for item in value)
+    return False
+
 def write_exception(reason):
     exception_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
@@ -131,9 +143,11 @@ if tempo_scores_path.exists():
 if details_path.exists():
     with details_path.open(encoding="utf-8") as details_file:
         details = json.load(details_file)
-    reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
+    correctness = details.get("correctness", 0)
+    if criterion_passed(correctness, "tempo_onchain_verifier"):
+        reward = score_of(correctness)
 elif scores is not None:
-    reward = 1 if int(scores.get("reward", 0)) == 1 else 0
+    reward = float(scores.get("reward", 0))
 
 with reward_path.open("w", encoding="utf-8") as reward_file:
     json.dump({"reward": reward}, reward_file, separators=(",", ":"))
@@ -141,7 +155,7 @@ with reward_path.open("w", encoding="utf-8") as reward_file:
 
 if reward == 0:
     if details_path.exists():
-        write_exception("RewardKit correctness score was below 1.")
+        write_exception("Tempo onchain verifier criterion did not pass.")
     elif tempo_scores_path.exists():
         write_exception("Tempo onchain verifier reward was below 1.")
     else:


### PR DESCRIPTION
## Motivation

Tempo tasks should consistently ask agents to expose `npm run eval`, and rewards should recognize weighted correctness once a solution has passed the onchain verifier.

## Summary

- Rename Tempo task runtime scripts from `example` to `eval` across instructions, oracle solutions, and the verifier.
- Update RewardKit static checks to require `package_has_eval_script`.
- Change Tempo reward finalization to gate on `tempo_onchain_verifier` and then emit the weighted correctness score.
- Regenerate Tempo task variants, synced RewardKit package copies, and dataset digests.

## Key design considerations

- Onchain evidence remains the hard gate for positive reward, while static criteria influence the fractional score instead of requiring a perfect score.