### PR TITLE
refactor: remove strict file-structure checks from task graders

### DIFF
--- a/shared/global/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/shared/global/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/client-access-keys/tests/correctness/criteria.py
+++ b/tasks/mpp/client-access-keys/tests/correctness/criteria.py
@@ -6,9 +6,6 @@ from tempo_bench_rewardkit.common.constants import (
     WorkspaceFile,
 )
 
-rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-rk.file_exists(WorkspaceFile.SOURCE_INDEX)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.RUN_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -10,37 +10,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:c5c054be4056dd64357fd18f5d41cddb5fb0ceb62376976809f855e8b77feb78"
+digest = "sha256:53bed50bd09d8246d4c1bc060196a9031dd2e13edd2d6ec33b96878167b9a01d"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:816288dc4d8813c3f02093fcb3181009b0bb1e02cf9fca06a4c71ebf3c3c9168"
+digest = "sha256:3a46746e7af21aef67c61c3247011eb9e086f5eb542c2c771aefeea7b8442c29"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:91271b33fe0bade684938b4268bb66de2639fc20641f4310c58bc6ec46d34458"
+digest = "sha256:2b7419d4a63beb28b5e5bac9271f565278ee33e984c64e3323be03d48d1a009a"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:5d2c7c1a8204db8884eeb8af406a8c88758c847e65536980c8d339bbdef51435"
+digest = "sha256:6d1bec6057db0f7aa22ddb5a1412f6211f39386c420d50712dd511c150bbf2d3"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:6db1bc6e2aca3fcb03ff42655bbf797653cc8c99c95f9cf9468696e01f24cb35"
+digest = "sha256:45c98ace7a113f595bf92c0570c107db9b79be4decbae2faaf7ce93b9fb4733c"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:50a11869498ff01118d6889214837e7f2569be6d6032323920c528bd2d250ba2"
+digest = "sha256:df2e3760175b06d6ecdbe802218d9a5baa088a97d31901528647664bd068bde8"
 
 [[tasks]]
 name = "tempo/mpp-client-access-keys"
-digest = "sha256:3ceafb6171da8faedcaad5d475052abd38fad0677580c597270013d8884fbcf9"
+digest = "sha256:45a5a1c2fb826fb64ab5c495c44497b198612c1f593110788f4de458f9bef56f"
 
 [[tasks]]
 name = "tempo/mpp-server-custom-payment-method"
-digest = "sha256:e8b390e77d943d9d422260d0b25884a86931b6e577edad950c192ae2b35e7bd2"
+digest = "sha256:b57f13b01c74395f2189485f18f1c9a66e053cce941a828e905619de7cde39b9"
 
 [[tasks]]
 name = "tempo/mpp-server-mcp-pathusd"
-digest = "sha256:20f82121d71652c40879be1aaf983dd2c2175854d51bcf8981f35d8e78bfd0c2"
+digest = "sha256:598894688d876e0520526e03912417d6405f646dd9ff85ea5b6a14facd40bcd7"
 

--- a/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-and-session/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/server-charge-and-session/tests/correctness/criteria.py
+++ b/tasks/mpp/server-charge-and-session/tests/correctness/criteria.py
@@ -15,9 +15,6 @@ OUT_PATH = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 
 # Shared checks stay local so each Harbor task is self-contained.
 def check_common_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/server-charge-pathusd-usdc/tests/correctness/criteria.py
+++ b/tasks/mpp/server-charge-pathusd-usdc/tests/correctness/criteria.py
@@ -15,9 +15,6 @@ OUT_PATH = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 
 # Shared checks stay local so each Harbor task is self-contained.
 def check_common_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/server-charge-pathusd/tests/correctness/criteria.py
+++ b/tasks/mpp/server-charge-pathusd/tests/correctness/criteria.py
@@ -14,9 +14,6 @@ out_path = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 # {"freeUrl":"http://127.0.0.1:3000/free","paidUrl":"http://127.0.0.1:3000/paid"}
 
 # App correctness and structure
-rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-rk.file_exists(WorkspaceFile.SOURCE_INDEX)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/server-custom-payment-method/tests/correctness/criteria.py
+++ b/tasks/mpp/server-custom-payment-method/tests/correctness/criteria.py
@@ -11,9 +11,6 @@ from tempo_bench_rewardkit.common.constants import (
 out_path = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 
 # App correctness and structure
-rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-rk.file_exists(WorkspaceFile.SOURCE_INDEX)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-discovery-endpoint/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/server-discovery-endpoint/tests/correctness/criteria.py
+++ b/tasks/mpp/server-discovery-endpoint/tests/correctness/criteria.py
@@ -15,9 +15,6 @@ OUT_PATH = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 
 # Shared checks stay local so each Harbor task is self-contained.
 def check_common_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-hono-charge-pathusd/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/server-hono-charge-pathusd/tests/correctness/criteria.py
+++ b/tasks/mpp/server-hono-charge-pathusd/tests/correctness/criteria.py
@@ -15,9 +15,6 @@ OUT_PATH = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 
 # Shared checks stay local so each Harbor task is self-contained.
 def check_common_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/mpp/server-mcp-pathusd/tests/correctness/criteria.py
+++ b/tasks/mpp/server-mcp-pathusd/tests/correctness/criteria.py
@@ -5,9 +5,6 @@ from tempo_bench_rewardkit.common.constants import (
     WorkspaceFile,
 )
 
-rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-rk.file_exists(WorkspaceFile.SOURCE_INDEX)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
 rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MCP_SDK_DEPENDENCY)

--- a/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
+++ b/tasks/mpp/server-x402-mpp-charges/environment/rewardkit-package/tempo_bench_rewardkit/common/checks.py
@@ -17,10 +17,7 @@ class TokenEfficiencyConfig:
     weight: float = 1.0
 
 
-def register_tempo_typescript_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON, name="package_json_exists")
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON, name="tsconfig_json_exists")
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX, name="src_index_ts_exists")
+def register_tempo_eval_contract() -> None:
     rk.file_contains_regex(
         WorkspaceFile.PACKAGE_JSON,
         SourcePattern.EVAL_SCRIPT,

--- a/tasks/mpp/server-x402-mpp-charges/tests/correctness/criteria.py
+++ b/tasks/mpp/server-x402-mpp-charges/tests/correctness/criteria.py
@@ -15,9 +15,6 @@ OUT_PATH = WORKSPACE_PATH / WorkspaceFile.OUT_JSON
 
 # Shared checks stay local so each Harbor task is self-contained.
 def check_common_project() -> None:
-    rk.file_exists(WorkspaceFile.PACKAGE_JSON)
-    rk.file_exists(WorkspaceFile.TSCONFIG_JSON)
-    rk.file_exists(WorkspaceFile.SOURCE_INDEX)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.BUILD_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.SERVE_SCRIPT)
     rk.file_contains_regex(WorkspaceFile.PACKAGE_JSON, SourcePattern.MPPX_DEPENDENCY)

--- a/tasks/tempo/_templates/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -1,10 +1,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     [

--- a/tasks/tempo/_templates/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/faucet-funded-transfer/tests/correctness/criteria.py
@@ -1,10 +1,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/_templates/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/set-fee-token/tests/correctness/criteria.py
@@ -1,10 +1,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["fee.setUserToken"],

--- a/tasks/tempo/_templates/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -1,10 +1,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.approveSync", "dex.placeSync"],

--- a/tasks/tempo/_templates/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -1,10 +1,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/_templates/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/tempo/_templates/transfer-with-memo/tests/correctness/criteria.py
@@ -1,10 +1,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(["token.transferSync"])
 register_source_patterns(

--- a/tasks/tempo/create-stablecoin-with-policy-base/tests/correctness/criteria.py
+++ b/tasks/tempo/create-stablecoin-with-policy-base/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     [

--- a/tasks/tempo/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/create-stablecoin-with-policy-docs/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     [

--- a/tasks/tempo/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     [

--- a/tasks/tempo/dataset.toml
+++ b/tasks/tempo/dataset.toml
@@ -11,73 +11,73 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-base"
-digest = "sha256:836bf9c3ccff992625ed54f598058af80e60143412e9443193aba09572018bf3"
+digest = "sha256:daa67e3eba478951ab6e180e1ee349c523e8a324d6ea7d47deedc0f0cccb312d"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-docs"
-digest = "sha256:b59a8220edf364fa81fdbe1baa9dc8ff5ac5240841225b2375c37a37d6e8773e"
+digest = "sha256:f26cdc05626b6210d972d8dba48b5f324ef406403aca223ad10bbd94e8d4c4b0"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:8925e44fe472a29235fb5a1070d197838cd726c677b8148c94ef3182169d5615"
+digest = "sha256:8cdeb85170e7430d44309ca684026cb6a9f3f38aec6f0af90c77efae21bfcadb"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-base"
-digest = "sha256:48b38719871c88942352c089123976cc9d7dc6951b4292b57e30f4ecd87cd137"
+digest = "sha256:0309cd52ca2e22d1052b34678b12f23ba89342e74bb13ed4c2a0e225a380cccd"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-docs"
-digest = "sha256:7b442bdee44cfa6b574af37f497ffbe585d36d7f02a24461f54d2fc1b65e893f"
+digest = "sha256:62e1b539599028754bd1a32ca5c4c8600bc723fbc6f5f57080c3442d4a4aa9f2"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:e02310bb8fac4cb0ac753a9beb8e85dafc10238d48f8c7e850883effb051a6e2"
+digest = "sha256:7f68d919fab21a6e142653ea021e16c35b3b0564cc48618df5cc35ae6e43af04"
 
 [[tasks]]
 name = "tempo/set-fee-token-base"
-digest = "sha256:62b2aa0f04d21650d97af3a2c9ec46a7d8718ff4ba9a234c8cd261f9a810167e"
+digest = "sha256:76da086608475946f69f7bdbcdad1342707d9460c964df4d253f0764e5daced5"
 
 [[tasks]]
 name = "tempo/set-fee-token-docs"
-digest = "sha256:bd449bde0d835b979d7fa163d17d0a3e0b3aaf9054b6ad749d65e9767c75c278"
+digest = "sha256:1299fb4ba3bf1aed3f88b22b5b5d854876078bbb2e47bfd2dfea5226981ff4ab"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:64ea36c88bb7b64e1d58bf879eb55813de68aeec433ed3ee314862414dc70202"
+digest = "sha256:e5e3c6a12e1cd877d15a7ea89f206a0bad4544327dd193ebfdb3b2575503fcc1"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-base"
-digest = "sha256:444bc3bf3acf4aa4d7b37e0849cb54f4f058f6d9c8b7d6b5b726bbeddf8b7e65"
+digest = "sha256:50c603ab71b784c68887fa8c6b0a9f5727ab9d5ace6c300e9d349ae5d8480dff"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-docs"
-digest = "sha256:cf917a8dac0013cd7a3970f0f6e781033bfbe29247ec420f93c2b56f80be2324"
+digest = "sha256:289596ef90dfa88e249adc576eed5f75fa8b4c34dd9bc0f580d74eccf3b202b6"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:4a93aa8cb28e0b6599b0ce99a8bc46bde08804ad7893de44d4e8f54e0a67543c"
+digest = "sha256:4b2f6213224ddcb624121bd459913bcb8bb0e73a25f94ab5837a74bc3d83516f"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-base"
-digest = "sha256:ab9cdd94e8c9c07cd44330d8c835893526bbd7bfbbfbc6dcb3b8d155fdfef8a1"
+digest = "sha256:bcf9a8074caf3553336a47e935286152ef1efe082fa7448d1f16c45a9e49902d"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-docs"
-digest = "sha256:c1a3fd507b8bb2556ccf51e030605cfb81c244392a141e53a87cb8c909c8180d"
+digest = "sha256:462953e1c7096aa338aa763d09cb7b4ecf7b54d2d134bb016ca9aea3310182ab"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:66696109fd08d86040776935fd2f505056fc45950574fec5c82540e9a6b88aa1"
+digest = "sha256:0e09cd3d1d87f7de9baf7bc34c8dd4bb3c94568359b5af2966287967568f6ef2"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-base"
-digest = "sha256:5b9ff1db070421d8879872684dfe56a1abe163f4ccf0a743efe429069ac09121"
+digest = "sha256:1f9b5c0012748ece41484cd3cfb2fc65774bded7c6ab9f0409217feee40efc35"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-docs"
-digest = "sha256:ff48ce26675c475a89b6bcde2aef08f1b371dfba77294588a77df62c54776466"
+digest = "sha256:d503f52923018cba7772b651c37e171a1ea4c65e2085f2c99e7075dbca3fb39f"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:5cd48fbd3786ea61d4bb15f3c1fee695445ca9123d6ad7c9640ef4356059e1d5"
+digest = "sha256:43437f1352fa0df33b4368a16528e5c7a149a1ee6b69f63d662cc489c259e595"
 

--- a/tasks/tempo/faucet-funded-transfer-base/tests/correctness/criteria.py
+++ b/tasks/tempo/faucet-funded-transfer-base/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/faucet-funded-transfer-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/faucet-funded-transfer-docs/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/set-fee-token-base/tests/correctness/criteria.py
+++ b/tasks/tempo/set-fee-token-base/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["fee.setUserToken"],

--- a/tasks/tempo/set-fee-token-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/set-fee-token-docs/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["fee.setUserToken"],

--- a/tasks/tempo/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/set-fee-token-mcp/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["fee.setUserToken"],

--- a/tasks/tempo/stablecoin-dex-swap-base/tests/correctness/criteria.py
+++ b/tasks/tempo/stablecoin-dex-swap-base/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.approveSync", "dex.placeSync"],

--- a/tasks/tempo/stablecoin-dex-swap-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/stablecoin-dex-swap-docs/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.approveSync", "dex.placeSync"],

--- a/tasks/tempo/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.approveSync", "dex.placeSync"],

--- a/tasks/tempo/transfer-with-memo-base/tests/correctness/criteria.py
+++ b/tasks/tempo/transfer-with-memo-base/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(["token.transferSync"])
 register_source_patterns(

--- a/tasks/tempo/transfer-with-memo-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/transfer-with-memo-docs/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(["token.transferSync"])
 register_source_patterns(

--- a/tasks/tempo/transfer-with-memo-fee-payer-base/tests/correctness/criteria.py
+++ b/tasks/tempo/transfer-with-memo-fee-payer-base/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
+++ b/tasks/tempo/transfer-with-memo-fee-payer-docs/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(
     ["token.transferSync"],

--- a/tasks/tempo/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -4,10 +4,10 @@
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     register_source_patterns,
-    register_tempo_typescript_project,
+    register_tempo_eval_contract,
 )
 
-register_tempo_typescript_project()
+register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
 rk.tempo_uses_viem_tempo_actions(["token.transferSync"])
 register_source_patterns(


### PR DESCRIPTION
## Motivation

Task graders currently penalize workspace layout (package.json, tsconfig.json, src/index.ts presence) rather than task outcomes. The verifiers already build and run the solution, so file structure is implicitly validated — these checks add noise without signal and punish valid alternative layouts.

## Summary

- Rename `register_tempo_typescript_project` to `register_tempo_eval_contract` in the shared RewardKit package and remove its three `file_exists` checks (package.json, tsconfig.json, src/index.ts).
- Remove `rk.file_exists(WorkspaceFile.PACKAGE_JSON/TSCONFIG_JSON/SOURCE_INDEX)` from all 9 MPP task criteria.
- Regenerate Tempo docs/MCP variants and refresh dataset digests for both datasets.

## Key design considerations

- `rejects_other_blockchains` negation checks and `register_source_patterns` positive source-pattern checks are intentionally kept — they grade behavior, not layout.
- The eval-script and package regex checks in the renamed helper are kept since they enforce the eval contract (how the verifier invokes the solution), not file structure.
- Oracle spot-checks pass locally: `tempo/transfer-with-memo-base` and `tempo/mpp-server-charge-pathusd` both score 1.0.