### PR TITLE
fix: support all task-suite runs

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -413,6 +413,10 @@ def benchmark_provenance(task_suite: str | None) -> list[dict[str, str]]:
 
 
 def run_benchmark_key(variant: dict[str, Any], task_suite: str | None) -> BenchmarkKey:
+    # An all-suite run combines datasets, so retain the variant's benchmark
+    # identity for the generated job name.
+    if task_suite == "all":
+        return benchmark_key(variant.get("benchmark"))
     return benchmark_key(task_suite or variant.get("benchmark"))
 
 

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -91,6 +91,9 @@ class RunBenchmarkTest(unittest.TestCase):
         self.assertEqual(
             run_benchmark_key({"benchmark": "tempo"}, "mpp"), BenchmarkKey.MPP
         )
+        self.assertEqual(
+            run_benchmark_key({"benchmark": "tempo"}, "all"), BenchmarkKey.TEMPO
+        )
 
     def test_parse_args_accepts_all_profiles(self) -> None:
         _, options = parse_args(["daytona-agent", "--profile", "all"])


### PR DESCRIPTION
## Motivation

Combined task-suite runs accepted `all` but failed while generating their job name.

## Summary

- Preserve the owning benchmark identity for `all` task-suite job names
- Add regression coverage for combined-suite naming

## Key design considerations

- `all` controls dataset selection while the variant controls the job naming namespace