### PR TITLE
fix: harden MCP benchmark grading

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Run the paired MCP efficiency suite (three attempts per arm):
 npm run bench:local:mcp
 ```
 
+The direct and code arms receive one shared pair ID. Export both runs before
+using `npm run results:compare`; comparisons reject exports without matching
+pair IDs.
+
 ## Running Development Benchmarks
 
 Development flows are for iteration and smoke testing. They keep attempts low and

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "results:export": "uv run python scripts/export_results.py",
     "results:compare": "uv run python scripts/compare_mcp_results.py",
     "harbor:view": "uv run harbor view jobs",
-    "check": "npm run check:scripts && npm run test:results && npm run test:tempo-verifier && npm run check:shell && npm run task:lint && npm run check:docs && npm run check:format && npm run check:lint",
+    "check": "npm run check:scripts && npm run test:results && npm run test:tempo-verifier && npm run test:mcp-bridge && npm run check:shell && npm run task:lint && npm run check:docs && npm run check:format && npm run check:lint",
     "check:dataset": "uv run python scripts/run_benchmark.py check-dataset",
     "check:docs": "npm run docs:prepare && npm run docs:check",
     "check:generated": "uv run python scripts/run_benchmark.py check-generated",

--- a/scripts/compare_mcp_results.py
+++ b/scripts/compare_mcp_results.py
@@ -60,6 +60,7 @@ OVERALL_QUALITY_SUMMARY_COLUMNS = [
     "median_quality_delta",
 ]
 KEYS = [
+    "pair_id",
     "task_family",
     "model",
     "agent",
@@ -87,6 +88,11 @@ def compare(direct_path: str, code_path: str) -> pd.DataFrame:
     code = code[code["profile"] == "mcp-code"].copy()
     if direct.empty or code.empty:
         raise ValueError("inputs must contain mcp-direct and mcp-code trials")
+    if (
+        not direct["pair_id"].astype(str).str.strip().all()
+        or not code["pair_id"].astype(str).str.strip().all()
+    ):
+        raise ValueError("all MCP trials must include a pair_id")
     merged = direct.merge(
         code, on=KEYS, suffixes=("_direct", "_code"), validate="one_to_one"
     )

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -18,6 +18,7 @@ LIVE_MCP_DOCS_SOURCE = "live"
 
 TRIAL_COLUMNS = [
     "run_id",
+    "pair_id",
     "job_name",
     "trial_name",
     "task_name",
@@ -176,6 +177,11 @@ def profile_from_trial(result: JsonObject) -> str:
             if name == "tempo":
                 return "mcp"
     return "docs"
+
+
+def pair_id_from_trial(result: JsonObject) -> str:
+    agent = as_object(as_object(result.get("config")).get("agent"))
+    return as_string(as_object(agent.get("env")).get("TEMPO_BENCH_PAIR_ID"))
 
 
 def parse_task_name(task_name: str, tempo_profile: str = "docs") -> dict[str, str]:
@@ -361,6 +367,7 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
 
     return {
         "run_id": context["run_id"],
+        "pair_id": pair_id_from_trial(result),
         "job_name": context["job_name"],
         "trial_name": result["trial_name"],
         "task_name": result["task_name"],

--- a/scripts/export_results_test.py
+++ b/scripts/export_results_test.py
@@ -176,7 +176,10 @@ class ExportResultsTest(unittest.TestCase):
                     {
                         "task_name": "tempo-mcp-v1/wallet-client",
                         "config": {
-                            "agent": {"mcp_servers": [{"name": "tempo-direct"}]}
+                            "agent": {
+                                "mcp_servers": [{"name": "tempo-direct"}],
+                                "env": {"TEMPO_BENCH_PAIR_ID": "pair-1"},
+                            }
                         },
                     }
                 ),
@@ -207,7 +210,10 @@ class ExportResultsTest(unittest.TestCase):
                     {
                         "task_name": "tempo-mcp-v1/wallet-client",
                         "config": {
-                            "agent": {"mcp_servers": [{"name": "tempo-direct"}]}
+                            "agent": {
+                                "mcp_servers": [{"name": "tempo-direct"}],
+                                "env": {"TEMPO_BENCH_PAIR_ID": "pair-1"},
+                            }
                         },
                         "verifier_result": {"rewards": {"reward": 1, "quality": 0.8}},
                     }
@@ -238,6 +244,7 @@ class ExportResultsTest(unittest.TestCase):
             self.assertTrue(row["mcp_used"])
             self.assertTrue(row["mcp_trace_clean"])
             self.assertTrue(row["eligible"])
+            self.assertEqual(row["pair_id"], "pair-1")
 
     def test_compare_pairs_direct_and_code_trials(self) -> None:
         with tempfile.TemporaryDirectory(prefix="tempo-bench-compare-") as root:
@@ -246,6 +253,7 @@ class ExportResultsTest(unittest.TestCase):
             code_path = root_path / "code.csv"
             row = {
                 "task_family": "tempo-mcp-v1/wallet-client",
+                "pair_id": "pair-1",
                 "model": "test",
                 "agent": "agent",
                 "attempt_index": 1,
@@ -271,6 +279,39 @@ class ExportResultsTest(unittest.TestCase):
             self.assertEqual(result.loc[0, "input_tokens_delta"], 8)
             self.assertEqual(result.loc[0, "mcp_calls_delta"], 2)
 
+    def test_compare_rejects_unpaired_mcp_trials(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tempo-bench-compare-") as root:
+            root_path = Path(root)
+            direct_path = root_path / "direct.csv"
+            code_path = root_path / "code.csv"
+            row = {
+                "task_family": "tempo-mcp-v1/wallet-client",
+                "pair_id": "",
+                "model": "test",
+                "agent": "agent",
+                "attempt_index": 1,
+                "task_checksum": "task",
+                "docs_source": "docs",
+                "passed": "true",
+                "input_tokens": 20,
+                "cache_tokens": 0,
+                "output_tokens": 10,
+                "model_turns": 2,
+                "mcp_calls": 3,
+                "duration_sec": 4,
+                "agent_execution_duration_sec": 3,
+                "cost_usd": 0.01,
+            }
+            pd.DataFrame([{**row, "profile": "mcp-direct"}]).to_csv(
+                direct_path, index=False
+            )
+            pd.DataFrame([{**row, "profile": "mcp-code"}]).to_csv(
+                code_path, index=False
+            )
+
+            with self.assertRaisesRegex(ValueError, "pair_id"):
+                compare(str(direct_path), str(code_path))
+
     def test_quality_summaries_preserve_missing_judge_scores(self) -> None:
         with tempfile.TemporaryDirectory(prefix="tempo-bench-quality-") as root:
             root_path = Path(root)
@@ -278,6 +319,7 @@ class ExportResultsTest(unittest.TestCase):
             code_path = root_path / "code.csv"
             base = {
                 "task_family": "tempo-mcp-v1/wallet-client",
+                "pair_id": "pair-1",
                 "model": "test",
                 "agent": "agent",
                 "task_checksum": "task",

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "shared/tempo/mcp-e
 
 from validation import (  # noqa: E402
     evidence_summary,
+    expected_answer_errors,
     has_required_tool_mix,
     used_data_tools,
     validated_data_evidence,
@@ -92,6 +93,33 @@ class McpEvalValidationTest(unittest.TestCase):
                     }
                 ],
             )
+
+    def test_requires_task_specific_terms_evidence_and_tools(self) -> None:
+        expected = {
+            "required_terms": ["fee", "payer"],
+            "required_patterns": [
+                {
+                    "name": "transaction hash",
+                    "pattern": "0x[a-f0-9]{64}",
+                    "min_matches": 1,
+                }
+            ],
+            "minimum_sources": 1,
+            "required_data_tools": [],
+        }
+        answer = {
+            "answer": "Fee payer 0x" + "a" * 64,
+            "sources": ["https://docs.tempo.xyz/"],
+        }
+        events = [{"allowed": True, "tool": "v1_transactions_get"}]
+
+        self.assertEqual(expected_answer_errors(answer, expected, events), [])
+        self.assertIn(
+            "answer must address task concept: payer",
+            expected_answer_errors(
+                {**answer, "answer": "Fee 0x" + "a" * 64}, expected, events
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -700,6 +700,15 @@ def apply_profile(config: dict[str, Any], profile_id: str) -> dict[str, Any]:
     return config
 
 
+def apply_pair_id(config: dict[str, Any], pair_id: str | None) -> dict[str, Any]:
+    if not pair_id:
+        return config
+    for agent in config.get("agents", []):
+        if agent.get("name") != "oracle":
+            agent.setdefault("env", {})["TEMPO_BENCH_PAIR_ID"] = pair_id
+    return config
+
+
 def redirect_dataset_paths(config: dict[str, Any], staging_root: Path) -> None:
     path_map = {
         "tasks/mpp": str(staging_root / "tasks" / "mpp"),
@@ -956,7 +965,10 @@ def stage_daytona_config(
     shutil.rmtree(staging_root, ignore_errors=True)
     stage_task_datasets(staging_root, docs_bundle, daytona_base_image(options))
 
-    config = apply_profile(finalize_config(config, options), options["profile"])
+    config = apply_pair_id(
+        apply_profile(finalize_config(config, options), options["profile"]),
+        options.get("pair_id"),
+    )
     redirect_dataset_paths(config, staging_root)
     staged_config.write_text(dump_yaml(config))
     return str(staged_config)
@@ -972,7 +984,10 @@ def stage_filtered_config(
     staged_config = staging_root / "job.yaml"
     shutil.rmtree(staging_root, ignore_errors=True)
     staging_root.mkdir(parents=True, exist_ok=True)
-    config = apply_profile(finalize_config(config, options), options["profile"])
+    config = apply_pair_id(
+        apply_profile(finalize_config(config, options), options["profile"]),
+        options.get("pair_id"),
+    )
     if (
         docs_bundle is not None
         or options["profile"] in {MCP_DIRECT_PROFILE["id"], MCP_CODE_PROFILE["id"]}
@@ -1027,15 +1042,15 @@ def main(argv: list[str]) -> None:
             raise RuntimeError(
                 "The all profile requires a job-backed benchmark variant."
             )
+        benchmark = run_benchmark_key(variant, options.get("task_suite"))
+        prefix = versioned_name(benchmark, variant["prefix"])
+        pair_id = options.get("job_name") or f"{prefix}-mcp-pair-{timestamp()}"
         profile_options = [
             options
             | {
                 "profile": profile_id,
-                "job_name": (
-                    f"{options['job_name']}-{profile_id}"
-                    if options.get("job_name")
-                    else None
-                ),
+                "job_name": f"{pair_id}-{profile_id}",
+                "pair_id": pair_id,
                 "sync": options["sync"] if index == 0 else False,
             }
             for index, profile_id in enumerate(

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -13,6 +13,7 @@ from scripts.run_benchmark import (
     MCP_DIRECT_PROFILE,
     MCP_PROFILE,
     BenchmarkKey,
+    apply_pair_id,
     apply_profile,
     benchmark_provenance,
     daytona_base_image,
@@ -165,6 +166,20 @@ class RunBenchmarkTest(unittest.TestCase):
                 0
             ]["mcp_servers"],
             MCP_CODE_PROFILE["mcp_servers"],
+        )
+
+    def test_pair_id_is_injected_for_non_oracle_agents(self) -> None:
+        self.assertEqual(
+            apply_pair_id(
+                {"agents": [{"name": "claude-code"}, {"name": "oracle"}]},
+                "pair-1",
+            ),
+            {
+                "agents": [
+                    {"name": "claude-code", "env": {"TEMPO_BENCH_PAIR_ID": "pair-1"}},
+                    {"name": "oracle"},
+                ]
+            },
         )
 
     def test_daytona_base_image_uses_the_supplied_image(self) -> None:

--- a/scripts/sync_shared.py
+++ b/scripts/sync_shared.py
@@ -164,7 +164,7 @@ def write_mcp_dataset_manifest() -> None:
         f"keywords = {toml_array(MCP_BENCHMARK['keywords'])}\n"
         "[[dataset.authors]]\n"
         f"name = {toml_string(MCP_BENCHMARK['author'])}\n\n\n"
-        f"{task_entries.rstrip()}",
+        f"{task_entries.rstrip()}\n\n",
     )
 
 

--- a/shared/tempo/mcp-eval/check.py
+++ b/shared/tempo/mcp-eval/check.py
@@ -1,9 +1,15 @@
 import json
+import os
 import sys
 from pathlib import Path
 from urllib.request import urlopen
 
-from validation import evidence_summary, has_required_tool_mix, validated_data_evidence
+from validation import (
+    evidence_summary,
+    expected_answer_errors,
+    has_required_tool_mix,
+    validated_data_evidence,
+)
 
 
 def fail(reason: str) -> None:
@@ -14,10 +20,17 @@ def fail(reason: str) -> None:
 
 
 workspace = Path("/app")
+tests_dir = Path(os.environ.get("TEMPO_BENCH_TESTS_DIR", "/tests"))
 try:
     answer = json.loads((workspace / "answer.json").read_text())
 except (OSError, json.JSONDecodeError):
     fail("answer.json must be valid JSON")
+try:
+    expected = json.loads((tests_dir / "expected.json").read_text())
+except (OSError, json.JSONDecodeError):
+    fail("expected.json must be valid JSON")
+if not isinstance(expected, dict):
+    fail("expected.json must be a JSON object")
 
 text = answer.get("answer")
 sources = answer.get("sources")
@@ -52,6 +65,8 @@ try:
     validated_evidence = validated_data_evidence(traces[0], evidence)
 except ValueError as error:
     fail(str(error))
+if errors := expected_answer_errors(answer, expected, traces[0]):
+    fail("; ".join(errors))
 Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
 Path("/logs/verifier/evidence.json").write_text(
     json.dumps({"evidence": evidence_summary(traces[0], validated_evidence)}) + "\n"

--- a/shared/tempo/mcp-eval/test.sh
+++ b/shared/tempo/mcp-eval/test.sh
@@ -10,6 +10,19 @@ JUDGE_WORKSPACE="$(mktemp -d)"
 mkdir -p "$LOG_DIR"
 trap 'rm -rf "$JUDGE_WORKSPACE"' EXIT
 
+write_failed_reward() {
+  python3 - "$LOG_DIR/reward.json" "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    json.dumps({"reward": 0, "valid_answer": 0, "quality_judge_unavailable": sys.argv[2]})
+    + "\n"
+)
+PY
+}
+
 python3 "$TESTS_DIR/check.py"
 
 if ! python3 - "$LOG_DIR/reward.json" <<'PY'
@@ -25,13 +38,15 @@ then
 fi
 
 if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
+  write_failed_reward 'missing_api_key'
+  printf '%s\n' 'Failing task because ANTHROPIC_API_KEY is required for MCP quality grading.' \
     > "$LOG_DIR/quality-skipped.txt"
   exit 0
 fi
 
 if [ ! -x "$REWARDKIT_PYTHON" ]; then
-  printf '%s\n' 'Skipping LLM quality reward because RewardKit is unavailable.' \
+  write_failed_reward 'missing_rewardkit'
+  printf '%s\n' 'Failing task because RewardKit is required for MCP quality grading.' \
     > "$LOG_DIR/quality-skipped.txt"
   exit 0
 fi
@@ -45,7 +60,8 @@ if ! (
   "$REWARDKIT_PYTHON" -m rewardkit "$TESTS_DIR/quality" \
     --workspace "$JUDGE_WORKSPACE" --output "$LOG_DIR/quality-reward.json"
 ) > "$LOG_DIR/quality-stdout.txt" 2> "$LOG_DIR/quality-stderr.txt"; then
-  printf '%s\n' 'Skipping LLM quality reward because the judge failed.' \
+  write_failed_reward 'judge_failed'
+  printf '%s\n' 'Failing task because the MCP quality judge failed.' \
     > "$LOG_DIR/quality-skipped.txt"
   exit 0
 fi

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 DOCS_PREFIX = "docs_"
@@ -70,3 +71,42 @@ def evidence_summary(
         ]
         summary.append({**item, "calls": calls})
     return summary
+
+
+def expected_answer_errors(
+    answer: dict[str, Any], expected: dict[str, Any], events: list[dict[str, Any]]
+) -> list[str]:
+    """Return task-specific deterministic answer-validation failures."""
+    text = answer.get("answer")
+    sources = answer.get("sources")
+    if not isinstance(text, str):
+        return ["answer must be a string"]
+    if not isinstance(sources, list):
+        return ["sources must be an array"]
+
+    errors = []
+    normalized = text.casefold()
+    for term in expected.get("required_terms", []):
+        if not isinstance(term, str) or term.casefold() not in normalized:
+            errors.append(f"answer must address task concept: {term}")
+    for requirement in expected.get("required_patterns", []):
+        if not isinstance(requirement, dict):
+            errors.append("expected pattern requirement must be an object")
+            continue
+        pattern = requirement.get("pattern")
+        count = requirement.get("min_matches", 1)
+        name = requirement.get("name", "required evidence")
+        if not isinstance(pattern, str) or not isinstance(count, int):
+            errors.append("expected pattern requirement is invalid")
+            continue
+        if len(re.findall(pattern, text, flags=re.IGNORECASE)) < count:
+            errors.append(f"answer is missing {name}")
+    minimum_sources = expected.get("minimum_sources", 1)
+    if not isinstance(minimum_sources, int) or len(sources) < minimum_sources:
+        errors.append(f"answer must provide at least {minimum_sources} sources")
+    required_tools = expected.get("required_data_tools", [])
+    actual_tools = used_data_tools(events)
+    for tool in required_tools:
+        if not isinstance(tool, str) or tool not in actual_tools:
+            errors.append(f"answer must use data tool: {tool}")
+    return errors

--- a/tasks/tempo-mcp-v1/access-keys/tests/expected.json
+++ b/tasks/tempo-mcp-v1/access-keys/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["access","key","account"]}
+{"required_terms":["access","key","fee"],"required_patterns":[{"name":"two transaction hashes","pattern":"0x[a-fA-F0-9]{64}","min_matches":2}],"minimum_sources":3,"required_data_tools":["v1_transactions_get"]}

--- a/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
+++ b/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["batch","transfer","recipient"]}
+{"required_terms":["batch","transfer","recipient","token"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_get"]}

--- a/tasks/tempo-mcp-v1/dataset.toml
+++ b/tasks/tempo-mcp-v1/dataset.toml
@@ -11,48 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-mcp-v1/access-keys"
-digest = "sha256:32625a33dc586237bb10c1b3e45fa88882eb15fa592f3e590baf9db6fad2e346"
+digest = "sha256:0753f8fa13ad605d17d3827d37f9f4773b0333f1a986196c019ccacf687500d6"
 
 [[tasks]]
 name = "tempo-mcp-v1/batched-transfers"
-digest = "sha256:0e202a10e08aeacc3cd5539eeff994a03dcad513de5995d149f52a3d4e069e59"
+digest = "sha256:457ea7c19cd70b2f0566456900fdb225b6d2557ba588ea6f525c17b5c6454e29"
 
 [[tasks]]
 name = "tempo-mcp-v1/dex-swap"
-digest = "sha256:7aa5d0f17b25234524f3fc106ba5473c1572d853edc40692133c01f41ab77a08"
+digest = "sha256:046b51acebe41584d1bc547b1dc1dd774b8e6b1cc836f91bed7c9c1401be5ada"
 
 [[tasks]]
 name = "tempo-mcp-v1/faucet-funding"
-digest = "sha256:99c01f1d1a1e79f5279271822549f934ddae6b0de028aacc4266bc8af7d35db2"
+digest = "sha256:084a5df69e178e2e9dd8ea14c010086693406ff0ade64cfd8ee1c82e9b024b22"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-and-payer"
-digest = "sha256:fd76c76337345725d79b26caf0cdfb885fb0a2d9d4b11104060f5e3d40dd0df5"
+digest = "sha256:04a2f5ef83ebb90d45ec77a14901344044d0a5d6b064ae8b4a5910ad1bfdc0dd"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-configuration"
-digest = "sha256:3ca7ee13bb92033a0b84a3ea7792060a1e191e03c323465ed05d0fb7e99ccf91"
+digest = "sha256:575b993e46d3df15c756885d4131b24f41bd7623bc1ccbfd65301fca46d7fd34"
 
 [[tasks]]
 name = "tempo-mcp-v1/passkey-account"
-digest = "sha256:b11dc2eacacc97f5c3983608adc99c70fe8f219681d30300c596828e13853cdc"
+digest = "sha256:6f8e54f810bc0c4ad7a2a7ef5a961234aff02ccfa512138fb35c4f2abe605138"
 
 [[tasks]]
 name = "tempo-mcp-v1/policy-authorization"
-digest = "sha256:18755e6ca98e4dd7811a15e00da1b4dc09fca97c052cfcc87f16570d76971f8b"
+digest = "sha256:b25b6729fb42171de29964246ef7db2fe21882beccfabcf0e0272c32158d76e1"
 
 [[tasks]]
 name = "tempo-mcp-v1/stablecoin-creation"
-digest = "sha256:cc2f162a0571f37d6586e6700d8285047501cafbcedd2cdb5052bcd52a6a088a"
+digest = "sha256:0fb9d0d79518209d1cf230ac3ad7ac245d689480941d12d4cbfc891e9bb83ebe"
 
 [[tasks]]
 name = "tempo-mcp-v1/tip20-transfer-memo"
-digest = "sha256:56d577a12738ce59b4467174ae1b6220f1ccfdac5fdd1f8f32316517775279d5"
+digest = "sha256:9e2018f29961a58fcef097e668ef29fc25f27016d9d8d820965536d19e3dc088"
 
 [[tasks]]
 name = "tempo-mcp-v1/transaction-status"
-digest = "sha256:6e6596db6abd77e98df2a7e1308800f5350fcb7f7cedcc100097bc31f1062237"
+digest = "sha256:b41c469da6610d3316639e836908a0a2c9e14a09d63d44fc93e2e7db1f28f897"
 
 [[tasks]]
 name = "tempo-mcp-v1/wallet-client"
-digest = "sha256:ea1e011b48bbe7980391134c38a0bc1b6e94ad66bf5dbcda8472b1d1c8807404"
+digest = "sha256:f32b32b45616a646cf2c8e2694a94feff820992fbe6512ede0ba7a68140cdb13"
+

--- a/tasks/tempo-mcp-v1/dex-swap/tests/expected.json
+++ b/tasks/tempo-mcp-v1/dex-swap/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["swap","amount","slippage"]}
+{"required_terms":["pool","fee","token","amm"],"required_patterns":[],"minimum_sources":2,"required_data_tools":["v1_fee-amm_pools"]}

--- a/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
+++ b/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["faucet","fund","transfer"]}
+{"required_terms":["address","balance","activities","faucet"],"required_patterns":[{"name":"an account address","pattern":"0x[a-fA-F0-9]{40}","min_matches":1}],"minimum_sources":3,"required_data_tools":["v1_addresses_address_balances","v1_addresses_address_activities"]}

--- a/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["fee","token","payer"]}
+{"required_terms":["fee","token","payer"],"required_patterns":[{"name":"the requested transaction hash","pattern":"0x52420cada2074e5ca33c381f39acb0c7849522f916a516ccad2ab936306198ec","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_transactionHash_get"]}

--- a/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["fee","token","transaction"]}
+{"required_terms":["fee","token","payer","pool"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":3,"required_data_tools":["v1_transactions_get","v1_fee-amm_pools"]}

--- a/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
+++ b/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["passkey","account","sign"]}
+{"required_terms":["account","authorization","observation","inference"],"required_patterns":[{"name":"an account address","pattern":"0x[a-fA-F0-9]{40}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_addresses_address_activities"]}

--- a/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
+++ b/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["policy","account","authorize"]}
+{"required_terms":["authorization","fee","sponsor","transaction"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_get"]}

--- a/tasks/tempo-mcp-v1/stablecoin-creation/tests/expected.json
+++ b/tasks/tempo-mcp-v1/stablecoin-creation/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["stablecoin","policy","currency"]}
+{"required_terms":["five","token","holder","transaction"],"required_patterns":[],"minimum_sources":3,"required_data_tools":["v1_tokens_get","v1_tokens_token_transactions"]}

--- a/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
+++ b/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["tip-20","transfer","memo"]}
+{"required_terms":["transfer","balance","snapshot","block"],"required_patterns":[{"name":"an account address","pattern":"0x[a-fA-F0-9]{40}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_addresses_address_activities"]}

--- a/tasks/tempo-mcp-v1/transaction-status/tests/expected.json
+++ b/tasks/tempo-mcp-v1/transaction-status/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["transaction","submit","status"]}
+{"required_terms":["block","transaction","transfer","t7"],"required_patterns":[],"minimum_sources":2,"required_data_tools":["v1_blocks_get"]}

--- a/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
+++ b/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
@@ -1,1 +1,1 @@
-{"terms":["wallet","client","transaction"]}
+{"required_terms":["transaction","transfer","account","inference"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_get"]}


### PR DESCRIPTION
## Motivation

Make MCP benchmark scores reflect task-specific evidence and trustworthy paired comparisons.

## Summary

- Validate task-specific claims, evidence, sources, and required MCP data tools
- Fail MCP tasks when quality judging is unavailable
- Add paired-run IDs to MCP exports and require them for comparisons
- Run MCP bridge tests in the standard check command

## Key design considerations

- Live MCP data remains allowed; paired arms share an explicit run identity rather than pinning docs or chain data.