### PR TITLE
docs: refresh Tempo task descriptions

### DIFF
--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -1,6 +1,6 @@
 # tempo/tempo-bench-v1
 
-Local Harbor dataset for Tempo integration evaluations.
+Harbor dataset for Tempo integration evaluations on Tempo testnet.
 
 Task directories in this directory are the authored Tempo benchmark tasks.
 Edit them directly. `npm run sync` refreshes dataset manifests, MPP shared
@@ -17,20 +17,17 @@ Current task intents:
 - `tempo-v1/faucet-funded-transfer`
 - `tempo-v1/stablecoin-dex-swap`
 
-Each task is run with either the Docs or MCP access profile. The benchmark job
-serves pinned docs for the Docs profile and injects the Tempo MCP server for
-the MCP profile, so both profiles use the same task artifact.
+Each task is run with either the Docs or MCP access profile. Docs uses Tempo's
+public documentation by default and can serve a pinned bundle with
+`--docs-sha`; MCP adds the Tempo MCP server at the job level. Both profiles use
+the same task artifact.
 
-Each task is Harbor-native and self-contained:
+Each task is authored directly as a Harbor task:
 
-- `instruction.md` is the agent-facing prompt, including the localnet
-  execution constraints and Docs access guidance.
-- `task.toml` owns fixture values, verifier selection, resources, and
-  sidecars. MCP configuration is applied by the benchmark job, not stored in
-  the task artifact.
-- `environment/` contains the task runtime and Docker Compose additions.
-  Common sidecars are symlinked from `../../shared/` where Harbor and Docker
-  can consume them.
+- `instruction.md` is the agent-facing prompt and output contract.
+- `task.toml` owns task metadata, environment defaults, verifier selection,
+  and resource limits. Profile configuration is applied by the benchmark job.
+- `environment/Dockerfile` extends the shared benchmark base image.
 - `tests/correctness/` contains task-specific RewardKit criteria and the
   independent onchain verifier. `tests/quality/` contains turn/token
   efficiency checks and the Claude Haiku LLM judge. `tests/test.sh` runs the
@@ -38,8 +35,8 @@ Each task is Harbor-native and self-contained:
   `/logs/verifier/reward.json` as zero and skips RewardKit. On success,
   RewardKit writes the primary score from the weighted aggregate of all static
   and available LLM quality criteria. A score of one requires every included
-  criterion to score one. `tests/tempo-bench-verifier/` is a minimal copied
-  verifier package for the selected `TEMPO_BENCH_CASE`.
+  criterion to score one. The shared Tempo verifier is installed in the base
+  image and selects the case named by `TEMPO_BENCH_CASE`.
 - `solution/` contains the oracle solution used for sanity checks.
 
 After changing a task, run `npm run dataset` to refresh `dataset.toml` digests.

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -23,11 +23,11 @@ digest = "sha256:d570aba84facf31ac0dcd3214456779725143039438bc9e39dfb3f1b6d9a6a9
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:579b41f09f8e33ca9689159ac461a7661a849e7ba91d805db2007ed5a86fe4c8"
+digest = "sha256:60ac6fe374fb39d1ce8a4eb75b61ed839df6bcbf21a2f892ee28496397432c03"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:7401db096b493ed57de50cf6d64f16b0c628e6e99a8ecca11f9b14fbce021c16"
+digest = "sha256:f5f70fb3fa9f149d37d5c0539ad04591ead165d247cdc805c683ca137cf768cf"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"

--- a/tasks/tempo-v1/stablecoin-dex-swap/README.md
+++ b/tasks/tempo-v1/stablecoin-dex-swap/README.md
@@ -9,7 +9,7 @@ on testnet.
 
 - Token approval flow
 - Stablecoin DEX swap execution
-- Maker and taker output artifacts
+- Taker output artifact and on-chain fill evidence
 
 ## Verification
 

--- a/tasks/tempo-v1/transfer-batched/README.md
+++ b/tasks/tempo-v1/transfer-batched/README.md
@@ -16,5 +16,5 @@ Build a TypeScript integration that pays every recipient in a supplied list the 
 - Usage of proper Tempo libraries: `viem/tempo` TIP-20 ABI utilities are required; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including:
   - Every configured recipient receives the configured stablecoin amount.
-  - All transfers originate from the configured payer.
+  - All transfers originate from the reported payer.
   - One native transaction contains a TIP-20 transfer call for every recipient.


### PR DESCRIPTION
## Summary

Update the Tempo v1 dataset README to describe the current testnet, authored-task, shared-base-image, Docs, and job-level MCP architecture.

Correct the DEX output-artifact wording and refer to the reported payer in the batched-transfer verifier description. Refresh the two affected dataset digests.

## Validation

- `npm run check`
- `npm run check:dataset`
- `npm run check:generated`
- `npm run bench:local:one -- --task-filter tempo-v1/stablecoin-dex-swap --job-name smoke-readmes-dex-oracle`
- `npm run bench:local:one -- --task-filter tempo-v1/transfer-batched --job-name smoke-readmes-batch-oracle`