### PR TITLE
fix: keep faucet evidence window scoped

### DIFF
--- a/shared/tempo/verifier/src/cases/faucet-funded-transfer.js
+++ b/shared/tempo/verifier/src/cases/faucet-funded-transfer.js
@@ -67,15 +67,13 @@ async function verify({ client, config, fromBlock }) {
     );
   }
 
-  return waitForEvidence(config, async () => {
-    const evidence = await findEvidence(fromBlock);
-    if (evidence || fromBlock === 0n) return evidence;
-
-    // A shared-environment runner can hand the verifier an RPC snapshot taken
-    // after submission execution. The task localnet is isolated per trial, so
-    // retrying from genesis preserves the full funding-and-transfer contract.
-    return findEvidence(0n);
-  }, "no matching faucet-funded transfer event observed");
+  // The verifier captures this baseline before `npm run eval`. Keep it: the
+  // localnet seeds the DEX maker with the same fixture key during setup.
+  return waitForEvidence(
+    config,
+    () => findEvidence(fromBlock),
+    "no matching faucet-funded transfer event observed",
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## Motivation

Prevent faucet verification from accepting localnet setup funding as submission evidence.

## Summary

- Remove the genesis fallback for faucet evidence lookup
- Document why the pre-eval block baseline is required

## Key design considerations

- Verification still checks the configured faucet funding and transfer sequence
- The isolated localnet seeds the DEX maker before submission execution