### PR TITLE
fix: verify stablecoin currency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "results:export": "uv run python scripts/export_results.py",
     "results:compare": "uv run python scripts/compare_mcp_results.py",
     "harbor:view": "uv run harbor view jobs",
-    "check": "npm run check:scripts && npm run test:results && npm run check:shell && npm run check:docs && npm run check:format && npm run check:lint",
+    "check": "npm run check:scripts && npm run test:results && npm run test:tempo-verifier && npm run check:shell && npm run check:docs && npm run check:format && npm run check:lint",
     "check:dataset": "uv run python scripts/run_benchmark.py check-dataset",
     "check:docs": "npm run docs:prepare && npm run docs:check",
     "check:generated": "uv run python scripts/run_benchmark.py check-generated",
@@ -39,6 +39,7 @@
     "check:scripts": "uv run python -m compileall -q scripts",
     "test:results": "uv run python -m unittest discover -s scripts -p '*_test.py'",
     "test:mcp-bridge": "node --test shared/tempo/mcp-bridge/server.test.mjs",
+    "test:tempo-verifier": "npm ci --ignore-scripts --no-audit --no-fund --prefix shared/tempo/verifier && npm test --prefix shared/tempo/verifier",
     "clean": "uv run python scripts/run_benchmark.py clean",
     "clean:jobs": "uv run python scripts/run_benchmark.py clean-jobs"
   }

--- a/shared/tempo/verifier/package.json
+++ b/shared/tempo/verifier/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "tempo-bench-verify": "bin/tempo-bench-verify.js"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "viem": "^2.53.1"
   }

--- a/shared/tempo/verifier/src/cases/create-stablecoin-with-policy.js
+++ b/shared/tempo/verifier/src/cases/create-stablecoin-with-policy.js
@@ -114,6 +114,7 @@ async function verify({ client, config, fromBlock }) {
       args.name === output.stablecoin.name &&
       args.symbol === output.stablecoin.symbol &&
       args.currency === output.stablecoin.currency &&
+      args.currency === config.stablecoinCurrency &&
       sameAddress(args.admin, output.payer) &&
       args.salt.toLowerCase() === output.stablecoin.salt.toLowerCase(),
     );

--- a/shared/tempo/verifier/src/cases/create-stablecoin-with-policy.js
+++ b/shared/tempo/verifier/src/cases/create-stablecoin-with-policy.js
@@ -39,7 +39,7 @@ function result(config) {
       "result",
     );
     expectObject(config, value.payer, ["address"], "payer");
-    expectObject(config, value.stablecoin, ["address", "name", "symbol", "currency", "salt"], "stablecoin");
+    expectObject(config, value.stablecoin, ["address", "name", "symbol", "salt"], "stablecoin");
     expectObject(config, value.policy, ["id"], "policy");
     return {
       payer: expectAddress(config, value.payer.address, "payer.address"),
@@ -47,7 +47,6 @@ function result(config) {
         address: expectAddress(config, value.stablecoin.address, "stablecoin.address"),
         name: expectText(config, value.stablecoin.name, "stablecoin.name"),
         symbol: expectText(config, value.stablecoin.symbol, "stablecoin.symbol"),
-        currency: expectText(config, value.stablecoin.currency, "stablecoin.currency"),
         salt: expectHex32(config, value.stablecoin.salt, "stablecoin.salt"),
       },
       policyId: expectUint(config, value.policy.id, "policy.id"),
@@ -113,7 +112,6 @@ async function verify({ client, config, fromBlock }) {
       sameAddress(args.token, output.stablecoin.address) &&
       args.name === output.stablecoin.name &&
       args.symbol === output.stablecoin.symbol &&
-      args.currency === output.stablecoin.currency &&
       args.currency === config.stablecoinCurrency &&
       sameAddress(args.admin, output.payer) &&
       args.salt.toLowerCase() === output.stablecoin.salt.toLowerCase(),

--- a/shared/tempo/verifier/test/create-stablecoin-with-policy.test.js
+++ b/shared/tempo/verifier/test/create-stablecoin-with-policy.test.js
@@ -36,7 +36,7 @@ test("rejects a stablecoin with the wrong configured currency", async () => {
     resultPath,
     JSON.stringify({
       payer: { address: payer },
-      stablecoin: { address: token, name: "Agent Dollar", symbol: "AGD", currency: "EUR", salt },
+      stablecoin: { address: token, name: "Agent Dollar", symbol: "AGD", salt },
       policy: { id: "1" },
       tokenCreateTransactionHash: hash("1"),
       policyCreateTransactionHash: hash("2"),

--- a/shared/tempo/verifier/test/create-stablecoin-with-policy.test.js
+++ b/shared/tempo/verifier/test/create-stablecoin-with-policy.test.js
@@ -1,0 +1,63 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const payer = "0x1111111111111111111111111111111111111111";
+const token = "0x2222222222222222222222222222222222222222";
+const salt = `0x${"01".repeat(32)}`;
+const hash = (digit) => `0x${digit.repeat(64)}`;
+
+test("rejects a stablecoin with the wrong configured currency", async () => {
+  const tempoPath = require.resolve("../src/tempo");
+  require.cache[tempoPath] = {
+    exports: {
+      findEvent(_receipt, _address, event, matches) {
+        const args = {
+          TokenCreated: { token, name: "Agent Dollar", symbol: "AGD", currency: "EUR", admin: payer, salt },
+          PolicyCreated: { policyId: 1n, updater: payer, policyType: 1 },
+          BlacklistUpdated: { policyId: 1n, updater: payer, account: payer, restricted: true },
+          TransferPolicyUpdate: { updater: payer, newPolicyId: 1n },
+        }[event.name];
+        return matches(args) ? { args } : null;
+      },
+      receiptAfter: async () => ({ blockNumber: 2n }),
+      sameAddress: (left, right) => left.toLowerCase() === right.toLowerCase(),
+      waitForEvidence: async (_config, check) => check(),
+    },
+  };
+  delete require.cache[require.resolve("../src/cases/create-stablecoin-with-policy")];
+  const { verify } = require("../src/cases/create-stablecoin-with-policy");
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tempo-verifier-"));
+  const resultPath = path.join(dir, "out.json");
+  fs.writeFileSync(
+    resultPath,
+    JSON.stringify({
+      payer: { address: payer },
+      stablecoin: { address: token, name: "Agent Dollar", symbol: "AGD", currency: "EUR", salt },
+      policy: { id: "1" },
+      tokenCreateTransactionHash: hash("1"),
+      policyCreateTransactionHash: hash("2"),
+      policyAccountTransactionHash: hash("3"),
+      linkPolicyTransactionHash: hash("4"),
+    }),
+  );
+
+  await assert.rejects(
+    verify({
+      client: {},
+      config: {
+        resultPath,
+        stablecoinCurrency: "USD",
+        policyType: "blacklist",
+        policyAccount: payer,
+        tip20Factory: payer,
+        tip403Registry: payer,
+      },
+      fromBlock: 1n,
+    }),
+    /does not create the output stablecoin/,
+  );
+});

--- a/tasks/tempo-v1/create-stablecoin-with-policy/instruction.md
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/instruction.md
@@ -33,7 +33,7 @@ When `npm run eval` finishes, write `/app/out.json` matching this schema:
   "additionalProperties": false,
   "properties": {
     "payer": { "type": "object", "required": ["address"], "additionalProperties": false, "properties": { "address": { "type": "string" } } },
-    "stablecoin": { "type": "object", "required": ["address", "name", "symbol", "currency", "salt"], "additionalProperties": false, "properties": { "address": { "type": "string" }, "name": { "type": "string" }, "symbol": { "type": "string" }, "currency": { "type": "string" }, "salt": { "type": "string" } } },
+    "stablecoin": { "type": "object", "required": ["address", "name", "symbol", "salt"], "additionalProperties": false, "properties": { "address": { "type": "string" }, "name": { "type": "string" }, "symbol": { "type": "string" }, "salt": { "type": "string" } } },
     "policy": { "type": "object", "required": ["id"], "additionalProperties": false, "properties": { "id": { "type": "string" } } },
     "tokenCreateTransactionHash": { "type": "string" },
     "policyCreateTransactionHash": { "type": "string" },

--- a/tasks/tempo-v1/create-stablecoin-with-policy/solution/src/index.ts
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/solution/src/index.ts
@@ -51,7 +51,6 @@ const output = {
     address: tokenResult.token,
     name,
     symbol,
-    currency: required("TEMPO_STABLECOIN_CURRENCY"),
     salt,
   },
   policy: { id: policyResult.policyId.toString() },

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,7 +11,7 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:cde77a23624d7d86e28bdbf5cf95678e3e40201110309b09fa5c4dbcc1fa9040"
+digest = "sha256:7e3dbaed73a5943c78bd95414d24b11481507f7745813e16c83643a6b1c38b82"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"


### PR DESCRIPTION
## Summary

Verify the stablecoin creation event against the task's configured `TEMPO_STABLECOIN_CURRENCY`.

Keep currency evaluator-owned by removing the redundant field from the agent output schema, oracle artifact, and verifier parser. Add a negative regression test for an on-chain event with the wrong configured currency, and run verifier tests from the root check.

## Validation

- `npm run check`
- `npm run check:dataset`
- `npm run check:generated`
- `npm run bench:local:one -- --task-filter tempo-v1/create-stablecoin-with-policy --job-name smoke-pr84-no-currency`
