### PR TITLE
feat: gate Tempo rewards on onchain verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ npm run bench:daytona:agent      # Full Daytona agent run
 Single task:
 
 ```bash
-npm run bench:local:one -- --task-filter tempo/transfer-with-memo
+npm run bench:local:one -- --task-filter tempo-v1/transfer-with-memo
 npm run bench:local:mpp -- --task-filter server-charge-pathusd
 npm run bench:daytona:agent:dev -- --task-filter transfer-with-memo-mcp --concurrency 1 --agent-concurrency 1
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,11 @@ pympp, `shared/global/rewardkit-lib/`) and the Tempo JS verifier
 (`shared/tempo/verifier/`). Local runs build it automatically (or run
 `npm run build-base`); CI publishes it to GHCR via
 `.github/workflows/build-base-image.yml`. After changing the base image
-contents, bump the `base_image` tag in `config/tasks.yaml` and re-run
+contents, re-run `npm run sync`.
+
+The pinned base-image tag is intentionally mutable during a Tempo Bench version.
+Only bump `base_image` when cutting a new Tempo Bench version; ordinary shared
+base-image changes should replace the image at the existing tag and re-run
 `npm run sync`.
 
 Harbor job configs are compiled artifacts: `npm run sync` renders

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run bench:local:oracle -- --task-suite all
 Fast oracle loop for one task while editing:
 
 ```bash
-npm run bench:local:one -- --task-filter tempo/transfer-with-memo
+npm run bench:local:one -- --task-filter tempo-v1/transfer-with-memo
 ```
 
 Fast Tempo oracle loop:
@@ -232,7 +232,7 @@ npm run clean
 Use the dev oracle commands while iterating on one Tempo task:
 
 ```bash
-npm run bench:local:one -- --task-filter tempo/transfer-with-memo
+npm run bench:local:one -- --task-filter tempo-v1/transfer-with-memo
 ```
 
 Use `npm run bench:local:mpp` for the same fast loop over MPP tasks. Commands

--- a/config/tasks.yaml
+++ b/config/tasks.yaml
@@ -6,6 +6,9 @@
 # venv (harbor-rewardkit, pympp[tempo], tempo-bench-rewardkit) and the Tempo
 # JS verifier; see shared/global/docker/base/Dockerfile. CI publishes it via
 # .github/workflows/build-base-image.yml; local runs build it automatically.
+# This tag is intentionally mutable during a Tempo Bench version. Only bump it
+# when cutting a new Tempo Bench version; ordinary shared-base changes replace
+# the image at the existing tag.
 base_image: ghcr.io/tempoxyz/tempo-bench-base:v1
 
 # Authored task templates under tasks/tempo-v1/_templates/<slug>/. Each one

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -130,7 +130,7 @@ def result_files(root: Path) -> list[Path]:
 def parse_task_name(task_name: str) -> dict[str, str]:
     if task_name.endswith(MCP_PROFILE_SUFFIX):
         return {"task_family": task_name[: -len(MCP_PROFILE_SUFFIX)], "profile": "mcp"}
-    if task_name.startswith("tempo/"):
+    if task_name.startswith("tempo-v1/"):
         return {"task_family": task_name, "profile": "docs"}
     return {"task_family": task_name, "profile": "unknown"}
 

--- a/scripts/export_results_test.py
+++ b/scripts/export_results_test.py
@@ -91,7 +91,7 @@ class ExportResultsTest(unittest.TestCase):
                 trial(
                     {
                         "trial_name": "trial-c",
-                        "task_name": "tempo/set-fee-token",
+                        "task_name": "tempo-v1/set-fee-token",
                         "agent_info": {
                             "name": "claude-code",
                             "model_info": {"name": "other-model"},

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -604,11 +604,12 @@ def apply_task_filter(
         config["datasets"] = [{"path": "tasks/mpp", "task_names": [mpp_filter]}]
         return config
 
-    filters = (
-        [task_filter, task_filter.removeprefix("tempo/")]
-        if task_filter.startswith("tempo/")
-        else [task_filter]
-    )
+    tempo_prefixes = ("tempo-v1/", "tempo/")
+    filters = [task_filter]
+    for prefix in tempo_prefixes:
+        if task_filter.startswith(prefix):
+            filters.append(task_filter.removeprefix(prefix))
+            break
     for dataset in config.get("datasets", []):
         if dataset.get("path") in {"tasks", "tasks/tempo-v1"}:
             dataset["task_names"] = filters

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -50,6 +50,24 @@ class RunBenchmarkTest(unittest.TestCase):
             ],
         )
 
+    def test_finalize_config_resolves_versioned_tempo_task_filter(self) -> None:
+        config = finalize_config(
+            base_config(), {"task_filter": "tempo-v1/transfer-with-memo"}
+        )
+
+        self.assertEqual(
+            config["datasets"],
+            [
+                {
+                    "path": "tasks/tempo-v1",
+                    "task_names": [
+                        "tempo-v1/transfer-with-memo",
+                        "transfer-with-memo",
+                    ],
+                }
+            ],
+        )
+
     def test_benchmark_provenance_uses_versioned_dataset_identity(self) -> None:
         self.assertEqual(
             benchmark_provenance("tempo"),

--- a/scripts/sync_shared.py
+++ b/scripts/sync_shared.py
@@ -183,7 +183,7 @@ def render_task_toml(task_dir: Path, slug: str, profile: dict[str, Any]) -> None
     doc = tomlkit.parse(task_config_path.read_text())
 
     task = doc["task"]
-    task["name"] = f"tempo/{slug}{profile['suffix']}"
+    task["name"] = f"tempo-v1/{slug}{profile['suffix']}"
     description = str(task.get("description", task["name"]))
     task["description"] = f"{description} ({profile['label']} profile)."
     keywords = task.get("keywords")
@@ -397,7 +397,7 @@ def read_manifest_digests(dataset_path: Path) -> dict[str, str]:
 
 def matrix_task_names() -> list[str]:
     return [
-        f"tempo/{slug}{profile['suffix']}"
+        f"tempo-v1/{slug}{profile['suffix']}"
         for slug in TASK_SLUGS
         for profile in ALL_PROFILES
     ]

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/__init__.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/__init__.py
@@ -3,7 +3,6 @@
 from .criteria import (
     agent_token_efficiency,
     tempo_mcp_tool_used,
-    tempo_onchain_verifier,
     tempo_rejects_other_blockchains,
     tempo_trajectory_matches,
     tempo_uses_viem_tempo_actions,
@@ -12,7 +11,6 @@ from .criteria import (
 __all__ = [
     "agent_token_efficiency",
     "tempo_mcp_tool_used",
-    "tempo_onchain_verifier",
     "tempo_rejects_other_blockchains",
     "tempo_trajectory_matches",
     "tempo_uses_viem_tempo_actions",

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
@@ -4,7 +4,6 @@ import fcntl
 import json
 import os
 import re
-import subprocess
 import threading
 from pathlib import Path
 from typing import Any
@@ -316,29 +315,6 @@ def tempo_uses_viem_tempo_actions(
     ]
     _write_json("tempo-actions.json", {"checks": results})
     return all(result["passed"] for result in results)
-
-
-@criterion(shared=True)
-def tempo_onchain_verifier(workspace: Path) -> bool:
-    timeout = int(os.environ.get("TEMPO_BENCH_REWARDKIT_TIMEOUT_SECONDS", "900"))
-    result = subprocess.run(
-        ["bash", "/tests/correctness/verify-tempo.sh"],
-        cwd=workspace,
-        text=True,
-        capture_output=True,
-        timeout=timeout,
-        check=False,
-    )
-    _write_json(
-        "onchain-criterion.json",
-        {
-            "command": "bash /tests/correctness/verify-tempo.sh",
-            "returncode": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-        },
-    )
-    return result.returncode == 0
 
 
 @criterion(shared=True)

--- a/shared/global/rewardkit/quality/check.py
+++ b/shared/global/rewardkit/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/shared/global/rewardkit/quality/check.py
+++ b/shared/global/rewardkit/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/shared/global/rewardkit/quality/reward.toml
+++ b/shared/global/rewardkit/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/shared/global/rewardkit/test.sh
+++ b/shared/global/rewardkit/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/shared/global/rewardkit/test.sh
+++ b/shared/global/rewardkit/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -30,16 +30,15 @@ Each generated task is Harbor-native and self-contained:
 - `environment/` contains the task runtime and Docker Compose additions.
   Common sidecars are symlinked from `../../shared/` where Harbor and Docker
   can consume them.
-- `tests/correctness/` contains the task's RewardKit criteria plus the e2e
-  command criterion. `tests/quality/` contains non-binary turn/token
-  efficiency checks and the Claude Haiku LLM judge. `tests/test.sh` writes
-  Harbor's primary `/logs/verifier/reward.json` from the RewardKit
-  correctness score, gated by the independent Tempo onchain verifier. A task
-  receives zero reward unless `tempo_onchain_verifier` passes; after that,
-  static correctness criteria contribute weighted partial credit instead of
-  requiring every criterion to pass. Quality dimensions remain diagnostic.
-  `tests/tempo-bench-verifier/` is a minimal copied verifier package for the
-  selected `TEMPO_BENCH_CASE`.
+- `tests/correctness/` contains task-specific RewardKit criteria and the
+  independent onchain verifier. `tests/quality/` contains turn/token
+  efficiency checks and the Claude Haiku LLM judge. `tests/test.sh` runs the
+  onchain verifier first: failure writes Harbor's primary
+  `/logs/verifier/reward.json` as zero and skips RewardKit. On success,
+  RewardKit writes the primary score from the weighted aggregate of all static
+  and available LLM quality criteria. A score of one requires every included
+  criterion to score one. `tests/tempo-bench-verifier/` is a minimal copied
+  verifier package for the selected `TEMPO_BENCH_CASE`.
 - `solution/` contains the oracle solution used for sanity checks.
 
 After changing sources or shared code, run `npm run sync`, then

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -10,12 +10,12 @@ authoring guide.
 
 Current task intents:
 
-- `tempo/transfer-with-memo`
-- `tempo/transfer-with-memo-fee-payer`
-- `tempo/set-fee-token`
-- `tempo/create-stablecoin-with-policy`
-- `tempo/faucet-funded-transfer`
-- `tempo/stablecoin-dex-swap`
+- `tempo-v1/transfer-with-memo`
+- `tempo-v1/transfer-with-memo-fee-payer`
+- `tempo-v1/set-fee-token`
+- `tempo-v1/create-stablecoin-with-policy`
+- `tempo-v1/faucet-funded-transfer`
+- `tempo-v1/stablecoin-dex-swap`
 
 Each intent is materialized into a Docs variant (no suffix) and an `-mcp`
 variant by `npm run sync`.

--- a/tasks/tempo-v1/_templates/README.md
+++ b/tasks/tempo-v1/_templates/README.md
@@ -14,7 +14,7 @@ A template task contains only the authored files:
 - `README.md` — the Harbor Hub display summary. It must include `## Overview`,
   `## What the Task Tests`, and `## Verification`.
 - `task.toml` — profile-neutral task config. `[task].name` is the bare
-  intent (`tempo/<slug>`); sync appends the profile suffix, description
+  intent (`tempo-v1/<slug>`); sync appends the profile suffix, description
   label, keywords, per-profile env, and MCP servers. Tempo fixture values
   live in `config/tasks.yaml` under `fixture_env` and `case_fixtures`;
   sync renders them into each generated task's `[environment.env]`. Shared

--- a/tasks/tempo-v1/_templates/create-stablecoin-with-policy/task.toml
+++ b/tasks/tempo-v1/_templates/create-stablecoin-with-policy/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/create-stablecoin-with-policy"
+name = "tempo-v1/create-stablecoin-with-policy"
 description = "Build a Tempo localnet integration that creates a TIP-20 stablecoin, creates a transfer policy, and links it."
 authors = []
 keywords = ["tempo", "tip20", "stablecoin", "tip403", "policy", "localnet", "typescript"]

--- a/tasks/tempo-v1/_templates/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/_templates/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -25,4 +25,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/_templates/faucet-funded-transfer/task.toml
+++ b/tasks/tempo-v1/_templates/faucet-funded-transfer/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/faucet-funded-transfer"
+name = "tempo-v1/faucet-funded-transfer"
 description = "Build a Tempo localnet integration that funds a wallet from the faucet and transfers AlphaUSD."
 authors = []
 keywords = ["tempo", "faucet", "tip20", "transfer", "localnet", "typescript"]

--- a/tasks/tempo-v1/_templates/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/_templates/faucet-funded-transfer/tests/correctness/criteria.py
@@ -15,4 +15,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/_templates/set-fee-token/task.toml
+++ b/tasks/tempo-v1/_templates/set-fee-token/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/set-fee-token"
+name = "tempo-v1/set-fee-token"
 description = "Build a Tempo localnet integration that sets AlphaUSD as the account's default fee token."
 authors = []
 keywords = ["tempo", "fee-token", "alpha-usd", "localnet", "typescript"]

--- a/tasks/tempo-v1/_templates/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/_templates/set-fee-token/tests/correctness/criteria.py
@@ -15,4 +15,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/_templates/stablecoin-dex-swap/task.toml
+++ b/tasks/tempo-v1/_templates/stablecoin-dex-swap/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/stablecoin-dex-swap"
+name = "tempo-v1/stablecoin-dex-swap"
 description = "Build a Tempo localnet integration that approves the Stablecoin DEX and executes a swap against seeded liquidity."
 authors = []
 keywords = ["tempo", "stablecoin-dex", "swap", "tip20", "localnet", "typescript"]

--- a/tasks/tempo-v1/_templates/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/_templates/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -22,4 +22,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/_templates/transfer-with-memo-fee-payer/task.toml
+++ b/tasks/tempo-v1/_templates/transfer-with-memo-fee-payer/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/transfer-with-memo-fee-payer"
+name = "tempo-v1/transfer-with-memo-fee-payer"
 description = "Build a Tempo localnet integration that sends a memo transfer sponsored by a fee payer."
 authors = []
 keywords = ["tempo", "tip20", "memo", "fee-payer", "localnet", "typescript"]

--- a/tasks/tempo-v1/_templates/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/_templates/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -31,4 +31,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/_templates/transfer-with-memo/task.toml
+++ b/tasks/tempo-v1/_templates/transfer-with-memo/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/transfer-with-memo"
+name = "tempo-v1/transfer-with-memo"
 description = "Build a minimal Tempo localnet integration that sends a TIP-20 transfer with a memo."
 authors = []
 keywords = ["tempo", "tip20", "memo", "localnet", "typescript"]

--- a/tasks/tempo-v1/_templates/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/_templates/transfer-with-memo/tests/correctness/criteria.py
@@ -19,4 +19,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/task.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/create-stablecoin-with-policy-mcp"
+name = "tempo-v1/create-stablecoin-with-policy-mcp"
 description = "Build a Tempo localnet integration that creates a TIP-20 stablecoin, creates a transfer policy, and links it. (MCP profile)."
 authors = []
 keywords = ["tempo", "tip20", "stablecoin", "tip403", "policy", "localnet", "typescript", "mcp"]

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/correctness/criteria.py
@@ -29,4 +29,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/test.sh
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/create-stablecoin-with-policy/task.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/create-stablecoin-with-policy"
+name = "tempo-v1/create-stablecoin-with-policy"
 description = "Build a Tempo localnet integration that creates a TIP-20 stablecoin, creates a transfer policy, and links it. (docs profile)."
 authors = []
 keywords = ["tempo", "tip20", "stablecoin", "tip403", "policy", "localnet", "typescript", "docs"]

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -29,4 +29,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/check.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/check.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo"
-digest = "sha256:f76014e05214c73f053ab2351ad8c1771b433581d50162e2a36c0e551ce2e806"
+digest = "sha256:955839443d18f117c9c79b6e3f259fe1e29a1f543d97fd3c9c26db306ee7bc23"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:decb48273ceebfe6e6edb7219da36d1158b43f2ea4a7e06a3606cf3536bab8c2"
+digest = "sha256:0cc12202b69043f38ff624d6a456a01b4707fd18c05ab338f160004e2b3b7a08"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer"
-digest = "sha256:d8e5b460016126e2702daa9809e538dfd7969499f06075aae5dedcc92d1a441d"
+digest = "sha256:81b37f8e656001c9fc7b417823fca09630685b0768de1239fc044f1b1472426e"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:c4771ed670f1b78305811742e003e47f45c8987bc72d303325101b55688edd19"
+digest = "sha256:4f7422dfa49ded5e1683951e17b58eb78ec10fb21839ea653ad4b0f2b4c98b2c"
 
 [[tasks]]
 name = "tempo/set-fee-token"
-digest = "sha256:5b52c5de73cb4dc2cc48a8609df34de3ed8e90a87f427559881da15fd9c8d5b1"
+digest = "sha256:82ad7866c45c953a9fda68befab8e9852951700d40b8596b3964e12c2b14baa4"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:39faca3705fdd09c71c61180cfdee90ac44e041dd510f3ee208b003119ef37c1"
+digest = "sha256:a436138223afd519669a94dd40700ac2e915197612bf88811a7dd754fedc9ac2"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy"
-digest = "sha256:bb5d88ca9e8a1dc051e846d2e979dc43d3b710830b8f885bfeb84ba888b01540"
+digest = "sha256:e036cc9240881ae2f0dcbf05edb512a933bc3d248f1d90577cfe00517a7dc5be"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:b25ce8ec8fc53d426b1b28ba14d20fea002d4809e4f98a11a4396b701426ce07"
+digest = "sha256:d57af84eef49fccad2871fde1add52bc11cb69768e668e78885f28c9bed9ccf9"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer"
-digest = "sha256:547e82df1ba1333aa3dae4d10a44f0b18bcbbf3a4ba4518cd2e2790bfe3f7a02"
+digest = "sha256:3df7ba00104a5e6b74e50ea1962025e6b6ea264b26bab9bc3af4a7726fcc8fb6"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:1ba197809c2599a5d05119f6bd70d88335ff896074974061978af2f59a261596"
+digest = "sha256:83e623a439fdfdaedd33193b975ea22248fa33541f22f284fb8d46bb67bb5f30"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap"
-digest = "sha256:6163644b367c91c07fca487668b32471acbafa4b2deeeb2b0d362a41c8693ba2"
+digest = "sha256:c876784f448f967c5e9f9108738d22f82460451c1a9beecf64df6b399d3c9a26"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:b4d88c73d5e46301718fae3c4e0274314feda738a5f63ed9d05a7713777dcd97"
+digest = "sha256:a29c0a1daedee56e3139124ed030949afb3abcb3d7e083981f44de8c55bc9e08"
 

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:22c00a9a5fc0e744a9ab840b308d0647c1f3388300fb0f247530053d84ea914f"
+digest = "sha256:442549f35bcac9c81933de50f298b1e3eee4022f8c8e4fef47e1278b77db859d"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-mcp"
-digest = "sha256:771d4d4dfbadc54f48c817b6f0db6438903c94551a40040d291fd8e8f832d854"
+digest = "sha256:bf742a3fee0ba3367baa373de326bc15304e43cbbcb926bb73f3d70767357eb1"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:22af0403b331a99c313635077b5ad8529e0a05ade4eeb220cb24bbdb4ac93333"
+digest = "sha256:f4049b119b5c213a4d2f04aa961225ee1006b1a62346d6f509fba4a03e98a1cb"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:216c2dadd1dd90c32ce9d6c7f905d6d95bb69d3fed3a124c5db57264351706e2"
+digest = "sha256:0f14c31ad13019dcc479819f75dc6ae35d71275b61d77198740303b29c75a616"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:c22a3e2aa4ac7ae7f1bbf38460a61dd173f96e0e5815aeb3aa7f6f5d8aa7c42a"
+digest = "sha256:12ae829536491dfc1d00b81bae2fb083b4c77761f374007604cdb73736c5bc3d"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token-mcp"
-digest = "sha256:e796e42fd8ae5030cd18b928c32fc0b03c2f340d004d5dec7b46a15e47b13ff5"
+digest = "sha256:ec455f367beabbb0a9660e0cc3196a07b863b4824632a5af8fb2194a82fb2d5b"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:24f74a12bf75825feadb2adec54b0a1a351f3bdeac0390e073c7ce8a94c0b2e1"
+digest = "sha256:1a4a73d71319677f6054016c90c195b30278ec0b619b17fc8d7f1522034c548b"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy-mcp"
-digest = "sha256:dbeb1b833872c7f27004bd387f255cef08ad82029a2ba9f38f877a988a551914"
+digest = "sha256:4343817750c317a0b61e2183dea0fc5a5fa2d6ec078b50e3e7d893a1fcff79ab"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:2a0ebb334147a185babfc06b6bb5ff20e6c7a9f36df6151c1bcbc25b0ac5e689"
+digest = "sha256:e16f5a028667912299f96c8781019de8c7cdd5c49bdca489e56f98debd7caf1b"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer-mcp"
-digest = "sha256:92c597d4b2fc7883aca1f6e46e23101ebce6d9b24f506f3084676141a668eccf"
+digest = "sha256:ca6c817ba7ae32675dc6d508a84b3868ecce871e8d1dd527ad01e9dd75dce254"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:aece9652427c99cec709c64339ca157d476311d2e9401ce8bd6f522e8fa9296b"
+digest = "sha256:521335a3de791b78aad8062018cae05f757da7ff86c1b8926cfcb1f0487e5205"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap-mcp"
-digest = "sha256:897ea378f7c116a45271f61b6ed700c5281f94acc2b5b168eeacc66092fdacc0"
+digest = "sha256:929b10ba934a9ea2fbee60baf8d09db4bc908f40da4d97556d5fe69b2e592352"
 

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -10,50 +10,50 @@ name = "Tempo"
 
 
 [[tasks]]
-name = "tempo/transfer-with-memo"
-digest = "sha256:955839443d18f117c9c79b6e3f259fe1e29a1f543d97fd3c9c26db306ee7bc23"
+name = "tempo-v1/transfer-with-memo"
+digest = "sha256:22c00a9a5fc0e744a9ab840b308d0647c1f3388300fb0f247530053d84ea914f"
 
 [[tasks]]
-name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:0cc12202b69043f38ff624d6a456a01b4707fd18c05ab338f160004e2b3b7a08"
+name = "tempo-v1/transfer-with-memo-mcp"
+digest = "sha256:771d4d4dfbadc54f48c817b6f0db6438903c94551a40040d291fd8e8f832d854"
 
 [[tasks]]
-name = "tempo/transfer-with-memo-fee-payer"
-digest = "sha256:81b37f8e656001c9fc7b417823fca09630685b0768de1239fc044f1b1472426e"
+name = "tempo-v1/transfer-with-memo-fee-payer"
+digest = "sha256:22af0403b331a99c313635077b5ad8529e0a05ade4eeb220cb24bbdb4ac93333"
 
 [[tasks]]
-name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:4f7422dfa49ded5e1683951e17b58eb78ec10fb21839ea653ad4b0f2b4c98b2c"
+name = "tempo-v1/transfer-with-memo-fee-payer-mcp"
+digest = "sha256:216c2dadd1dd90c32ce9d6c7f905d6d95bb69d3fed3a124c5db57264351706e2"
 
 [[tasks]]
-name = "tempo/set-fee-token"
-digest = "sha256:82ad7866c45c953a9fda68befab8e9852951700d40b8596b3964e12c2b14baa4"
+name = "tempo-v1/set-fee-token"
+digest = "sha256:c22a3e2aa4ac7ae7f1bbf38460a61dd173f96e0e5815aeb3aa7f6f5d8aa7c42a"
 
 [[tasks]]
-name = "tempo/set-fee-token-mcp"
-digest = "sha256:a436138223afd519669a94dd40700ac2e915197612bf88811a7dd754fedc9ac2"
+name = "tempo-v1/set-fee-token-mcp"
+digest = "sha256:e796e42fd8ae5030cd18b928c32fc0b03c2f340d004d5dec7b46a15e47b13ff5"
 
 [[tasks]]
-name = "tempo/create-stablecoin-with-policy"
-digest = "sha256:e036cc9240881ae2f0dcbf05edb512a933bc3d248f1d90577cfe00517a7dc5be"
+name = "tempo-v1/create-stablecoin-with-policy"
+digest = "sha256:24f74a12bf75825feadb2adec54b0a1a351f3bdeac0390e073c7ce8a94c0b2e1"
 
 [[tasks]]
-name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:d57af84eef49fccad2871fde1add52bc11cb69768e668e78885f28c9bed9ccf9"
+name = "tempo-v1/create-stablecoin-with-policy-mcp"
+digest = "sha256:dbeb1b833872c7f27004bd387f255cef08ad82029a2ba9f38f877a988a551914"
 
 [[tasks]]
-name = "tempo/faucet-funded-transfer"
-digest = "sha256:3df7ba00104a5e6b74e50ea1962025e6b6ea264b26bab9bc3af4a7726fcc8fb6"
+name = "tempo-v1/faucet-funded-transfer"
+digest = "sha256:2a0ebb334147a185babfc06b6bb5ff20e6c7a9f36df6151c1bcbc25b0ac5e689"
 
 [[tasks]]
-name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:83e623a439fdfdaedd33193b975ea22248fa33541f22f284fb8d46bb67bb5f30"
+name = "tempo-v1/faucet-funded-transfer-mcp"
+digest = "sha256:92c597d4b2fc7883aca1f6e46e23101ebce6d9b24f506f3084676141a668eccf"
 
 [[tasks]]
-name = "tempo/stablecoin-dex-swap"
-digest = "sha256:c876784f448f967c5e9f9108738d22f82460451c1a9beecf64df6b399d3c9a26"
+name = "tempo-v1/stablecoin-dex-swap"
+digest = "sha256:aece9652427c99cec709c64339ca157d476311d2e9401ce8bd6f522e8fa9296b"
 
 [[tasks]]
-name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:a29c0a1daedee56e3139124ed030949afb3abcb3d7e083981f44de8c55bc9e08"
+name = "tempo-v1/stablecoin-dex-swap-mcp"
+digest = "sha256:897ea378f7c116a45271f61b6ed700c5281f94acc2b5b168eeacc66092fdacc0"
 

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/task.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/faucet-funded-transfer-mcp"
+name = "tempo-v1/faucet-funded-transfer-mcp"
 description = "Build a Tempo localnet integration that funds a wallet from the faucet and transfers AlphaUSD. (MCP profile)."
 authors = []
 keywords = ["tempo", "faucet", "tip20", "transfer", "localnet", "typescript", "mcp"]

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/correctness/criteria.py
@@ -19,4 +19,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/test.sh
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/faucet-funded-transfer/task.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/faucet-funded-transfer"
+name = "tempo-v1/faucet-funded-transfer"
 description = "Build a Tempo localnet integration that funds a wallet from the faucet and transfers AlphaUSD. (docs profile)."
 authors = []
 keywords = ["tempo", "faucet", "tip20", "transfer", "localnet", "typescript", "docs"]

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/correctness/criteria.py
@@ -19,4 +19,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/quality/check.py
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/quality/check.py
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/set-fee-token-mcp/task.toml
+++ b/tasks/tempo-v1/set-fee-token-mcp/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/set-fee-token-mcp"
+name = "tempo-v1/set-fee-token-mcp"
 description = "Build a Tempo localnet integration that sets AlphaUSD as the account's default fee token. (MCP profile)."
 authors = []
 keywords = ["tempo", "fee-token", "alpha-usd", "localnet", "typescript", "mcp"]

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/correctness/criteria.py
@@ -19,4 +19,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/test.sh
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/test.sh
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/set-fee-token/task.toml
+++ b/tasks/tempo-v1/set-fee-token/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/set-fee-token"
+name = "tempo-v1/set-fee-token"
 description = "Build a Tempo localnet integration that sets AlphaUSD as the account's default fee token. (docs profile)."
 authors = []
 keywords = ["tempo", "fee-token", "alpha-usd", "localnet", "typescript", "docs"]

--- a/tasks/tempo-v1/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/set-fee-token/tests/correctness/criteria.py
@@ -19,4 +19,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/set-fee-token/tests/quality/check.py
+++ b/tasks/tempo-v1/set-fee-token/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/set-fee-token/tests/quality/check.py
+++ b/tasks/tempo-v1/set-fee-token/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
+++ b/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/set-fee-token/tests/test.sh
+++ b/tasks/tempo-v1/set-fee-token/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/set-fee-token/tests/test.sh
+++ b/tasks/tempo-v1/set-fee-token/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/task.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/stablecoin-dex-swap-mcp"
+name = "tempo-v1/stablecoin-dex-swap-mcp"
 description = "Build a Tempo localnet integration that approves the Stablecoin DEX and executes a swap against seeded liquidity. (MCP profile)."
 authors = []
 keywords = ["tempo", "stablecoin-dex", "swap", "tip20", "localnet", "typescript", "mcp"]

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/correctness/criteria.py
@@ -26,4 +26,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/test.sh
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/stablecoin-dex-swap/task.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/stablecoin-dex-swap"
+name = "tempo-v1/stablecoin-dex-swap"
 description = "Build a Tempo localnet integration that approves the Stablecoin DEX and executes a swap against seeded liquidity. (docs profile)."
 authors = []
 keywords = ["tempo", "stablecoin-dex", "swap", "tip20", "localnet", "typescript", "docs"]

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -26,4 +26,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/check.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/check.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/task.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/transfer-with-memo-fee-payer-mcp"
+name = "tempo-v1/transfer-with-memo-fee-payer-mcp"
 description = "Build a Tempo localnet integration that sends a memo transfer sponsored by a fee payer. (MCP profile)."
 authors = []
 keywords = ["tempo", "tip20", "memo", "fee-payer", "localnet", "typescript", "mcp"]

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/correctness/criteria.py
@@ -35,4 +35,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/task.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/transfer-with-memo-fee-payer"
+name = "tempo-v1/transfer-with-memo-fee-payer"
 description = "Build a Tempo localnet integration that sends a memo transfer sponsored by a fee payer. (docs profile)."
 authors = []
 keywords = ["tempo", "tip20", "memo", "fee-payer", "localnet", "typescript", "docs"]

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -35,4 +35,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/transfer-with-memo-mcp/task.toml
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/transfer-with-memo-mcp"
+name = "tempo-v1/transfer-with-memo-mcp"
 description = "Build a minimal Tempo localnet integration that sends a TIP-20 transfer with a memo. (MCP profile)."
 authors = []
 keywords = ["tempo", "tip20", "memo", "localnet", "typescript", "mcp"]

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/correctness/criteria.py
@@ -23,4 +23,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi

--- a/tasks/tempo-v1/transfer-with-memo/task.toml
+++ b/tasks/tempo-v1/transfer-with-memo/task.toml
@@ -5,7 +5,7 @@ schema_version = "1.3"
 artifacts = ["/app/package.json", "/app/src"]
 
 [task]
-name = "tempo/transfer-with-memo"
+name = "tempo-v1/transfer-with-memo"
 description = "Build a minimal Tempo localnet integration that sends a TIP-20 transfer with a memo. (docs profile)."
 authors = []
 keywords = ["tempo", "tip20", "memo", "localnet", "typescript", "docs"]

--- a/tasks/tempo-v1/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-with-memo/tests/correctness/criteria.py
@@ -23,4 +23,3 @@ register_source_patterns(
         },
     ]
 )
-rk.tempo_onchain_verifier()

--- a/tasks/tempo-v1/transfer-with-memo/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo/tests/quality/check.py
@@ -1,10 +1,14 @@
 # SYNCED FROM shared/global/rewardkit/quality/check.py
 # BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+from pathlib import Path
+
 import rewardkit as rk
 from tempo_bench_rewardkit.common.checks import (
     TokenEfficiencyConfig,
     register_token_efficiency_check,
 )
 
-rk.trajectory_turn_count(max_turns=20, path="/logs/agent/trajectory.json")
-register_token_efficiency_check(TokenEfficiencyConfig())
+trajectory_path = Path("/logs/agent/trajectory.json")
+if trajectory_path.exists():
+    rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
+    register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo/tests/quality/check.py
+++ b/tasks/tempo-v1/transfer-with-memo/tests/quality/check.py
@@ -8,7 +8,8 @@ from tempo_bench_rewardkit.common.checks import (
     register_token_efficiency_check,
 )
 
-trajectory_path = Path("/logs/agent/trajectory.json")
-if trajectory_path.exists():
+trajectory_paths = (Path("/logs/agent/trajectory.json"), Path("/logs/trajectory.json"))
+trajectory_path = next((path for path in trajectory_paths if path.exists()), None)
+if trajectory_path is not None:
     rk.trajectory_turn_count(max_turns=20, path=str(trajectory_path))
     register_token_efficiency_check(TokenEfficiencyConfig())

--- a/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
@@ -1,7 +1,7 @@
 # SYNCED FROM shared/global/rewardkit/quality/reward.toml BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 [judge]
 judge = "anthropic/claude-haiku-4-5"
-mode = "batched"
+mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
 atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300

--- a/tasks/tempo-v1/transfer-with-memo/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo/tests/test.sh
@@ -1,210 +1,34 @@
 #!/usr/bin/env bash
 # SYNCED FROM shared/global/rewardkit/test.sh BY npm run sync. DO NOT EDIT COPIES IN tasks/.
-set -u
+set -u -o pipefail
 
 LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-ARTIFACT_DIR="${TEMPO_BENCH_ARTIFACT_DIR:-/logs/artifacts}"
 WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
-
-mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
-# The venv is baked into the tempo-bench base image; see
-# shared/global/docker/base/Dockerfile.
-REWARDKIT_VENV="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}"
-REWARDKIT_PYTHON="$REWARDKIT_VENV/bin/python"
-REWARD_FILE="$LOG_DIR/reward.json"
-DETAILS_FILE="$LOG_DIR/reward-details.json"
-REWARDKIT_OUTPUT_FILE="$LOG_DIR/rewardkit-output.json"
-TEMPO_SCORES_FILE="$LOG_DIR/tempo-bench-scores.json"
+REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
-rm -f "$REWARD_FILE" "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-rm -f "$ARTIFACT_DIR/exception.txt"
 
-write_exception_artifact() {
-  phase="$1"
-  reason="$2"
-  shift 2
-
-  {
-    printf 'Tempo task verifier could not produce a passing correctness score.\n'
-    printf 'phase: %s\n' "$phase"
-    printf 'reason: %s\n' "$reason"
-    printf '\nlogs:\n'
-    for log_file in "$@"; do
-      printf -- '- %s\n' "$log_file"
-    done
-  } > "$ARTIFACT_DIR/exception.txt"
-}
-
-emit_log_file() {
-  file_name="$1"
-  file_path="$LOG_DIR/$file_name"
-  if [ ! -f "$file_path" ]; then
-    return
-  fi
-  printf '\n===== %s =====\n' "$file_name"
-  cat "$file_path"
-}
-
-emit_harbor_summary() {
-  for file_name in \
-    grader.stdout.txt \
-    grader.status.json \
-    tempo-bench-reward.json \
-    tempo-bench-scores.json; do
-    emit_log_file "$file_name"
-  done
-  emit_log_file grader.stderr.txt >&2
-}
-
-finish() {
-  status=$?
-  trap - EXIT
-  emit_harbor_summary
-  exit "$status"
-}
-trap finish EXIT
-
-skip_llm_quality() {
-  reason="$1"
-  REWARDKIT_TESTS_DIR="/tmp/tempo-bench-rewardkit-tests"
-  rm -rf "$REWARDKIT_TESTS_DIR"
-  cp -R "$TESTS_DIR" "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' "$reason" > "$LOG_DIR/quality-skipped.txt"
-}
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  skip_llm_quality 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.'
-fi
-
-write_binary_reward() {
-  python3 - "$DETAILS_FILE" "$TEMPO_SCORES_FILE" "$REWARD_FILE" "$ARTIFACT_DIR/exception.txt" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-details_path = Path(sys.argv[1])
-tempo_scores_path = Path(sys.argv[2])
-reward_path = Path(sys.argv[3])
-exception_path = Path(sys.argv[4])
-reward = 0
-details = None
-scores = None
-
-def score_of(value):
-    if isinstance(value, dict):
-        return float(value.get("score", 0))
-    if isinstance(value, list):
-        return min((score_of(item) for item in value), default=0.0)
-    return float(value or 0)
-
-def criterion_passed(value, name):
-    if isinstance(value, dict):
-        if value.get("name") == name:
-            raw = value.get("raw", value.get("value", 0))
-            if isinstance(raw, bool):
-                return raw
-            return float(value.get("value", raw or 0)) > 0
-        return any(criterion_passed(item, name) for item in value.get("criteria", []))
-    if isinstance(value, list):
-        return any(criterion_passed(item, name) for item in value)
-    return False
-
-def write_exception(reason):
-    exception_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "Tempo task verifier produced reward 0.",
-        f"reason: {reason}",
-        "",
-        "logs:",
-        f"- {details_path}",
-        f"- {tempo_scores_path}",
-    ]
-
-    if details:
-        lines.append("")
-        lines.append(f"correctness score: {score_of(details.get('correctness', 0)):g}")
-
-    if scores:
-        lines.append("")
-        lines.append(f"tempo scores: {json.dumps(scores, sort_keys=True)}")
-
-    exception_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-if tempo_scores_path.exists():
-    with tempo_scores_path.open(encoding="utf-8") as scores_file:
-        scores = json.load(scores_file)
-
-if details_path.exists():
-    with details_path.open(encoding="utf-8") as details_file:
-        details = json.load(details_file)
-    correctness = details.get("correctness", 0)
-    if criterion_passed(correctness, "tempo_onchain_verifier"):
-        reward = score_of(correctness)
-elif scores is not None:
-    reward = float(scores.get("reward", 0))
-
-with reward_path.open("w", encoding="utf-8") as reward_file:
-    json.dump({"reward": reward}, reward_file, separators=(",", ":"))
-    reward_file.write("\n")
-
-if reward == 0:
-    if details_path.exists():
-        write_exception("Tempo onchain verifier criterion did not pass.")
-    elif tempo_scores_path.exists():
-        write_exception("Tempo onchain verifier reward was below 1.")
-    else:
-        write_exception("No RewardKit details or Tempo score file was available.")
-PY
-}
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
-if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  write_exception_artifact \
-    "rewardkit-venv" \
-    "missing baked RewardKit venv: $REWARDKIT_VENV (rebuild the tempo-bench base image)"
+if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
   exit 0
 fi
 
-run_rewardkit() {
-  "$REWARDKIT_PYTHON" -m rewardkit "$REWARDKIT_TESTS_DIR" \
-    --workspace "$WORKSPACE" \
-    --output "$REWARDKIT_OUTPUT_FILE" \
-    > "$LOG_DIR/rewardkit.stdout.txt" \
-    2> "$LOG_DIR/rewardkit.stderr.txt"
-}
-
-if ! run_rewardkit; then
-  if [ "$REWARDKIT_TESTS_DIR" = "$TESTS_DIR" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-    cp "$LOG_DIR/rewardkit.stderr.txt" "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-    skip_llm_quality 'Skipping LLM quality reward because the LLM judge failed; reran programmatic rewards only.'
-    rm -f "$DETAILS_FILE" "$REWARDKIT_OUTPUT_FILE"
-    if ! run_rewardkit; then
-      write_exception_artifact \
-        "rewardkit" \
-        "RewardKit failed after disabling the LLM quality reward" \
-        "$LOG_DIR/rewardkit.stdout.txt" \
-        "$LOG_DIR/rewardkit.stderr.txt" \
-        "$LOG_DIR/rewardkit-with-llm.stderr.txt"
-      write_binary_reward || write_zero_reward
-      exit 0
-    fi
-  else
-    write_exception_artifact \
-      "rewardkit" \
-      "RewardKit failed" \
-      "$LOG_DIR/rewardkit.stdout.txt" \
-      "$LOG_DIR/rewardkit.stderr.txt"
-    write_binary_reward || write_zero_reward
-    exit 0
-  fi
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
+  REWARDKIT_TESTS_DIR="$(mktemp -d)"
+  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
+  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
+  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+    > "$LOG_DIR/quality-skipped.txt"
 fi
 
-write_binary_reward || write_zero_reward
-
-exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
+  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  write_zero_reward
+fi

--- a/tasks/tempo-v1/transfer-with-memo/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo/tests/test.sh
@@ -7,13 +7,20 @@ WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
 TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
 REWARDKIT_TESTS_DIR="$TESTS_DIR"
+REWARDKIT_WORKSPACE="$(mktemp -d)"
 
 mkdir -p "$LOG_DIR"
 rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
+trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
   printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
 }
+
+if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
+  write_zero_reward
+  exit 0
+fi
 
 if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
   write_zero_reward
@@ -29,6 +36,6 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; t
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$WORKSPACE"; then
+  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
   write_zero_reward
 fi


### PR DESCRIPTION
## Motivation

Ensure Tempo task rewards cannot mask failed onchain behavior, while keeping quality assessment diagnostic and granular.

## Summary

- Gate reward evaluation on the onchain verifier, returning zero on failure
- Grade quality with individual five-point Likert RewardKit checks when a judge is configured
- Keep the shared v1 base image mutable and document its version-cut policy

## Key design considerations

- Missing judge credentials skip quality grading without bypassing the onchain gate
- Full reward requires both onchain success and perfect Likert quality scores