### PR TITLE
chore: remove Tempo reliability quality criterion

### DIFF
--- a/shared/global/rewardkit/quality/reward.toml
+++ b/shared/global/rewardkit/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy-mcp/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo/transfer-with-memo"
-digest = "sha256:f76014e05214c73f053ab2351ad8c1771b433581d50162e2a36c0e551ce2e806"
+digest = "sha256:2b6d1b48e88b5f7b2987d19cc64671627dbf85545eab56980d81d8dc569423bf"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-mcp"
-digest = "sha256:decb48273ceebfe6e6edb7219da36d1158b43f2ea4a7e06a3606cf3536bab8c2"
+digest = "sha256:64ac87e6787e29fda8afa26558995b9f3bebb3b52aae525cfb975b8cf64a24a5"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer"
-digest = "sha256:d8e5b460016126e2702daa9809e538dfd7969499f06075aae5dedcc92d1a441d"
+digest = "sha256:fe304cfa5c04e39e4eb7548d85f0a4118c6217b3e27d38a4796f1daaeebfcf66"
 
 [[tasks]]
 name = "tempo/transfer-with-memo-fee-payer-mcp"
-digest = "sha256:c4771ed670f1b78305811742e003e47f45c8987bc72d303325101b55688edd19"
+digest = "sha256:0692f13b769545b4e4f24c8b63e3a4b794aceea745c381593417ce818260fc08"
 
 [[tasks]]
 name = "tempo/set-fee-token"
-digest = "sha256:5b52c5de73cb4dc2cc48a8609df34de3ed8e90a87f427559881da15fd9c8d5b1"
+digest = "sha256:7b29eed00d7bb94d0286ce1d1b8536de4ef5ff11313a89d1626a8bd8a974ea3a"
 
 [[tasks]]
 name = "tempo/set-fee-token-mcp"
-digest = "sha256:39faca3705fdd09c71c61180cfdee90ac44e041dd510f3ee208b003119ef37c1"
+digest = "sha256:013d5a906eef6c5178c39df35d034c39738d7be459fe6c51d8a98f0c42b3a085"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy"
-digest = "sha256:bb5d88ca9e8a1dc051e846d2e979dc43d3b710830b8f885bfeb84ba888b01540"
+digest = "sha256:b61e4e117d16e2734e1e9a22cddbf6097d3c947ca9d3cb697a513e192b10ad5c"
 
 [[tasks]]
 name = "tempo/create-stablecoin-with-policy-mcp"
-digest = "sha256:b25ce8ec8fc53d426b1b28ba14d20fea002d4809e4f98a11a4396b701426ce07"
+digest = "sha256:f2eeac7248af7256dbef9fc1939f9b68547fe3231a29bf344b5b921e458b8454"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer"
-digest = "sha256:547e82df1ba1333aa3dae4d10a44f0b18bcbbf3a4ba4518cd2e2790bfe3f7a02"
+digest = "sha256:9eec4bd6f4335d52981ad5c06f7c2f3f6d628a886a343903d96a7a0f12f98f2b"
 
 [[tasks]]
 name = "tempo/faucet-funded-transfer-mcp"
-digest = "sha256:1ba197809c2599a5d05119f6bd70d88335ff896074974061978af2f59a261596"
+digest = "sha256:d05fbce387f30a11b500dfe51c211a49e6d9045094f56727bc88e5b0e9c554aa"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap"
-digest = "sha256:6163644b367c91c07fca487668b32471acbafa4b2deeeb2b0d362a41c8693ba2"
+digest = "sha256:343bb4e23f4afc40b0014b40d18a12b036a1eafab213481d964d4e2ad76f5006"
 
 [[tasks]]
 name = "tempo/stablecoin-dex-swap-mcp"
-digest = "sha256:b4d88c73d5e46301718fae3c4e0274314feda738a5f63ed9d05a7713777dcd97"
+digest = "sha256:42ce80ad5b733b164f1abb595e4356d413f02b332fe814f0f226efb8573e04c4"
 

--- a/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer-mcp/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/set-fee-token-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/set-fee-token-mcp/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
+++ b/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap-mcp/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer-mcp/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-mcp/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5

--- a/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
@@ -19,12 +19,6 @@ points = 5
 description = "The code uses appropriate Tempo or TIP-20 transaction primitives for the requested task, constructs addresses and units carefully, and waits for the submitted transaction to be accepted or confirmed."
 
 [[criterion]]
-name = "is_reliable_and_observable"
-type = "likert"
-points = 5
-description = "The implementation has clear validation and error handling, surfaces useful failure messages, and avoids timing assumptions that would make localnet runs flaky."
-
-[[criterion]]
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5


### PR DESCRIPTION
## Motivation

The reliability-and-observability rubric penalizes intentionally minimal Tempo task solutions for defensive behavior outside the task contract.

## Summary

- Remove the reliability-and-observability quality criterion
- Refresh generated Tempo quality files and dataset digests

## Key design considerations

- Keep the remaining quality criteria unchanged