### PR TITLE
fix: harden Tempo reward scoring

### DIFF
--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
@@ -412,6 +412,17 @@ def agent_token_efficiency(
         return 0.0
 
     metrics = _token_metrics(json.loads(path.read_text(encoding="utf-8")))
-    score = _score_by_cutoff(metrics["total_tokens"], cutoffs)
-    _merge_efficiency("tokens", {"score": score, "cutoffs": cutoffs, **metrics})
+    # Cached prompt reads repeat prior context across turns; they do not reflect
+    # new agent work. Score the uncached estimate while retaining all token
+    # totals in the artifact for cost analysis.
+    score = _score_by_cutoff(metrics["uncached_token_estimate"], cutoffs)
+    _merge_efficiency(
+        "tokens",
+        {
+            "score": score,
+            "score_basis": "uncached_token_estimate",
+            "cutoffs": cutoffs,
+            **metrics,
+        },
+    )
     return score

--- a/shared/tempo/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/tempo/verifier/src/cases/faucet-funded-transfer.js
@@ -27,7 +27,7 @@ async function verify({ client, config, fromBlock }) {
   const expectedValue = parseUnits(config.amount, config.decimals);
   const event = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
 
-  return waitForEvidence(config, async () => {
+  async function findEvidence(startBlock) {
     const latestBlock = await client.getBlockNumber();
     const logs = await client.getLogs({
       address: config.token,
@@ -36,7 +36,7 @@ async function verify({ client, config, fromBlock }) {
         from: fundedSender,
         to: config.recipient,
       },
-      fromBlock,
+      fromBlock: startBlock,
       toBlock: latestBlock,
     });
 
@@ -50,7 +50,7 @@ async function verify({ client, config, fromBlock }) {
         from: localnetFaucet,
         to: fundedSender,
       },
-      fromBlock,
+      fromBlock: startBlock,
       toBlock: match.blockNumber,
     });
     const funding = fundingLogs.find(
@@ -65,6 +65,16 @@ async function verify({ client, config, fromBlock }) {
         fundingTransactionHash: funding.transactionHash,
       })
     );
+  }
+
+  return waitForEvidence(config, async () => {
+    const evidence = await findEvidence(fromBlock);
+    if (evidence || fromBlock === 0n) return evidence;
+
+    // A shared-environment runner can hand the verifier an RPC snapshot taken
+    // after submission execution. The task localnet is isolated per trial, so
+    // retrying from genesis preserves the full funding-and-transfer contract.
+    return findEvidence(0n);
   }, "no matching faucet-funded transfer event observed");
 }
 


### PR DESCRIPTION
## Motivation

Avoid false negatives in faucet verification and prevent cached prompt reuse from being treated as new agent work.

## Summary

- Retry faucet evidence from the isolated localnet genesis when the initial block window has no match
- Score trajectory efficiency from uncached token usage and retain full token totals for analysis

## Key design considerations

- Faucet verification still requires the configured funding, sender, recipient, amount, and event ordering
- The mutable `v1` base image picks up the updated verifier and RewardKit library