### PR TITLE
feat: pin Daytona runs to source images

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,8 +5,17 @@ on:
     branches: [main]
     paths:
       - shared/global/docker/base/**
-      - shared/global/rewardkit-package/**
+      - shared/global/rewardkit-lib/**
       - shared/tempo/verifier/**
+      - scripts/base_image.py
+      - config/tasks.yaml
+      - .github/workflows/build-base-image.yml
+  pull_request:
+    paths:
+      - shared/global/docker/base/**
+      - shared/global/rewardkit-lib/**
+      - shared/tempo/verifier/**
+      - scripts/base_image.py
       - config/tasks.yaml
       - .github/workflows/build-base-image.yml
   workflow_dispatch:
@@ -17,18 +26,29 @@ permissions:
 
 jobs:
   build-and-push:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
 
-      - name: Read pinned base image ref
+      - name: Resolve image refs
         id: image
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          ref=$(sed -nE 's/^[[:space:]]*base_image:[[:space:]]*([^[:space:]#]+).*/\1/p' config/tasks.yaml)
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          repository=$(uv run python scripts/base_image.py ref | sed 's/:source-.*$//')
+          source_tag=$(uv run python scripts/base_image.py tag)
+          if [ "$EVENT_NAME" = pull_request ]; then
+            tag="pr-$PR_NUMBER-$source_tag"
+          else
+            tag="main-$source_tag"
+          fi
+          echo "ref=$repository:$tag" >> "$GITHUB_OUTPUT"
+          echo "release_ref=$(sed -nE 's/^[[:space:]]*base_image:[[:space:]]*([^[:space:]#]+).*/\1/p' config/tasks.yaml)" >> "$GITHUB_OUTPUT"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,3 +59,10 @@ jobs:
           docker build -t "${{ steps.image.outputs.ref }}" \
             -f shared/global/docker/base/Dockerfile .
           docker push "${{ steps.image.outputs.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            docker tag "${{ steps.image.outputs.ref }}" "${{ steps.image.outputs.release_ref }}"
+            docker push "${{ steps.image.outputs.release_ref }}"
+          fi
+
+      - name: Publish image reference
+        run: echo "Base image: \`${{ steps.image.outputs.ref }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cleanup-pr-base-images.yml
+++ b/.github/workflows/cleanup-pr-base-images.yml
@@ -1,0 +1,33 @@
+name: Cleanup PR base images
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete expired PR image versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: tempo-bench-base
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cutoff=$(date -u -d '7 days ago' +%s)
+          gh api --paginate "/orgs/$OWNER/packages/container/$PACKAGE/versions?per_page=100" \
+            --jq '.[] | [.id, .created_at, (.metadata.container.tags | join(","))] | @tsv' |
+            while IFS=$'\t' read -r id created_at tags; do
+              created=$(date -u -d "$created_at" +%s)
+              if [[ "$tags" == *"pr-${PR_NUMBER}-source-"* ]] || \
+                 { [[ "$tags" == pr-*-source-* ]] && (( created < cutoff )); }; then
+                gh api --method DELETE "/orgs/$OWNER/packages/container/$PACKAGE/versions/$id"
+              fi
+            done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,9 @@ pympp, `shared/global/rewardkit-lib/`) and the Tempo JS verifier
 `.github/workflows/build-base-image.yml`. After changing the base image
 contents, re-run `npm run sync`.
 
-Daytona requires an explicit CI-published base image and resolves it to an
-immutable digest before running. PR base images are short-lived; use the image
-tag from the PR build workflow for Daytona validation.
+Daytona requires an explicit CI-published base image. PR base images are
+short-lived; use the image tag from the PR build workflow for Daytona
+validation.
 
 The pinned base-image tag is intentionally mutable during a Tempo Bench version.
 Only bump `base_image` when cutting a new Tempo Bench version; ordinary shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ pympp, `shared/global/rewardkit-lib/`) and the Tempo JS verifier
 `.github/workflows/build-base-image.yml`. After changing the base image
 contents, re-run `npm run sync`.
 
+Daytona requires an explicit CI-published base image and resolves it to an
+immutable digest before running. PR base images are short-lived; use the image
+tag from the PR build workflow for Daytona validation.
+
 The pinned base-image tag is intentionally mutable during a Tempo Bench version.
 Only bump `base_image` when cutting a new Tempo Bench version; ordinary shared
 base-image changes should replace the image at the existing tag and re-run

--- a/README.md
+++ b/README.md
@@ -221,8 +221,7 @@ npm run clean
 
 ## Daytona Base Images
 
-Daytona runs require an explicit base image and resolve its tag to an immutable
-digest before staging task Dockerfiles. If you change the shared base image,
+Daytona runs require an explicit base image. If you change the shared base image,
 RewardKit library, or Tempo verifier on a branch, CI publishes a short-lived PR
 image before you run Daytona:
 
@@ -231,9 +230,9 @@ image before you run Daytona:
 npm run bench:daytona:agent:dev -- --base-image ghcr.io/tempoxyz/tempo-bench-base:pr-<number>-source-<hash>
 ```
 
-The runner resolves tags to digests and writes the exact `FROM` reference into
-the staged tasks. PR image versions are deleted when the PR closes and by a
-seven-day cleanup job.
+The runner writes the exact image reference into staged tasks. CI never
+overwrites source-tagged images; PR image versions are deleted when the PR
+closes and by a seven-day cleanup job.
 
 ## Jobs
 

--- a/README.md
+++ b/README.md
@@ -209,12 +209,31 @@ npm run check
 # Check generated Tempo files
 npm run check:generated
 
+# Print the immutable source-derived base-image tag for Daytona
+npm run base-image:ref
+
 # Open Harbor job viewer
 npm run harbor:view
 
 # Clean job/cache output
 npm run clean
 ```
+
+## Daytona Base Images
+
+Daytona runs require an explicit base image and resolve its tag to an immutable
+digest before staging task Dockerfiles. If you change the shared base image,
+RewardKit library, or Tempo verifier on a branch, CI publishes a short-lived PR
+image before you run Daytona:
+
+```bash
+# CI prints the PR image tag, then resolve and use it for the run.
+npm run bench:daytona:agent:dev -- --base-image ghcr.io/tempoxyz/tempo-bench-base:pr-<number>-source-<hash>
+```
+
+The runner resolves tags to digests and writes the exact `FROM` reference into
+the staged tasks. PR image versions are deleted when the PR closes and by a
+seven-day cleanup job.
 
 ## Jobs
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "sync": "uv run python scripts/run_benchmark.py sync",
     "dataset": "uv run python scripts/run_benchmark.py dataset",
     "build-base": "uv run python scripts/run_benchmark.py build-base",
+    "base-image:ref": "uv run python scripts/base_image.py ref",
     "bench": "uv run python scripts/run_benchmark.py local-agent",
     "bench:model": "uv run python scripts/run_benchmark.py model",
     "bench:local:tempo": "uv run python scripts/run_benchmark.py local-oracle-dev --no-sync --task-suite tempo",

--- a/scripts/base_image.py
+++ b/scripts/base_image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -24,12 +25,25 @@ def base_image_repository() -> str:
 
 def source_hash() -> str:
     digest = hashlib.sha256()
-    for input_path in INPUTS:
-        directory = ROOT / input_path
-        for file_path in sorted(
-            path for path in directory.rglob("*") if path.is_file()
-        ):
-            digest.update(file_path.relative_to(ROOT).as_posix().encode())
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            *(str(path) for path in INPUTS),
+        ],
+        check=True,
+        cwd=ROOT,
+        capture_output=True,
+    )
+    for name in sorted(filter(None, result.stdout.decode().split("\0"))):
+        file_path = ROOT / name
+        if file_path.is_file():
+            digest.update(name.encode())
             digest.update(b"\0")
             digest.update(file_path.read_bytes())
             digest.update(b"\0")

--- a/scripts/base_image.py
+++ b/scripts/base_image.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Print the immutable base-image tag derived from its build inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUTS = (
+    Path("shared/global/docker/base"),
+    Path("shared/global/rewardkit-lib"),
+    Path("shared/tempo/verifier"),
+)
+
+
+def base_image_repository() -> str:
+    image = yaml.safe_load((ROOT / "config/tasks.yaml").read_text())["base_image"]
+    return str(image).rsplit(":", maxsplit=1)[0]
+
+
+def source_hash() -> str:
+    digest = hashlib.sha256()
+    for input_path in INPUTS:
+        directory = ROOT / input_path
+        for file_path in sorted(
+            path for path in directory.rglob("*") if path.is_file()
+        ):
+            digest.update(file_path.relative_to(ROOT).as_posix().encode())
+            digest.update(b"\0")
+            digest.update(file_path.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()[:16]
+
+
+def source_tag() -> str:
+    return f"source-{source_hash()}"
+
+
+def source_image_ref() -> str:
+    return f"{base_image_repository()}:{source_tag()}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("field", choices=["hash", "ref", "tag"])
+    args = parser.parse_args()
+    value = {
+        "hash": source_hash(),
+        "ref": source_image_ref(),
+        "tag": source_tag(),
+    }[args.field]
+    print(value)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/base_image_test.py
+++ b/scripts/base_image_test.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.base_image import source_hash, source_image_ref
+from scripts.run_benchmark import base_image_ref, override_staged_base_image
+
+
+class BaseImageTest(unittest.TestCase):
+    def test_source_image_ref_uses_a_stable_content_hash(self) -> None:
+        self.assertRegex(source_hash(), r"^[0-9a-f]{16}$")
+        self.assertEqual(
+            source_image_ref(),
+            f"{base_image_ref().rsplit(':', 1)[0]}:source-{source_hash()}",
+        )
+
+    def test_override_staged_base_image_uses_an_immutable_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dockerfile = (
+                Path(directory)
+                / "tasks"
+                / "tempo-v1"
+                / "task"
+                / "environment"
+                / "Dockerfile"
+            )
+            dockerfile.parent.mkdir(parents=True)
+            dockerfile.write_text(f"FROM {base_image_ref()}\n")
+
+            override_staged_base_image(Path(directory), "ghcr.io/test/base@sha256:abc")
+
+            self.assertEqual(
+                dockerfile.read_text(), "FROM ghcr.io/test/base@sha256:abc\n"
+            )

--- a/scripts/base_image_test.py
+++ b/scripts/base_image_test.py
@@ -16,7 +16,7 @@ class BaseImageTest(unittest.TestCase):
             f"{base_image_ref().rsplit(':', 1)[0]}:source-{source_hash()}",
         )
 
-    def test_override_staged_base_image_uses_an_immutable_ref(self) -> None:
+    def test_override_staged_base_image_uses_the_published_ref(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             dockerfile = (
                 Path(directory)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -96,6 +96,7 @@ Options:
                           (default: tasks/tempo-v1)
   --docs-sha SHA          Serve docs pinned to this SHA instead of public docs
   --profile PROFILE       Tempo access profile: docs, mcp, or all (default: docs)
+  --base-image REF        Immutable Daytona base image tag or digest (required)
   --no-force-build        Ask Harbor to reuse Docker environment builds
   --no-delete             Keep Harbor environments after the run for debugging
   --disable-verification  Skip verifier execution
@@ -143,6 +144,7 @@ def parse_args(argv: list[str]) -> tuple[str | None, dict[str, Any]]:
     parser.add_argument(
         "--profile", choices=(*PROFILE_IDS, "all"), default=DOCS_PROFILE["id"]
     )
+    parser.add_argument("--base-image")
     parser.add_argument("--no-sync", action="store_false", dest="sync", default=True)
     parser.add_argument("--no-force-build", action="store_true")
     parser.add_argument("--no-delete", action="store_true")
@@ -304,6 +306,33 @@ def build_base_image() -> None:
             ".",
         ],
     )
+
+
+def resolve_image_digest(image: str) -> str:
+    if "@sha256:" in image:
+        return image
+    digest = run_output(
+        "docker",
+        ["buildx", "imagetools", "inspect", "--format", "{{.Manifest.Digest}}", image],
+    )
+    if not digest or not digest.startswith("sha256:"):
+        msg = (
+            f"Could not resolve a digest for {image}. Publish this branch base image "
+            "with the Build base image workflow, then retry."
+        )
+        raise RuntimeError(msg)
+    repository = image.rsplit(":", maxsplit=1)[0]
+    return f"{repository}@{digest}"
+
+
+def daytona_base_image(options: dict[str, Any]) -> str:
+    image = options.get("base_image")
+    if not image:
+        raise RuntimeError(
+            "Daytona requires --base-image. Publish a branch image in CI and use its "
+            "tag or digest."
+        )
+    return resolve_image_digest(image)
 
 
 def sync_dataset(options: dict[str, Any]) -> None:
@@ -821,12 +850,27 @@ def stage_pinned_docs_task(task_dir: Path, docs_bundle: str) -> None:
     trust_docs_ca(environment_dir, generate_docs_tls_assets(environment_dir))
 
 
-def stage_task_datasets(staging_root: Path, docs_bundle: str | None) -> None:
+def override_staged_base_image(staging_root: Path, image: str) -> None:
+    expected = f"FROM {base_image_ref()}"
+    for dockerfile in staging_root.glob("tasks/*/*/environment/Dockerfile"):
+        content = dockerfile.read_text()
+        if expected not in content:
+            raise RuntimeError(f"Unexpected base image in staged task: {dockerfile}")
+        dockerfile.write_text(content.replace(expected, f"FROM {image}", count=1))
+
+
+def stage_task_datasets(
+    staging_root: Path,
+    docs_bundle: str | None,
+    base_image: str | None = None,
+) -> None:
     staged_tasks = staging_root / "tasks" / "tempo-v1"
     staged_tasks.parent.mkdir(parents=True, exist_ok=True)
     copy_tasks(Path("tasks/tempo-v1"), staged_tasks)
     if Path("tasks/mpp").exists():
         copy_tasks(Path("tasks/mpp"), staging_root / "tasks" / "mpp")
+    if base_image is not None:
+        override_staged_base_image(staging_root, base_image)
     if docs_bundle is not None:
         for task_dir in staged_tasks.iterdir():
             if task_dir.is_dir() and (task_dir / "task.toml").exists():
@@ -853,7 +897,7 @@ def stage_daytona_config(
     staged_config = staging_root / "job.yaml"
 
     shutil.rmtree(staging_root, ignore_errors=True)
-    stage_task_datasets(staging_root, docs_bundle)
+    stage_task_datasets(staging_root, docs_bundle, daytona_base_image(options))
 
     config = apply_profile(finalize_config(config, options), options["profile"])
     redirect_dataset_paths(config, staging_root)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -308,23 +308,6 @@ def build_base_image() -> None:
     )
 
 
-def resolve_image_digest(image: str) -> str:
-    if "@sha256:" in image:
-        return image
-    digest = run_output(
-        "docker",
-        ["buildx", "imagetools", "inspect", "--format", "{{.Manifest.Digest}}", image],
-    )
-    if not digest or not digest.startswith("sha256:"):
-        msg = (
-            f"Could not resolve a digest for {image}. Publish this branch base image "
-            "with the Build base image workflow, then retry."
-        )
-        raise RuntimeError(msg)
-    repository = image.rsplit(":", maxsplit=1)[0]
-    return f"{repository}@{digest}"
-
-
 def daytona_base_image(options: dict[str, Any]) -> str:
     image = options.get("base_image")
     if not image:
@@ -332,7 +315,7 @@ def daytona_base_image(options: dict[str, Any]) -> str:
             "Daytona requires --base-image. Publish a branch image in CI and use its "
             "tag or digest."
         )
-    return resolve_image_digest(image)
+    return image
 
 
 def sync_dataset(options: dict[str, Any]) -> None:

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -6,12 +6,14 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 from scripts.run_benchmark import (
     MCP_PROFILE,
     BenchmarkKey,
     apply_profile,
     benchmark_provenance,
+    daytona_base_image,
     finalize_config,
     parse_args,
     run_benchmark_key,
@@ -106,6 +108,17 @@ class RunBenchmarkTest(unittest.TestCase):
                 {"name": "oracle"},
             ],
         )
+
+    @patch("scripts.run_benchmark.run_output", return_value="sha256:base")
+    def test_daytona_base_image_resolves_to_a_digest(self, _: object) -> None:
+        self.assertEqual(
+            daytona_base_image({"base_image": "ghcr.io/tempoxyz/base:source-test"}),
+            "ghcr.io/tempoxyz/base@sha256:base",
+        )
+
+    def test_daytona_base_image_requires_an_explicit_image(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "requires --base-image"):
+            daytona_base_image({})
 
     def test_staged_pinned_docs_keep_the_public_hostname(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -6,7 +6,6 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
 
 from scripts.run_benchmark import (
     MCP_PROFILE,
@@ -109,11 +108,10 @@ class RunBenchmarkTest(unittest.TestCase):
             ],
         )
 
-    @patch("scripts.run_benchmark.run_output", return_value="sha256:base")
-    def test_daytona_base_image_resolves_to_a_digest(self, _: object) -> None:
+    def test_daytona_base_image_uses_the_supplied_image(self) -> None:
         self.assertEqual(
             daytona_base_image({"base_image": "ghcr.io/tempoxyz/base:source-test"}),
-            "ghcr.io/tempoxyz/base@sha256:base",
+            "ghcr.io/tempoxyz/base:source-test",
         )
 
     def test_daytona_base_image_requires_an_explicit_image(self) -> None:


### PR DESCRIPTION
## Motivation

Daytona can run a stale mutable base image after verifier changes, producing results against a different contract than the checked-out tasks.

## Summary

- Publish source-hashed base images from CI, including branch-dispatched builds
- Resolve Daytona base image tags to immutable digests before staging tasks
- Document the branch image workflow and add an explicit image override

## Key design considerations

- The mutable release tag remains a main-branch convenience alias
- Daytona task Dockerfiles use the resolved digest for each run