### PR TITLE
fix: run MCP evals against live docs

### DIFF
--- a/config/tasks.yaml
+++ b/config/tasks.yaml
@@ -30,14 +30,6 @@ profiles:
         transport: streamable-http
         url: http://tempo-mcp-code:8787/mcp
 
-# The canonical run may override the public data MCP with a pinned deployment
-# URL. The bridge exposes the same read-only data tools in both arms and only
-# varies direct docs calls versus docs_code.
-mcp_eval:
-  target_id: tempo-api-mcp-v1
-  endpoint: https://api.tempo.xyz/mcp
-  docs_sha: ${TEMPO_MCP_EVAL_DOCS_SHA:-unrecorded}
-
 mpp:
   # Files copied from shared/mpp into every MPP task by sync.
   shared_files:

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -14,6 +14,7 @@ JsonObject = dict[str, Any]
 Numeric = float | int | str
 
 MCP_PROFILE_SUFFIX = "-mcp"
+LIVE_MCP_DOCS_SOURCE = "live"
 
 TRIAL_COLUMNS = [
     "run_id",
@@ -185,6 +186,15 @@ def parse_task_name(task_name: str, tempo_profile: str = "docs") -> dict[str, st
     return {"task_family": task_name, "profile": "unknown"}
 
 
+def result_docs_source(result: JsonObject, profile: str, context: JsonObject) -> str:
+    if result.get("task_name", "").startswith("tempo-mcp-v1/") and profile in {
+        "mcp-direct",
+        "mcp-code",
+    }:
+        return LIVE_MCP_DOCS_SOURCE
+    return as_string(context.get("docs_source"))
+
+
 def as_object(value: Any) -> JsonObject:
     return value if isinstance(value, dict) else {}
 
@@ -335,6 +345,7 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
     model_info = as_object(agent_info.get("model_info"))
     exception_info = as_object(result.get("exception_info"))
     task = parse_task_name(result["task_name"], profile_from_trial(result))
+    docs_source = result_docs_source(result, task["profile"], context)
     rewards = extract_rewards(result)
     reward = primary_reward(rewards)
     tokens = token_totals(result)
@@ -390,7 +401,7 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
         "cost_usd": tokens["cost"],
         "task_checksum": as_string(result.get("task_checksum")),
         "git_sha": context["git_sha"],
-        "docs_source": context["docs_source"],
+        "docs_source": docs_source,
         "mcp_target_id": context["mcp_target_id"] or trace["target_id"],
         "result_path": str(file_path),
         "rewards": rewards,

--- a/scripts/export_results_test.py
+++ b/scripts/export_results_test.py
@@ -191,10 +191,11 @@ class ExportResultsTest(unittest.TestCase):
                     }
                 ),
             )
+            rows = export_results(job_dir)["trials"]
             self.assertEqual(
-                {row["profile"] for row in export_results(job_dir)["trials"]},
-                {"mcp-direct", "mcp-code"},
+                {row["profile"] for row in rows}, {"mcp-direct", "mcp-code"}
             )
+            self.assertEqual({row["docs_source"] for row in rows}, {"live"})
 
     def test_export_marks_only_clean_mcp_trials_eligible(self) -> None:
         with tempfile.TemporaryDirectory(prefix="tempo-bench-export-") as root:

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -244,6 +244,10 @@ def docs_source(options: dict[str, Any]) -> dict[str, str]:
     return {"mode": "pinned", "repo": lock["repo"], "sha": sha.lower()}
 
 
+def uses_live_mcp_eval(options: dict[str, Any]) -> bool:
+    return options.get("task_suite") == "tempo-mcp"
+
+
 def ensure_docs_bundle(source: dict[str, str]) -> str | None:
     if source["mode"] == "public":
         return None
@@ -1067,7 +1071,7 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
     } and not variant.get("job"):
         raise RuntimeError("The MCP profile requires a job-backed benchmark variant.")
 
-    source = docs_source(options)
+    source = {"mode": "live"} if uses_live_mcp_eval(options) else docs_source(options)
     load_env_file(options.get("env_file"))
     preflight(variant, options)
     preflight_mcp_target(options)
@@ -1075,7 +1079,7 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
         sync_dataset(options)
     if not variant.get("needs_daytona_auth"):
         build_base_image()
-    docs_bundle = ensure_docs_bundle(source)
+    docs_bundle = None if source["mode"] == "live" else ensure_docs_bundle(source)
 
     benchmark = run_benchmark_key(variant, options.get("task_suite"))
     default_run_name = versioned_name(benchmark, variant["prefix"])

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -19,8 +19,10 @@ from scripts.run_benchmark import (
     finalize_config,
     parse_args,
     run_benchmark_key,
+    run_benchmark_variant,
     stage_filtered_config,
     stage_pinned_docs_task,
+    uses_live_mcp_eval,
     versioned_name,
 )
 
@@ -55,6 +57,33 @@ class RunBenchmarkTest(unittest.TestCase):
             finalize_config(base_config(), {"task_suite": "tempo-mcp"})["datasets"],
             [{"path": "tasks/tempo-mcp-v1"}],
         )
+
+    def test_tempo_mcp_suite_uses_the_live_mcp_server(self) -> None:
+        self.assertTrue(uses_live_mcp_eval({"task_suite": "tempo-mcp"}))
+        self.assertFalse(uses_live_mcp_eval({"task_suite": "tempo"}))
+
+    def test_live_mcp_eval_skips_pinned_docs_preparation(self) -> None:
+        options = {
+            "profile": "mcp-direct",
+            "task_suite": "tempo-mcp",
+            "sync": False,
+            "env_file": None,
+            "job_name": "live-mcp-test",
+        }
+        with (
+            patch("scripts.run_benchmark.preflight"),
+            patch("scripts.run_benchmark.preflight_mcp_target"),
+            patch("scripts.run_benchmark.ensure_docs_bundle") as ensure_bundle,
+            patch(
+                "scripts.run_benchmark.stage_daytona_config", return_value="job.yaml"
+            ) as stage,
+            patch("scripts.run_benchmark.run") as run,
+        ):
+            run_benchmark_variant("daytona-agent-dev", options)
+
+        ensure_bundle.assert_not_called()
+        self.assertIsNone(stage.call_args.args[2])
+        run.assert_called_once()
 
     def test_finalize_config_requires_all_suite_for_full_matrix(self) -> None:
         config = finalize_config(base_config(), {"task_suite": "all"})


### PR DESCRIPTION
## Motivation

MCP evaluation arms query the live Tempo MCP server, so staging a pinned docs bundle added misleading provenance and caused concurrent paired runs to contend for the same cache.

## Summary

- Run the Tempo MCP suite without local pinned-doc preparation.
- Export live MCP trials with a `live` docs source.
- Add coverage for the live execution path and provenance export.

## Key design considerations

- The change is limited to `tempo-mcp`; existing pinned Tempo docs runs retain their current behavior.