### PR TITLE
refactor: harden MCP evidence validation

### DIFF
--- a/scripts/compare_mcp_results.py
+++ b/scripts/compare_mcp_results.py
@@ -113,7 +113,7 @@ def compare(direct_path: str, code_path: str) -> pd.DataFrame:
         & merged["quality_direct"].notna()
         & merged["quality_code"].notna()
     )
-    merged["quality_delta"] = (merged["quality_direct"] - merged["quality_code"]).where(
+    merged["quality_delta"] = (merged["quality_code"] - merged["quality_direct"]).where(
         merged["quality_comparable"]
     )
     return merged

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -15,6 +15,14 @@ Numeric = float | int | str
 
 MCP_PROFILE_SUFFIX = "-mcp"
 LIVE_MCP_DOCS_SOURCE = "live"
+VALIDATION_COMPONENTS = (
+    "schema_valid",
+    "docs_source_valid",
+    "mcp_tool_mix_valid",
+    "data_evidence_valid",
+    "task_requirements_valid",
+    "quality_judge_available",
+)
 
 TRIAL_COLUMNS = [
     "run_id",
@@ -33,6 +41,12 @@ TRIAL_COLUMNS = [
     "mcp_used",
     "mcp_trace_clean",
     "eligible",
+    "outcome",
+    "validation_error_count",
+    "validation_warning_count",
+    "validation_errors",
+    "validation_warnings",
+    *VALIDATION_COMPONENTS,
     "exception_type",
     "exception_message",
     "started_at",
@@ -324,6 +338,25 @@ def trace_metrics(file_path: Path) -> dict[str, Numeric]:
     }
 
 
+def validation_metrics(file_path: Path) -> JsonObject:
+    details = read_json(file_path.parent / "verifier" / "validation.json") or {}
+    components = as_object(details.get("components"))
+    errors = [item for item in details.get("errors", []) if isinstance(item, str)]
+    warnings = [item for item in details.get("warnings", []) if isinstance(item, str)]
+    return {
+        "validation_error_count": len(errors),
+        "validation_warning_count": len(warnings),
+        "validation_errors": " | ".join(errors),
+        "validation_warnings": " | ".join(warnings),
+        **{
+            component: as_number(components.get(component))
+            if component in components
+            else ""
+            for component in VALIDATION_COMPONENTS
+        },
+    }
+
+
 def extract_rewards(result: JsonObject) -> dict[str, float | int]:
     raw_rewards = as_object(as_object(result.get("verifier_result")).get("rewards"))
     return {
@@ -356,6 +389,11 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
     reward = primary_reward(rewards)
     tokens = token_totals(result)
     trace = trace_metrics(file_path)
+    validation = validation_metrics(file_path)
+    if (
+        judge_available := as_number(rewards.get("quality_judge_available"))
+    ) is not None:
+        validation["quality_judge_available"] = judge_available
     passed = isinstance(reward, int | float) and reward >= 1
     used_mcp = isinstance(trace["calls"], int | float) and trace["calls"] > 0
     trace_clean = (
@@ -363,6 +401,13 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
         and trace["denied"] == 0
         and isinstance(trace["errors"], int | float)
         and trace["errors"] == 0
+    )
+    outcome = (
+        "execution_error"
+        if exception_info
+        else "passed"
+        if passed
+        else "verifier_failed"
     )
 
     return {
@@ -384,6 +429,8 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
         "mcp_used": used_mcp,
         "mcp_trace_clean": trace_clean,
         "eligible": passed and used_mcp and trace_clean,
+        "outcome": outcome,
+        **validation,
         "exception_type": as_string(exception_info.get("exception_type")),
         "exception_message": as_string(exception_info.get("exception_message")),
         "started_at": as_string(result.get("started_at")),

--- a/scripts/export_results_test.py
+++ b/scripts/export_results_test.py
@@ -215,9 +215,29 @@ class ExportResultsTest(unittest.TestCase):
                                 "env": {"TEMPO_BENCH_PAIR_ID": "pair-1"},
                             }
                         },
-                        "verifier_result": {"rewards": {"reward": 1, "quality": 0.8}},
+                        "verifier_result": {
+                            "rewards": {
+                                "reward": 1,
+                                "quality": 0.8,
+                                "quality_judge_available": 1,
+                            }
+                        },
                     }
                 ),
+            )
+            write_json(
+                trial_dir / "verifier" / "validation.json",
+                {
+                    "components": {
+                        "schema_valid": 1,
+                        "docs_source_valid": 1,
+                        "mcp_tool_mix_valid": 1,
+                        "data_evidence_valid": 1,
+                        "task_requirements_valid": 1,
+                    },
+                    "errors": [],
+                    "warnings": ["documentation provenance in evidence"],
+                },
             )
             trace = trial_dir / "artifacts" / "var/log/tempo-mcp/direct-trace.jsonl"
             trace.parent.mkdir(parents=True)
@@ -245,6 +265,11 @@ class ExportResultsTest(unittest.TestCase):
             self.assertTrue(row["mcp_trace_clean"])
             self.assertTrue(row["eligible"])
             self.assertEqual(row["pair_id"], "pair-1")
+            self.assertEqual(row["outcome"], "passed")
+            self.assertEqual(row["validation_error_count"], 0)
+            self.assertEqual(row["validation_warning_count"], 1)
+            self.assertEqual(row["data_evidence_valid"], 1)
+            self.assertEqual(row["quality_judge_available"], 1)
 
     def test_compare_pairs_direct_and_code_trials(self) -> None:
         with tempfile.TemporaryDirectory(prefix="tempo-bench-compare-") as root:
@@ -358,6 +383,7 @@ class ExportResultsTest(unittest.TestCase):
             self.assertAlmostEqual(
                 task_summary.loc[0, "paired_quality_coverage"], 2 / 3
             )
+            self.assertAlmostEqual(task_summary.loc[0, "mean_quality_delta"], 0.0)
             self.assertAlmostEqual(task_summary.loc[0, "mean_quality_delta"], 0.0)
             self.assertEqual(overall_summary.loc[0, "n_tasks"], 1)
             self.assertAlmostEqual(overall_summary.loc[0, "direct_quality_at_k"], 0.6)

--- a/scripts/mcp_eval_check_test.py
+++ b/scripts/mcp_eval_check_test.py
@@ -9,7 +9,6 @@ import unittest
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "shared/tempo/mcp-eval/check.py"
 

--- a/scripts/mcp_eval_check_test.py
+++ b/scripts/mcp_eval_check_test.py
@@ -56,16 +56,43 @@ class McpEvalCheckTest(unittest.TestCase):
             {"allowed": True, "tool": "docs_search"},
         ]
         self.expected = {
-            "required_terms": ["fee"],
-            "required_patterns": [],
             "minimum_sources": 1,
             "required_data_tools": ["v1_transactions_get"],
+            "structured": {
+                "required_fields": ["summary", "observations", "inferences"],
+                "array_fields": {
+                    "observations": {
+                        "min_items": 1,
+                        "item_required_fields": ["subject", "details", "evidence_refs"],
+                        "item_patterns": {},
+                    },
+                    "inferences": {
+                        "min_items": 1,
+                        "item_required_fields": ["claim", "basis", "evidence_refs"],
+                        "item_patterns": {},
+                    },
+                },
+            },
         }
 
     def test_accepts_docs_provenance_as_a_warning_alongside_data_evidence(self) -> None:
         result = run_check(
             {
-                "answer": "The observed fee was paid by the account.",
+                "summary": "The observed fee was paid by the account.",
+                "observations": [
+                    {
+                        "subject": "transaction",
+                        "details": "Observed fee payer.",
+                        "evidence_refs": [0],
+                    }
+                ],
+                "inferences": [
+                    {
+                        "claim": "The fee was sponsored.",
+                        "basis": "Fee payer field.",
+                        "evidence_refs": [0],
+                    }
+                ],
                 "sources": ["https://docs.tempo.xyz"],
                 "evidence": [
                     {
@@ -89,7 +116,9 @@ class McpEvalCheckTest(unittest.TestCase):
     def test_reports_all_deterministic_failures(self) -> None:
         result = run_check(
             {
-                "answer": "No details available.",
+                "summary": "No details available.",
+                "observations": [],
+                "inferences": [],
                 "sources": [],
                 "evidence": [
                     {
@@ -113,7 +142,8 @@ class McpEvalCheckTest(unittest.TestCase):
             result["validation"]["errors"],
         )
         self.assertIn(
-            "answer must address task concept: fee", result["validation"]["errors"]
+            "answer field needs at least 1 item(s): observations",
+            result["validation"]["errors"],
         )
 
 

--- a/scripts/mcp_eval_check_test.py
+++ b/scripts/mcp_eval_check_test.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK = ROOT / "shared/tempo/mcp-eval/check.py"
+
+
+def run_check(
+    answer: dict[str, Any], expected: dict[str, Any], events: list[dict[str, Any]]
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="tempo-mcp-check-") as root:
+        root_path = Path(root)
+        workspace = root_path / "workspace"
+        tests_dir = root_path / "tests"
+        log_dir = root_path / "logs"
+        trace_path = root_path / "trace.json"
+        workspace.mkdir()
+        tests_dir.mkdir()
+        (workspace / "answer.json").write_text(json.dumps(answer))
+        (tests_dir / "expected.json").write_text(json.dumps(expected))
+        trace_path.write_text(json.dumps({"events": events}))
+        env = {
+            **os.environ,
+            "TEMPO_BENCH_WORKSPACE": str(workspace),
+            "TEMPO_BENCH_TESTS_DIR": str(tests_dir),
+            "TEMPO_BENCH_LOG_DIR": str(log_dir),
+            "TEMPO_BENCH_TRACE_PATH": str(trace_path),
+        }
+        result = subprocess.run(
+            [sys.executable, str(CHECK)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if result.returncode:
+            raise AssertionError(result.stderr)
+        return {
+            "reward": json.loads((log_dir / "reward.json").read_text()),
+            "validation": json.loads((log_dir / "validation.json").read_text()),
+        }
+
+
+class McpEvalCheckTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.events = [
+            {"allowed": True, "tool": "v1_transactions_get"},
+            {"allowed": True, "tool": "docs_search"},
+        ]
+        self.expected = {
+            "required_terms": ["fee"],
+            "required_patterns": [],
+            "minimum_sources": 1,
+            "required_data_tools": ["v1_transactions_get"],
+        }
+
+    def test_accepts_docs_provenance_as_a_warning_alongside_data_evidence(self) -> None:
+        result = run_check(
+            {
+                "answer": "The observed fee was paid by the account.",
+                "sources": ["https://docs.tempo.xyz"],
+                "evidence": [
+                    {
+                        "source": "mcp://tempo-direct/v1_transactions_get",
+                        "claim": "The transaction identifies the fee payer.",
+                    },
+                    {
+                        "source": "mcp://tempo/docs_search",
+                        "claim": "The documentation search returned the fee guide.",
+                    },
+                ],
+            },
+            self.expected,
+            self.events,
+        )
+        self.assertEqual(result["reward"]["reward"], 1)
+        self.assertEqual(result["validation"]["errors"], [])
+        self.assertEqual(len(result["validation"]["warnings"]), 1)
+        self.assertEqual(result["reward"]["data_evidence_valid"], 1)
+
+    def test_reports_all_deterministic_failures(self) -> None:
+        result = run_check(
+            {
+                "answer": "No details available.",
+                "sources": [],
+                "evidence": [
+                    {
+                        "source": "https://docs.tempo.xyz",
+                        "claim": "Documentation claim only.",
+                    }
+                ],
+            },
+            self.expected,
+            self.events,
+        )
+        self.assertEqual(result["reward"]["reward"], 0)
+        self.assertEqual(result["reward"]["mcp_tool_mix_valid"], 1)
+        self.assertEqual(result["reward"]["data_evidence_valid"], 0)
+        self.assertIn(
+            "answer must cite at least one Tempo documentation URL",
+            result["validation"]["errors"],
+        )
+        self.assertIn(
+            "evidence must include at least one trace-backed MCP data tool",
+            result["validation"]["errors"],
+        )
+        self.assertIn(
+            "answer must address task concept: fee", result["validation"]["errors"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -7,9 +7,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "shared/tempo/mcp-eval"))
 
 from validation import (  # noqa: E402
+    data_tool_from_source,
     evidence_summary,
     expected_answer_errors,
     has_required_tool_mix,
+    is_tempo_docs_url,
     used_data_tools,
     validated_data_evidence,
 )
@@ -81,6 +83,40 @@ class McpEvalValidationTest(unittest.TestCase):
                 }
             ],
         )
+
+    def test_evidence_accepts_injected_mcp_server_names(self) -> None:
+        events = [{"allowed": True, "tool": "v1_blocks_get"}]
+        for source in (
+            "mcp://tempo/v1_blocks_get",
+            "mcp://tempo-direct/v1_blocks_get",
+            "mcp://tempo-code/v1_blocks_get",
+        ):
+            with self.subTest(source=source):
+                self.assertEqual(data_tool_from_source(source), "v1_blocks_get")
+                self.assertEqual(
+                    validated_data_evidence(
+                        events,
+                        [
+                            {
+                                "source": source,
+                                "claim": "The block contains the transfer.",
+                            }
+                        ],
+                    ),
+                    [{"source": source, "claim": "The block contains the transfer."}],
+                )
+
+    def test_docs_urls_accept_bare_origins_without_matching_lookalikes(self) -> None:
+        for source in (
+            "https://docs.tempo.xyz",
+            "https://developers.tempo.xyz/docs",
+            "https://accounts.tempo.xyz/docs",
+            "https://tips.sh",
+            "https://docs.tempo.xyz/guide/payments",
+        ):
+            with self.subTest(source=source):
+                self.assertTrue(is_tempo_docs_url(source))
+        self.assertFalse(is_tempo_docs_url("https://docs.tempo.xyz.example.com"))
 
     def test_evidence_rejects_an_exploratory_tool(self) -> None:
         with self.assertRaisesRegex(ValueError, "was not used"):

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -191,30 +191,43 @@ class McpEvalValidationTest(unittest.TestCase):
             "evidence source was not used: v1_transactions_get", result["errors"]
         )
 
-    def test_requires_task_specific_terms_evidence_and_tools(self) -> None:
+    def test_requires_structured_task_fields_and_tools(self) -> None:
         expected = {
-            "required_terms": ["fee", "payer"],
-            "required_patterns": [
-                {
-                    "name": "transaction hash",
-                    "pattern": "0x[a-f0-9]{64}",
-                    "min_matches": 1,
-                }
-            ],
             "minimum_sources": 1,
             "required_data_tools": [],
+            "structured": {
+                "required_fields": ["summary", "observations", "inferences"],
+                "array_fields": {
+                    "observations": {
+                        "min_items": 1,
+                        "item_required_fields": ["subject", "details"],
+                        "item_patterns": {"subject": "0x[a-f0-9]{64}"},
+                    },
+                    "inferences": {
+                        "min_items": 1,
+                        "item_required_fields": ["claim", "basis"],
+                        "item_patterns": {},
+                    },
+                },
+            },
         }
         answer = {
-            "answer": "Fee payer 0x" + "a" * 64,
+            "summary": "The fee payer sponsored the transaction.",
+            "observations": [
+                {"subject": "0x" + "a" * 64, "details": "Observed fee payer."}
+            ],
+            "inferences": [{"claim": "The fee was sponsored.", "basis": "Fee payer."}],
             "sources": ["https://docs.tempo.xyz/"],
         }
         events = [{"allowed": True, "tool": "v1_transactions_get"}]
 
         self.assertEqual(expected_answer_errors(answer, expected, events), [])
         self.assertIn(
-            "answer must address task concept: payer",
+            "answer item is missing field: inferences[0].basis",
             expected_answer_errors(
-                {**answer, "answer": "Fee 0x" + "a" * 64}, expected, events
+                {**answer, "inferences": [{"claim": "The fee was sponsored."}]},
+                expected,
+                events,
             ),
         )
 

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -156,11 +156,15 @@ class McpEvalValidationTest(unittest.TestCase):
                     "source": "mcp://tempo/docs/wallet-developers",
                     "claim": "The docs route identifies the wallet guide.",
                 },
+                {
+                    "source": "mcp://tempo/spec-fee",
+                    "claim": "The docs page covers fee semantics.",
+                },
             ],
         )
         self.assertEqual(len(result["evidence"]), 1)
         self.assertEqual(result["errors"], [])
-        self.assertEqual(len(result["warnings"]), 4)
+        self.assertEqual(len(result["warnings"]), 5)
 
     def test_docs_only_evidence_does_not_satisfy_data_provenance(self) -> None:
         result = validated_data_evidence(

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -92,6 +92,7 @@ class McpEvalValidationTest(unittest.TestCase):
             "mcp://tempo/v1_blocks_get",
             "mcp://tempo-direct/v1_blocks_get",
             "mcp://tempo-code/v1_blocks_get",
+            "mcp://tempo/v1_blocks_get?include=transactions",
         ):
             with self.subTest(source=source):
                 self.assertEqual(data_tool_from_source(source), "v1_blocks_get")

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -223,6 +223,35 @@ class McpEvalValidationTest(unittest.TestCase):
         events = [{"allowed": True, "tool": "v1_transactions_get"}]
 
         self.assertEqual(expected_answer_errors(answer, expected, events), [])
+        self.assertEqual(
+            expected_answer_errors(
+                {
+                    **answer,
+                    "observations": [
+                        {
+                            "subject": "transaction 0x" + "a" * 64,
+                            "details": "Observed fee payer.",
+                        }
+                    ],
+                },
+                expected,
+                events,
+            ),
+            [],
+        )
+        self.assertIn(
+            "answer item has invalid value: observations[0].subject",
+            expected_answer_errors(
+                {
+                    **answer,
+                    "observations": [
+                        {"subject": "not-a-hash", "details": "Observed fee payer."}
+                    ],
+                },
+                expected,
+                events,
+            ),
+        )
         self.assertIn(
             "answer item is missing field: inferences[0].basis",
             expected_answer_errors(

--- a/scripts/mcp_eval_validation_test.py
+++ b/scripts/mcp_eval_validation_test.py
@@ -68,8 +68,10 @@ class McpEvalValidationTest(unittest.TestCase):
                 }
             ],
         )
+        self.assertEqual(evidence["errors"], [])
+        self.assertEqual(evidence["warnings"], [])
         self.assertEqual(
-            evidence_summary(events, evidence),
+            evidence_summary(events, evidence["evidence"]),
             [
                 {
                     "source": "mcp://tempo/v1_blocks_get",
@@ -103,7 +105,16 @@ class McpEvalValidationTest(unittest.TestCase):
                             }
                         ],
                     ),
-                    [{"source": source, "claim": "The block contains the transfer."}],
+                    {
+                        "evidence": [
+                            {
+                                "source": source,
+                                "claim": "The block contains the transfer.",
+                            }
+                        ],
+                        "errors": [],
+                        "warnings": [],
+                    },
                 )
 
     def test_docs_urls_accept_bare_origins_without_matching_lookalikes(self) -> None:
@@ -117,18 +128,64 @@ class McpEvalValidationTest(unittest.TestCase):
             with self.subTest(source=source):
                 self.assertTrue(is_tempo_docs_url(source))
         self.assertFalse(is_tempo_docs_url("https://docs.tempo.xyz.example.com"))
+        self.assertFalse(is_tempo_docs_url("https://developers.tempo.xyz/other"))
+
+    def test_docs_evidence_is_a_warning_when_data_evidence_is_trace_backed(
+        self,
+    ) -> None:
+        result = validated_data_evidence(
+            [{"allowed": True, "tool": "v1_blocks_get"}],
+            [
+                {
+                    "source": "mcp://tempo/v1_blocks_get",
+                    "claim": "The block contains the transfer.",
+                },
+                {
+                    "source": "https://docs.tempo.xyz",
+                    "claim": "Tempo documents this transaction type.",
+                },
+                {
+                    "source": "mcp://tempo/docs_search",
+                    "claim": "The MCP docs search returned the transaction guide.",
+                },
+                {
+                    "source": "mcp://tempo-code/v1_docs_read_page",
+                    "claim": "The docs page describes the transaction type.",
+                },
+                {
+                    "source": "mcp://tempo/docs/wallet-developers",
+                    "claim": "The docs route identifies the wallet guide.",
+                },
+            ],
+        )
+        self.assertEqual(len(result["evidence"]), 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(len(result["warnings"]), 4)
+
+    def test_docs_only_evidence_does_not_satisfy_data_provenance(self) -> None:
+        result = validated_data_evidence(
+            [{"allowed": True, "tool": "docs_code"}],
+            [{"source": "mcp://tempo/docs_code", "claim": "Documentation claim."}],
+        )
+        self.assertEqual(result["evidence"], [])
+        self.assertIn(
+            "evidence must include at least one trace-backed MCP data tool",
+            result["errors"],
+        )
 
     def test_evidence_rejects_an_exploratory_tool(self) -> None:
-        with self.assertRaisesRegex(ValueError, "was not used"):
-            validated_data_evidence(
-                [{"allowed": True, "tool": "v1_blocks_get"}],
-                [
-                    {
-                        "source": "mcp://tempo/v1_transactions_get",
-                        "claim": "Not supported by the trace.",
-                    }
-                ],
-            )
+        result = validated_data_evidence(
+            [{"allowed": True, "tool": "v1_blocks_get"}],
+            [
+                {
+                    "source": "mcp://tempo/v1_transactions_get",
+                    "claim": "Not supported by the trace.",
+                }
+            ],
+        )
+        self.assertIn(
+            "evidence source was not used: v1_transactions_get", result["errors"]
+        )
 
     def test_requires_task_specific_terms_evidence_and_tools(self) -> None:
         expected = {

--- a/shared/tempo/mcp-eval/check.py
+++ b/shared/tempo/mcp-eval/check.py
@@ -77,14 +77,14 @@ if not isinstance(expected, dict):
     expected = {}
     errors.append("expected.json must be a JSON object")
 
-text = answer.get("answer")
+summary = answer.get("summary")
 sources = answer.get("sources")
 evidence = answer.get("evidence")
-if not isinstance(text, str) or not text.strip():
-    errors.append("answer must be a non-empty string")
+if not isinstance(summary, str) or not summary.strip():
+    errors.append("summary must be a non-empty string")
 if (
-    isinstance(text, str)
-    and text.strip()
+    isinstance(summary, str)
+    and summary.strip()
     and isinstance(sources, list)
     and isinstance(evidence, list)
 ):

--- a/shared/tempo/mcp-eval/check.py
+++ b/shared/tempo/mcp-eval/check.py
@@ -8,6 +8,7 @@ from validation import (
     evidence_summary,
     expected_answer_errors,
     has_required_tool_mix,
+    is_tempo_docs_url,
     validated_data_evidence,
 )
 
@@ -37,15 +38,8 @@ sources = answer.get("sources")
 evidence = answer.get("evidence")
 if not isinstance(text, str) or not text.strip():
     fail("answer must be a non-empty string")
-tempo_docs_prefixes = (
-    "https://docs.tempo.xyz/",
-    "https://developers.tempo.xyz/docs/",
-    "https://accounts.tempo.xyz/docs/",
-    "https://tips.sh/",
-)
 if not isinstance(sources, list) or not any(
-    isinstance(source, str) and source.startswith(tempo_docs_prefixes)
-    for source in sources
+    is_tempo_docs_url(source) for source in sources
 ):
     fail("answer must cite at least one Tempo documentation URL")
 try:

--- a/shared/tempo/mcp-eval/check.py
+++ b/shared/tempo/mcp-eval/check.py
@@ -13,56 +13,129 @@ from validation import (
 )
 
 
-def fail(reason: str) -> None:
-    print(reason, file=sys.stderr)
-    Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
-    Path("/logs/verifier/reward.json").write_text('{"reward":0,"valid_answer":0}\n')
-    raise SystemExit(0)
+def write_result(
+    components: dict[str, int],
+    errors: list[str],
+    warnings: list[str],
+    evidence: list[dict],
+) -> None:
+    log_dir = Path(os.environ.get("TEMPO_BENCH_LOG_DIR", "/logs/verifier"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    valid_answer = int(not errors)
+    (log_dir / "validation.json").write_text(
+        json.dumps(
+            {
+                "components": components,
+                "errors": errors,
+                "warnings": warnings,
+                "trace_backed_data_evidence": evidence,
+            }
+        )
+        + "\n"
+    )
+    (log_dir / "reward.json").write_text(
+        json.dumps({"reward": valid_answer, "valid_answer": valid_answer, **components})
+        + "\n"
+    )
+    if evidence:
+        (log_dir / "evidence.json").write_text(
+            json.dumps({"evidence": evidence}) + "\n"
+        )
+    for error in errors:
+        print(error, file=sys.stderr)
+    for warning in warnings:
+        print(f"warning: {warning}", file=sys.stderr)
 
 
-workspace = Path("/app")
+workspace = Path(os.environ.get("TEMPO_BENCH_WORKSPACE", "/app"))
 tests_dir = Path(os.environ.get("TEMPO_BENCH_TESTS_DIR", "/tests"))
+components = {
+    "schema_valid": 0,
+    "docs_source_valid": 0,
+    "mcp_tool_mix_valid": 0,
+    "data_evidence_valid": 0,
+    "task_requirements_valid": 0,
+    "quality_judge_available": 0,
+}
+errors: list[str] = []
+warnings: list[str] = []
+validated_evidence: list[dict] = []
 try:
     answer = json.loads((workspace / "answer.json").read_text())
 except (OSError, json.JSONDecodeError):
-    fail("answer.json must be valid JSON")
+    answer = {}
+    errors.append("answer.json must be valid JSON")
+if not isinstance(answer, dict):
+    answer = {}
+    errors.append("answer.json must be a JSON object")
 try:
     expected = json.loads((tests_dir / "expected.json").read_text())
 except (OSError, json.JSONDecodeError):
-    fail("expected.json must be valid JSON")
+    expected = {}
+    errors.append("expected.json must be valid JSON")
 if not isinstance(expected, dict):
-    fail("expected.json must be a JSON object")
+    expected = {}
+    errors.append("expected.json must be a JSON object")
 
 text = answer.get("answer")
 sources = answer.get("sources")
 evidence = answer.get("evidence")
 if not isinstance(text, str) or not text.strip():
-    fail("answer must be a non-empty string")
-if not isinstance(sources, list) or not any(
-    is_tempo_docs_url(source) for source in sources
+    errors.append("answer must be a non-empty string")
+if (
+    isinstance(text, str)
+    and text.strip()
+    and isinstance(sources, list)
+    and isinstance(evidence, list)
 ):
-    fail("answer must cite at least one Tempo documentation URL")
+    components["schema_valid"] = 1
+if isinstance(sources, list) and any(is_tempo_docs_url(source) for source in sources):
+    components["docs_source_valid"] = 1
+else:
+    errors.append("answer must cite at least one Tempo documentation URL")
 try:
-    traces = []
-    for host in ("tempo-mcp-direct", "tempo-mcp-code"):
-        with urlopen(f"http://{host}:8787/trace", timeout=5) as response:  # noqa: S310 -- local task service
-            payload = json.loads(response.read())
+    trace_path = os.environ.get("TEMPO_BENCH_TRACE_PATH")
+    if trace_path:
+        payload = json.loads(Path(trace_path).read_text())
         events = payload.get("events")
-        if isinstance(events, list) and events:
-            traces.append(events)
+        traces = [events] if isinstance(events, list) and events else []
+    else:
+        traces = []
+        for host in ("tempo-mcp-direct", "tempo-mcp-code"):
+            with urlopen(f"http://{host}:8787/trace", timeout=5) as response:  # noqa: S310 -- local task service
+                payload = json.loads(response.read())
+            events = payload.get("events")
+            if isinstance(events, list) and events:
+                traces.append(events)
 except (OSError, TimeoutError, json.JSONDecodeError):
-    fail("could not read MCP bridge traces")
+    traces = []
+    errors.append("could not read MCP bridge traces")
 
-if len(traces) != 1 or not has_required_tool_mix(traces[0]):
-    fail("the active MCP arm must use both a Tempo data tool and a Tempo docs tool")
-try:
-    validated_evidence = validated_data_evidence(traces[0], evidence)
-except ValueError as error:
-    fail(str(error))
-if errors := expected_answer_errors(answer, expected, traces[0]):
-    fail("; ".join(errors))
-Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
-Path("/logs/verifier/evidence.json").write_text(
-    json.dumps({"evidence": evidence_summary(traces[0], validated_evidence)}) + "\n"
+if len(traces) == 1:
+    trace = traces[0]
+    if has_required_tool_mix(trace):
+        components["mcp_tool_mix_valid"] = 1
+    else:
+        errors.append(
+            "the active MCP arm must use both a Tempo data tool and a Tempo docs tool"
+        )
+    evidence_result = validated_data_evidence(trace, evidence)
+    validated_evidence = evidence_result["evidence"]
+    errors.extend(evidence_result["errors"])
+    warnings.extend(evidence_result["warnings"])
+    if validated_evidence:
+        components["data_evidence_valid"] = 1
+    task_errors = expected_answer_errors(answer, expected, trace)
+    if task_errors:
+        errors.extend(task_errors)
+    else:
+        components["task_requirements_valid"] = 1
+else:
+    errors.append("exactly one active MCP arm must provide a trace")
+
+write_result(
+    components,
+    errors,
+    warnings,
+    evidence_summary(traces[0], validated_evidence) if len(traces) == 1 else [],
 )
-Path("/logs/verifier/reward.json").write_text('{"reward":1,"valid_answer":1}\n')

--- a/shared/tempo/mcp-eval/test.sh
+++ b/shared/tempo/mcp-eval/test.sh
@@ -16,10 +16,17 @@ import json
 import sys
 from pathlib import Path
 
-Path(sys.argv[1]).write_text(
-    json.dumps({"reward": 0, "valid_answer": 0, "quality_judge_unavailable": sys.argv[2]})
-    + "\n"
+reward_path = Path(sys.argv[1])
+reward = json.loads(reward_path.read_text()) if reward_path.exists() else {}
+reward.update(
+    {
+        "reward": 0,
+        "valid_answer": 0,
+        "quality_judge_available": 0,
+        "quality_judge_unavailable": sys.argv[2],
+    }
 )
+reward_path.write_text(json.dumps(reward) + "\n")
 PY
 }
 
@@ -77,5 +84,6 @@ reward = json.loads(reward_path.read_text())
 quality = json.loads(quality_path.read_text()).get("reward")
 if isinstance(quality, int | float):
     reward["quality"] = quality
+    reward["quality_judge_available"] = 1
 reward_path.write_text(json.dumps(reward) + "\n")
 PY

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -7,7 +7,36 @@ from typing import Any
 
 DOCS_PREFIX = "docs_"
 DATA_PREFIXES = ("v1_", "rpc_")
-DATA_SOURCE_PREFIX = "mcp://tempo/"
+DATA_SOURCE_PREFIXES = (
+    "mcp://tempo/",
+    "mcp://tempo-direct/",
+    "mcp://tempo-code/",
+)
+TEMPO_DOCS_URLS = (
+    "https://docs.tempo.xyz",
+    "https://developers.tempo.xyz/docs",
+    "https://accounts.tempo.xyz/docs",
+    "https://tips.sh",
+)
+
+
+def is_tempo_docs_url(source: Any) -> bool:
+    """Return whether source is a Tempo documentation URL, including a bare origin."""
+    return isinstance(source, str) and any(
+        source == base or source.startswith(f"{base}/") for base in TEMPO_DOCS_URLS
+    )
+
+
+def data_tool_from_source(source: Any) -> str:
+    """Normalize a supported MCP evidence URI to its underlying data tool name."""
+    if not isinstance(source, str):
+        raise ValueError("each evidence source must be an MCP data-tool URI")
+    for prefix in DATA_SOURCE_PREFIXES:
+        if source.startswith(prefix):
+            tool = source.removeprefix(prefix)
+            if tool:
+                return tool
+    raise ValueError("each evidence source must be an MCP data-tool URI")
 
 
 def has_required_tool_mix(events: list[dict[str, Any]]) -> bool:
@@ -44,9 +73,7 @@ def validated_data_evidence(
             raise ValueError("each evidence item must be an object")
         source = item.get("source")
         claim = item.get("claim")
-        if not isinstance(source, str) or not source.startswith(DATA_SOURCE_PREFIX):
-            raise ValueError("each evidence source must be an MCP data-tool URI")
-        tool = source.removeprefix(DATA_SOURCE_PREFIX)
+        tool = data_tool_from_source(source)
         if tool not in used_tools:
             raise ValueError(f"evidence source was not used: {tool}")
         if not isinstance(claim, str) or not claim.strip():
@@ -60,7 +87,7 @@ def evidence_summary(
 ) -> list[dict[str, Any]]:
     summary: list[dict[str, Any]] = []
     for item in evidence:
-        tool = item["source"].removeprefix(DATA_SOURCE_PREFIX)
+        tool = data_tool_from_source(item["source"])
         calls = [
             {
                 "arguments": event.get("arguments", {}),

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -163,30 +163,82 @@ def expected_answer_errors(
     answer: dict[str, Any], expected: dict[str, Any], events: list[dict[str, Any]]
 ) -> list[str]:
     """Return task-specific deterministic answer-validation failures."""
-    text = answer.get("answer")
     sources = answer.get("sources")
-    if not isinstance(text, str):
-        return ["answer must be a string"]
     if not isinstance(sources, list):
         return ["sources must be an array"]
 
     errors = []
-    normalized = text.casefold()
-    for term in expected.get("required_terms", []):
-        if not isinstance(term, str) or term.casefold() not in normalized:
-            errors.append(f"answer must address task concept: {term}")
-    for requirement in expected.get("required_patterns", []):
-        if not isinstance(requirement, dict):
-            errors.append("expected pattern requirement must be an object")
-            continue
-        pattern = requirement.get("pattern")
-        count = requirement.get("min_matches", 1)
-        name = requirement.get("name", "required evidence")
-        if not isinstance(pattern, str) or not isinstance(count, int):
-            errors.append("expected pattern requirement is invalid")
-            continue
-        if len(re.findall(pattern, text, flags=re.IGNORECASE)) < count:
-            errors.append(f"answer is missing {name}")
+    structured = expected.get("structured")
+    if not isinstance(structured, dict):
+        errors.append("expected structured requirements must be an object")
+    else:
+        required_fields = structured.get("required_fields", [])
+        if not isinstance(required_fields, list):
+            errors.append("expected required_fields must be an array")
+        else:
+            for field in required_fields:
+                value = answer.get(field) if isinstance(field, str) else None
+                if value in (None, "") or value == [] or value == {}:
+                    errors.append(f"answer is missing structured field: {field}")
+        array_fields = structured.get("array_fields", {})
+        if not isinstance(array_fields, dict):
+            errors.append("expected array_fields must be an object")
+        else:
+            for field, requirement in array_fields.items():
+                value = answer.get(field)
+                if not isinstance(value, list):
+                    errors.append(f"answer field must be an array: {field}")
+                    continue
+                if not isinstance(requirement, dict):
+                    errors.append(
+                        f"expected array field requirement is invalid: {field}"
+                    )
+                    continue
+                min_items = requirement.get("min_items", 1)
+                if not isinstance(min_items, int) or len(value) < min_items:
+                    errors.append(
+                        f"answer field needs at least {min_items} item(s): {field}"
+                    )
+                    continue
+                item_fields = requirement.get("item_required_fields", [])
+                item_patterns = requirement.get("item_patterns", {})
+                if not isinstance(item_fields, list) or not isinstance(
+                    item_patterns, dict
+                ):
+                    errors.append(f"expected item requirement is invalid: {field}")
+                    continue
+                for index, item in enumerate(value):
+                    if not isinstance(item, dict):
+                        errors.append(
+                            f"answer item must be an object: {field}[{index}]"
+                        )
+                        continue
+                    for item_field in item_fields:
+                        item_value = (
+                            item.get(item_field)
+                            if isinstance(item_field, str)
+                            else None
+                        )
+                        item_label = f"{field}[{index}].{item_field}"
+                        if (
+                            item_value in (None, "")
+                            or item_value == []
+                            or item_value == {}
+                        ):
+                            errors.append(f"answer item is missing field: {item_label}")
+                    for item_field, pattern in item_patterns.items():
+                        item_value = item.get(item_field)
+                        item_label = f"{field}[{index}].{item_field}"
+                        if not isinstance(pattern, str) or not isinstance(
+                            item_value, str
+                        ):
+                            errors.append(
+                                f"answer item has invalid patterned field: {item_label}"
+                            )
+                        elif not re.fullmatch(pattern, item_value, flags=re.IGNORECASE):
+                            errors.append(
+                                f"answer item has invalid value: {item_label}"
+                            )
     minimum_sources = expected.get("minimum_sources", 1)
     if not isinstance(minimum_sources, int) or len(sources) < minimum_sources:
         errors.append(f"answer must provide at least {minimum_sources} sources")

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -102,7 +102,7 @@ def used_data_tools(events: list[dict[str, Any]]) -> set[str]:
 def validated_data_evidence(
     events: list[dict[str, Any]], evidence: Any
 ) -> dict[str, Any]:
-    """Validate trace-backed data evidence without rejecting recognized docs citations."""
+    """Validate data evidence while preserving recognized docs citations as warnings."""
     used_tools = used_data_tools(events)
     validated: list[dict[str, str]] = []
     errors: list[str] = []

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -47,7 +47,11 @@ def mcp_tool_from_source(source: Any) -> str:
         raise ValueError("each evidence source must be an MCP data-tool URI")
     for prefix in DATA_SOURCE_PREFIXES:
         if source.startswith(prefix):
-            tool = source.removeprefix(prefix)
+            tool = (
+                source.removeprefix(prefix)
+                .split("?", maxsplit=1)[0]
+                .split("#", maxsplit=1)[0]
+            )
             if tool:
                 return tool
     raise ValueError("each evidence source must be an MCP data-tool URI")

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -67,11 +67,12 @@ def docs_tool_name(tool: str) -> bool:
 
 
 def docs_evidence_source(source: Any) -> bool:
-    """Return whether source is recognizable Tempo documentation provenance."""
+    """Return whether source is non-data provenance on an approved Tempo surface."""
     if is_tempo_docs_url(source):
         return True
     try:
-        return docs_tool_name(mcp_tool_from_source(source))
+        tool = mcp_tool_from_source(source)
+        return docs_tool_name(tool) or not tool.startswith(DATA_PREFIXES)
     except ValueError:
         return False
 

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 DOCS_PREFIX = "docs_"
 DATA_PREFIXES = ("v1_", "rpc_")
@@ -12,23 +13,36 @@ DATA_SOURCE_PREFIXES = (
     "mcp://tempo-direct/",
     "mcp://tempo-code/",
 )
-TEMPO_DOCS_URLS = (
-    "https://docs.tempo.xyz",
-    "https://developers.tempo.xyz/docs",
-    "https://accounts.tempo.xyz/docs",
-    "https://tips.sh",
+TEMPO_DOCS_ORIGINS = (
+    ("docs.tempo.xyz", "/"),
+    ("developers.tempo.xyz", "/docs"),
+    ("accounts.tempo.xyz", "/docs"),
+    ("tips.sh", "/"),
 )
 
 
 def is_tempo_docs_url(source: Any) -> bool:
-    """Return whether source is a Tempo documentation URL, including a bare origin."""
-    return isinstance(source, str) and any(
-        source == base or source.startswith(f"{base}/") for base in TEMPO_DOCS_URLS
-    )
+    """Return whether source is an allowed Tempo docs URL, including its bare origin."""
+    if not isinstance(source, str):
+        return False
+    parsed = urlparse(source)
+    if parsed.scheme != "https" or not parsed.hostname:
+        return False
+    path = parsed.path or "/"
+    for hostname, allowed_path in TEMPO_DOCS_ORIGINS:
+        if parsed.hostname != hostname:
+            continue
+        if (
+            allowed_path == "/"
+            or path == allowed_path
+            or path.startswith(f"{allowed_path}/")
+        ):
+            return True
+    return False
 
 
-def data_tool_from_source(source: Any) -> str:
-    """Normalize a supported MCP evidence URI to its underlying data tool name."""
+def mcp_tool_from_source(source: Any) -> str:
+    """Normalize a supported MCP evidence URI to its underlying tool name."""
     if not isinstance(source, str):
         raise ValueError("each evidence source must be an MCP data-tool URI")
     for prefix in DATA_SOURCE_PREFIXES:
@@ -37,6 +51,29 @@ def data_tool_from_source(source: Any) -> str:
             if tool:
                 return tool
     raise ValueError("each evidence source must be an MCP data-tool URI")
+
+
+def data_tool_from_source(source: Any) -> str:
+    """Return the data tool named by source, rejecting docs and unknown MCP tools."""
+    tool = mcp_tool_from_source(source)
+    if not tool.startswith(DATA_PREFIXES) or docs_tool_name(tool):
+        raise ValueError("each evidence source must be an MCP data-tool URI")
+    return tool
+
+
+def docs_tool_name(tool: str) -> bool:
+    """Return whether tool is a direct, path-style, or legacy docs tool alias."""
+    return tool.startswith((DOCS_PREFIX, "docs/", "v1_docs_"))
+
+
+def docs_evidence_source(source: Any) -> bool:
+    """Return whether source is recognizable Tempo documentation provenance."""
+    if is_tempo_docs_url(source):
+        return True
+    try:
+        return docs_tool_name(mcp_tool_from_source(source))
+    except ValueError:
+        return False
 
 
 def has_required_tool_mix(events: list[dict[str, Any]]) -> bool:
@@ -63,23 +100,44 @@ def used_data_tools(events: list[dict[str, Any]]) -> set[str]:
 
 def validated_data_evidence(
     events: list[dict[str, Any]], evidence: Any
-) -> list[dict[str, str]]:
-    if not isinstance(evidence, list) or not evidence:
-        raise ValueError("evidence must be a non-empty array")
+) -> dict[str, Any]:
+    """Validate trace-backed data evidence without rejecting recognized docs citations."""
     used_tools = used_data_tools(events)
     validated: list[dict[str, str]] = []
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not isinstance(evidence, list) or not evidence:
+        return {
+            "evidence": validated,
+            "errors": ["evidence must be a non-empty array"],
+            "warnings": warnings,
+        }
     for item in evidence:
         if not isinstance(item, dict):
-            raise ValueError("each evidence item must be an object")
+            errors.append("each evidence item must be an object")
+            continue
         source = item.get("source")
         claim = item.get("claim")
-        tool = data_tool_from_source(source)
-        if tool not in used_tools:
-            raise ValueError(f"evidence source was not used: {tool}")
         if not isinstance(claim, str) or not claim.strip():
-            raise ValueError("each evidence item must include a non-empty claim")
+            errors.append("each evidence item must include a non-empty claim")
+            continue
+        if docs_evidence_source(source):
+            warnings.append(
+                "documentation provenance in evidence does not count as data evidence"
+            )
+            continue
+        try:
+            tool = data_tool_from_source(source)
+        except ValueError as error:
+            errors.append(str(error))
+            continue
+        if tool not in used_tools:
+            errors.append(f"evidence source was not used: {tool}")
+            continue
         validated.append({"source": source, "claim": claim})
-    return validated
+    if not validated:
+        errors.append("evidence must include at least one trace-backed MCP data tool")
+    return {"evidence": validated, "errors": errors, "warnings": warnings}
 
 
 def evidence_summary(

--- a/shared/tempo/mcp-eval/validation.py
+++ b/shared/tempo/mcp-eval/validation.py
@@ -239,7 +239,7 @@ def expected_answer_errors(
                             errors.append(
                                 f"answer item has invalid patterned field: {item_label}"
                             )
-                        elif not re.fullmatch(pattern, item_value, flags=re.IGNORECASE):
+                        elif not re.search(pattern, item_value, flags=re.IGNORECASE):
                             errors.append(
                                 f"answer item has invalid value: {item_label}"
                             )

--- a/tasks/tempo-mcp-v1/access-keys/instruction.md
+++ b/tasks/tempo-mcp-v1/access-keys/instruction.md
@@ -53,4 +53,4 @@ sources you actually inspected:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/access-keys/instruction.md
+++ b/tasks/tempo-mcp-v1/access-keys/instruction.md
@@ -10,10 +10,38 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": ["subject", "details", "evidence_refs"],
+        "additionalProperties": false,
+        "properties": {
+          "subject": { "type": "string" },
+          "details": { "type": "string" },
+          "evidence_refs": { "type": "array", "items": { "type": "integer" } }
+        }
+      }
+    },
+    "inferences": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["claim", "basis", "evidence_refs"],
+        "additionalProperties": false,
+        "properties": {
+          "claim": { "type": "string" },
+          "basis": { "type": "string" },
+          "evidence_refs": { "type": "array", "items": { "type": "integer" } }
+        }
+      }
+    },
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -40,7 +68,14 @@ sources you actually inspected:
 
 ```json
 {
-  "answer": "Transaction 0x… used …; the observed fee payer was … .",
+  "summary": "Two transactions demonstrate access-key use or sponsored fees.",
+  "observations": [
+    {"subject": "0x…", "details": "Observed authorization or fee-payer fields.", "evidence_refs": [0]},
+    {"subject": "0x…", "details": "Observed authorization or fee-payer fields.", "evidence_refs": [0]}
+  ],
+  "inferences": [
+    {"claim": "The observed fields are consistent with the documented mechanism.", "basis": "The cited docs and transaction fields.", "evidence_refs": [0]}
+  ],
   "sources": [
     "https://developers.tempo.xyz/docs/…"
   ],
@@ -53,4 +88,4 @@ sources you actually inspected:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Put direct chain facts in `observations` and interpretations in `inferences`; for this task, each observation subject must be a transaction hash. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/access-keys/tests/expected.json
+++ b/tasks/tempo-mcp-v1/access-keys/tests/expected.json
@@ -7,7 +7,7 @@
       "observations": {
         "min_items": 2,
         "item_required_fields": ["subject", "details", "evidence_refs"],
-        "item_patterns": {}
+        "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}
       },
       "inferences": {
         "min_items": 1,

--- a/tasks/tempo-mcp-v1/access-keys/tests/expected.json
+++ b/tasks/tempo-mcp-v1/access-keys/tests/expected.json
@@ -7,7 +7,7 @@
       "observations": {
         "min_items": 2,
         "item_required_fields": ["subject", "details", "evidence_refs"],
-        "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}
+        "item_patterns": {}
       },
       "inferences": {
         "min_items": 1,

--- a/tasks/tempo-mcp-v1/access-keys/tests/expected.json
+++ b/tasks/tempo-mcp-v1/access-keys/tests/expected.json
@@ -1,1 +1,19 @@
-{"required_terms":["access","key","fee"],"required_patterns":[{"name":"two transaction hashes","pattern":"0x[a-fA-F0-9]{64}","min_matches":2}],"minimum_sources":3,"required_data_tools":["v1_transactions_get"]}
+{
+  "minimum_sources": 3,
+  "required_data_tools": ["v1_transactions_get"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {
+        "min_items": 2,
+        "item_required_fields": ["subject", "details", "evidence_refs"],
+        "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}
+      },
+      "inferences": {
+        "min_items": 1,
+        "item_required_fields": ["claim", "basis", "evidence_refs"],
+        "item_patterns": {}
+      }
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/batched-transfers/instruction.md
+++ b/tasks/tempo-mcp-v1/batched-transfers/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/batched-transfers/instruction.md
+++ b/tasks/tempo-mcp-v1/batched-transfers/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Put each observed transfer leg under `observations`, using its transaction hash as `subject`; put the documented multi-payment interpretation under `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
+++ b/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
+++ b/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
+++ b/tasks/tempo-mcp-v1/batched-transfers/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["batch","transfer","recipient","token"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_get"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_transactions_get"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/dataset.toml
+++ b/tasks/tempo-mcp-v1/dataset.toml
@@ -11,11 +11,11 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-mcp-v1/access-keys"
-digest = "sha256:089f6979880de5a6e92d1e496cf5d625fa3e3866b810342fadebb081c16d7d2f"
+digest = "sha256:5ecd9053535dfb6d5b84d9a3d56b49e410e2e5f06e12dff3266980cd4abeec05"
 
 [[tasks]]
 name = "tempo-mcp-v1/batched-transfers"
-digest = "sha256:0b4cdf393c9d340cf7ed78b7a7ec44eff04628052f58d83c4ab990616982541d"
+digest = "sha256:55e1103a2175d5cc61b00f412cdbcf76db32b001da9c57886dada337a4c137e0"
 
 [[tasks]]
 name = "tempo-mcp-v1/dex-swap"
@@ -23,23 +23,23 @@ digest = "sha256:e5fab8461c0c91c4c6227286c661e45924780749dbcf18d0800172fa6c773be
 
 [[tasks]]
 name = "tempo-mcp-v1/faucet-funding"
-digest = "sha256:2f31e656303e6f040aafe95c0aae4eaafbf78e018bc62f784072ad3501b87eab"
+digest = "sha256:06ce549ef02bc163ee09eb7f04201ce9ace7325caf7b6ef33d73622989545baa"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-and-payer"
-digest = "sha256:440fb98953980c7eb4042ea46eae49b6c29423a931e26bc4fe0662750919d243"
+digest = "sha256:cdcc872565775a9156de4746f9ef2bab5c1e899c4d76522b13adc9ea4c81f2f0"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-configuration"
-digest = "sha256:6fd83aa3eceeb74b348ffd4060ca874781fee832d48b967732e71b7bcc7e2d2b"
+digest = "sha256:c90b8e28d0da02761b1cde48e1f5c0ba3be70bdac3ac62a750ce4d85daf4c37e"
 
 [[tasks]]
 name = "tempo-mcp-v1/passkey-account"
-digest = "sha256:19c56692bb8ef8f5d37169a1c7afda245d325d8d61518ad09f9c0a31037e1fc7"
+digest = "sha256:6eb5b4c1b91f58c30e75ed20a55717bbd0b0be4b3639ed888f97daa5dd0a00b0"
 
 [[tasks]]
 name = "tempo-mcp-v1/policy-authorization"
-digest = "sha256:38afc2ab004dfccf7b94004e4edf2bede73636f0bc689e14120d098707885b11"
+digest = "sha256:0a76c12ba3b37aa9620059c36187c2dfc8a6663f259ea8a148c097719f41d598"
 
 [[tasks]]
 name = "tempo-mcp-v1/stablecoin-creation"
@@ -47,7 +47,7 @@ digest = "sha256:adccc82f2030930754bf5a2e6bbb6e08de986f991c65b20d5e66af3b3ba0bf9
 
 [[tasks]]
 name = "tempo-mcp-v1/tip20-transfer-memo"
-digest = "sha256:806163aa8264106cf19a8278e4db7416491846c33e5d8903a47f768c42e37fba"
+digest = "sha256:56ad34c479328318d00fae085ff12eb9609e41dcb6f9831483364d1b9f0822b9"
 
 [[tasks]]
 name = "tempo-mcp-v1/transaction-status"
@@ -55,5 +55,5 @@ digest = "sha256:a8d751193b0746e073f149bb8bd9195ed2d771e9c06cf3b73c54dd9b098213d
 
 [[tasks]]
 name = "tempo-mcp-v1/wallet-client"
-digest = "sha256:c9707090182d6d49d3fcb45efbc76130956df3918decd62c2449bcf7d50dd10f"
+digest = "sha256:c30a8999ff29f3ee3d8671128ab82341b32ae7928cdef8e029033a7c1298a864"
 

--- a/tasks/tempo-mcp-v1/dataset.toml
+++ b/tasks/tempo-mcp-v1/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-mcp-v1/access-keys"
-digest = "sha256:df4378d0f460fae261b6c674fd45a970e1bfc397514ea5a55308b472c8d4984c"
+digest = "sha256:089f6979880de5a6e92d1e496cf5d625fa3e3866b810342fadebb081c16d7d2f"
 
 [[tasks]]
 name = "tempo-mcp-v1/batched-transfers"
-digest = "sha256:5f01b7dc9db6012f949b3054aa77762d1e9de27f97fb20cffdaef991e3310ce5"
+digest = "sha256:0b4cdf393c9d340cf7ed78b7a7ec44eff04628052f58d83c4ab990616982541d"
 
 [[tasks]]
 name = "tempo-mcp-v1/dex-swap"
-digest = "sha256:d6620359762dfc4856ef39b8d94f311656270b325e7c0244d983f0bea5510c5e"
+digest = "sha256:e5fab8461c0c91c4c6227286c661e45924780749dbcf18d0800172fa6c773bea"
 
 [[tasks]]
 name = "tempo-mcp-v1/faucet-funding"
-digest = "sha256:36f768bce3ab546011458325b9bcfaf6a33af16a47dae6da97f46cfd7741ca32"
+digest = "sha256:2f31e656303e6f040aafe95c0aae4eaafbf78e018bc62f784072ad3501b87eab"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-and-payer"
-digest = "sha256:10c274e8cf7e68498c095ba0896c0136fd6a691e580295be84a8b8b7bf858e6f"
+digest = "sha256:440fb98953980c7eb4042ea46eae49b6c29423a931e26bc4fe0662750919d243"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-configuration"
-digest = "sha256:5b623ce9eb704ede761fc217e230b047af61a34e4a47244932f58a2a65ff34c0"
+digest = "sha256:6fd83aa3eceeb74b348ffd4060ca874781fee832d48b967732e71b7bcc7e2d2b"
 
 [[tasks]]
 name = "tempo-mcp-v1/passkey-account"
-digest = "sha256:77c22cf6029607a75f0a7debba8a1208e95063b7ed599d7819696255ccc60e21"
+digest = "sha256:19c56692bb8ef8f5d37169a1c7afda245d325d8d61518ad09f9c0a31037e1fc7"
 
 [[tasks]]
 name = "tempo-mcp-v1/policy-authorization"
-digest = "sha256:d2ee35521c64b2642534ddfed2811e20db89ff9238d59e34765fdb602abb9338"
+digest = "sha256:38afc2ab004dfccf7b94004e4edf2bede73636f0bc689e14120d098707885b11"
 
 [[tasks]]
 name = "tempo-mcp-v1/stablecoin-creation"
-digest = "sha256:4eb491a53f251cd1c846abcb9a0c783eb8928a9e92cee9b32eb2b8e89bfd8343"
+digest = "sha256:adccc82f2030930754bf5a2e6bbb6e08de986f991c65b20d5e66af3b3ba0bf96"
 
 [[tasks]]
 name = "tempo-mcp-v1/tip20-transfer-memo"
-digest = "sha256:956f9687c8b9fe8dc8c07d69b7862c822d0c85fbf76a0630c2f73c4acdc74ae3"
+digest = "sha256:806163aa8264106cf19a8278e4db7416491846c33e5d8903a47f768c42e37fba"
 
 [[tasks]]
 name = "tempo-mcp-v1/transaction-status"
-digest = "sha256:a7bc4898ff17ce2662ddf838f7b7979210e6138f1dc31451aaa99df1660211d3"
+digest = "sha256:a8d751193b0746e073f149bb8bd9195ed2d771e9c06cf3b73c54dd9b098213d1"
 
 [[tasks]]
 name = "tempo-mcp-v1/wallet-client"
-digest = "sha256:fd6906d6638d46b2ac2e4f49846ac949d4482de23defed97f6d33bd46ada9497"
+digest = "sha256:c9707090182d6d49d3fcb45efbc76130956df3918decd62c2449bcf7d50dd10f"
 

--- a/tasks/tempo-mcp-v1/dataset.toml
+++ b/tasks/tempo-mcp-v1/dataset.toml
@@ -11,11 +11,11 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-mcp-v1/access-keys"
-digest = "sha256:5ecd9053535dfb6d5b84d9a3d56b49e410e2e5f06e12dff3266980cd4abeec05"
+digest = "sha256:089f6979880de5a6e92d1e496cf5d625fa3e3866b810342fadebb081c16d7d2f"
 
 [[tasks]]
 name = "tempo-mcp-v1/batched-transfers"
-digest = "sha256:55e1103a2175d5cc61b00f412cdbcf76db32b001da9c57886dada337a4c137e0"
+digest = "sha256:0b4cdf393c9d340cf7ed78b7a7ec44eff04628052f58d83c4ab990616982541d"
 
 [[tasks]]
 name = "tempo-mcp-v1/dex-swap"
@@ -23,23 +23,23 @@ digest = "sha256:e5fab8461c0c91c4c6227286c661e45924780749dbcf18d0800172fa6c773be
 
 [[tasks]]
 name = "tempo-mcp-v1/faucet-funding"
-digest = "sha256:06ce549ef02bc163ee09eb7f04201ce9ace7325caf7b6ef33d73622989545baa"
+digest = "sha256:2f31e656303e6f040aafe95c0aae4eaafbf78e018bc62f784072ad3501b87eab"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-and-payer"
-digest = "sha256:cdcc872565775a9156de4746f9ef2bab5c1e899c4d76522b13adc9ea4c81f2f0"
+digest = "sha256:440fb98953980c7eb4042ea46eae49b6c29423a931e26bc4fe0662750919d243"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-configuration"
-digest = "sha256:c90b8e28d0da02761b1cde48e1f5c0ba3be70bdac3ac62a750ce4d85daf4c37e"
+digest = "sha256:6fd83aa3eceeb74b348ffd4060ca874781fee832d48b967732e71b7bcc7e2d2b"
 
 [[tasks]]
 name = "tempo-mcp-v1/passkey-account"
-digest = "sha256:6eb5b4c1b91f58c30e75ed20a55717bbd0b0be4b3639ed888f97daa5dd0a00b0"
+digest = "sha256:19c56692bb8ef8f5d37169a1c7afda245d325d8d61518ad09f9c0a31037e1fc7"
 
 [[tasks]]
 name = "tempo-mcp-v1/policy-authorization"
-digest = "sha256:0a76c12ba3b37aa9620059c36187c2dfc8a6663f259ea8a148c097719f41d598"
+digest = "sha256:38afc2ab004dfccf7b94004e4edf2bede73636f0bc689e14120d098707885b11"
 
 [[tasks]]
 name = "tempo-mcp-v1/stablecoin-creation"
@@ -47,7 +47,7 @@ digest = "sha256:adccc82f2030930754bf5a2e6bbb6e08de986f991c65b20d5e66af3b3ba0bf9
 
 [[tasks]]
 name = "tempo-mcp-v1/tip20-transfer-memo"
-digest = "sha256:56ad34c479328318d00fae085ff12eb9609e41dcb6f9831483364d1b9f0822b9"
+digest = "sha256:806163aa8264106cf19a8278e4db7416491846c33e5d8903a47f768c42e37fba"
 
 [[tasks]]
 name = "tempo-mcp-v1/transaction-status"
@@ -55,5 +55,5 @@ digest = "sha256:a8d751193b0746e073f149bb8bd9195ed2d771e9c06cf3b73c54dd9b098213d
 
 [[tasks]]
 name = "tempo-mcp-v1/wallet-client"
-digest = "sha256:c30a8999ff29f3ee3d8671128ab82341b32ae7928cdef8e029033a7c1298a864"
+digest = "sha256:c9707090182d6d49d3fcb45efbc76130956df3918decd62c2449bcf7d50dd10f"
 

--- a/tasks/tempo-mcp-v1/dataset.toml
+++ b/tasks/tempo-mcp-v1/dataset.toml
@@ -11,49 +11,49 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-mcp-v1/access-keys"
-digest = "sha256:0753f8fa13ad605d17d3827d37f9f4773b0333f1a986196c019ccacf687500d6"
+digest = "sha256:df4378d0f460fae261b6c674fd45a970e1bfc397514ea5a55308b472c8d4984c"
 
 [[tasks]]
 name = "tempo-mcp-v1/batched-transfers"
-digest = "sha256:457ea7c19cd70b2f0566456900fdb225b6d2557ba588ea6f525c17b5c6454e29"
+digest = "sha256:5f01b7dc9db6012f949b3054aa77762d1e9de27f97fb20cffdaef991e3310ce5"
 
 [[tasks]]
 name = "tempo-mcp-v1/dex-swap"
-digest = "sha256:046b51acebe41584d1bc547b1dc1dd774b8e6b1cc836f91bed7c9c1401be5ada"
+digest = "sha256:d6620359762dfc4856ef39b8d94f311656270b325e7c0244d983f0bea5510c5e"
 
 [[tasks]]
 name = "tempo-mcp-v1/faucet-funding"
-digest = "sha256:084a5df69e178e2e9dd8ea14c010086693406ff0ade64cfd8ee1c82e9b024b22"
+digest = "sha256:36f768bce3ab546011458325b9bcfaf6a33af16a47dae6da97f46cfd7741ca32"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-and-payer"
-digest = "sha256:04a2f5ef83ebb90d45ec77a14901344044d0a5d6b064ae8b4a5910ad1bfdc0dd"
+digest = "sha256:10c274e8cf7e68498c095ba0896c0136fd6a691e580295be84a8b8b7bf858e6f"
 
 [[tasks]]
 name = "tempo-mcp-v1/fee-token-configuration"
-digest = "sha256:575b993e46d3df15c756885d4131b24f41bd7623bc1ccbfd65301fca46d7fd34"
+digest = "sha256:5b623ce9eb704ede761fc217e230b047af61a34e4a47244932f58a2a65ff34c0"
 
 [[tasks]]
 name = "tempo-mcp-v1/passkey-account"
-digest = "sha256:6f8e54f810bc0c4ad7a2a7ef5a961234aff02ccfa512138fb35c4f2abe605138"
+digest = "sha256:77c22cf6029607a75f0a7debba8a1208e95063b7ed599d7819696255ccc60e21"
 
 [[tasks]]
 name = "tempo-mcp-v1/policy-authorization"
-digest = "sha256:b25b6729fb42171de29964246ef7db2fe21882beccfabcf0e0272c32158d76e1"
+digest = "sha256:d2ee35521c64b2642534ddfed2811e20db89ff9238d59e34765fdb602abb9338"
 
 [[tasks]]
 name = "tempo-mcp-v1/stablecoin-creation"
-digest = "sha256:0fb9d0d79518209d1cf230ac3ad7ac245d689480941d12d4cbfc891e9bb83ebe"
+digest = "sha256:4eb491a53f251cd1c846abcb9a0c783eb8928a9e92cee9b32eb2b8e89bfd8343"
 
 [[tasks]]
 name = "tempo-mcp-v1/tip20-transfer-memo"
-digest = "sha256:9e2018f29961a58fcef097e668ef29fc25f27016d9d8d820965536d19e3dc088"
+digest = "sha256:956f9687c8b9fe8dc8c07d69b7862c822d0c85fbf76a0630c2f73c4acdc74ae3"
 
 [[tasks]]
 name = "tempo-mcp-v1/transaction-status"
-digest = "sha256:b41c469da6610d3316639e836908a0a2c9e14a09d63d44fc93e2e7db1f28f897"
+digest = "sha256:a7bc4898ff17ce2662ddf838f7b7979210e6138f1dc31451aaa99df1660211d3"
 
 [[tasks]]
 name = "tempo-mcp-v1/wallet-client"
-digest = "sha256:f32b32b45616a646cf2c8e2694a94feff820992fbe6512ede0ba7a68140cdb13"
+digest = "sha256:fd6906d6638d46b2ac2e4f49846ac949d4482de23defed97f6d33bd46ada9497"
 

--- a/tasks/tempo-mcp-v1/dex-swap/instruction.md
+++ b/tasks/tempo-mcp-v1/dex-swap/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Put pool and fee-token facts in `observations`, then explain the Fee AMM conclusion in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/dex-swap/instruction.md
+++ b/tasks/tempo-mcp-v1/dex-swap/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/dex-swap/tests/expected.json
+++ b/tasks/tempo-mcp-v1/dex-swap/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["pool","fee","token","amm"],"required_patterns":[],"minimum_sources":2,"required_data_tools":["v1_fee-amm_pools"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_fee-amm_pools"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/faucet-funding/instruction.md
+++ b/tasks/tempo-mcp-v1/faucet-funding/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/faucet-funding/instruction.md
+++ b/tasks/tempo-mcp-v1/faucet-funding/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use the inspected address as an observation `subject`, record balance/activity facts in `details`, and keep feature interpretation in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
+++ b/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
+++ b/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
+++ b/tasks/tempo-mcp-v1/faucet-funding/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["address","balance","activities","faucet"],"required_patterns":[{"name":"an account address","pattern":"0x[a-fA-F0-9]{40}","min_matches":1}],"minimum_sources":3,"required_data_tools":["v1_addresses_address_balances","v1_addresses_address_activities"]}
+{
+  "minimum_sources": 3,
+  "required_data_tools": ["v1_addresses_address_balances", "v1_addresses_address_activities"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/fee-token-and-payer/instruction.md
+++ b/tasks/tempo-mcp-v1/fee-token-and-payer/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use the requested transaction hash as an observation `subject`, put token/payer/fee facts in `details`, and map fee behavior to docs in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/fee-token-and-payer/instruction.md
+++ b/tasks/tempo-mcp-v1/fee-token-and-payer/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["fee","token","payer"],"required_patterns":[{"name":"the requested transaction hash","pattern":"0x52420cada2074e5ca33c381f39acb0c7849522f916a516ccad2ab936306198ec","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_transactionHash_get"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_transactions_transactionHash_get"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x52420cada2074e5ca33c381f39acb0c7849522f916a516ccad2ab936306198ec"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x52420cada2074e5ca33c381f39acb0c7849522f916a516ccad2ab936306198ec"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-and-payer/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x52420cada2074e5ca33c381f39acb0c7849522f916a516ccad2ab936306198ec"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/fee-token-configuration/instruction.md
+++ b/tasks/tempo-mcp-v1/fee-token-configuration/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use the transaction hash as an observation `subject`, place observed fee-token and payer facts in `details`, and describe pool/configuration interpretation in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/fee-token-configuration/instruction.md
+++ b/tasks/tempo-mcp-v1/fee-token-configuration/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
+++ b/tasks/tempo-mcp-v1/fee-token-configuration/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["fee","token","payer","pool"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":3,"required_data_tools":["v1_transactions_get","v1_fee-amm_pools"]}
+{
+  "minimum_sources": 3,
+  "required_data_tools": ["v1_transactions_get", "v1_fee-amm_pools"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/passkey-account/instruction.md
+++ b/tasks/tempo-mcp-v1/passkey-account/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use the account address as an observation `subject`, record directly observed authorization behavior in `details`, and explain what it implies only in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/passkey-account/instruction.md
+++ b/tasks/tempo-mcp-v1/passkey-account/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
+++ b/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
+++ b/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["account","authorization","observation","inference"],"required_patterns":[{"name":"an account address","pattern":"0x[a-fA-F0-9]{40}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_addresses_address_activities"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_addresses_address_activities"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
+++ b/tasks/tempo-mcp-v1/passkey-account/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/policy-authorization/instruction.md
+++ b/tasks/tempo-mcp-v1/policy-authorization/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use a transaction hash as each observation `subject`; keep only returned authorization and fee facts in `details`, then place documentation-based interpretation in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/policy-authorization/instruction.md
+++ b/tasks/tempo-mcp-v1/policy-authorization/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
+++ b/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
+++ b/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
+++ b/tasks/tempo-mcp-v1/policy-authorization/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["authorization","fee","sponsor","transaction"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_get"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_transactions_get"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/stablecoin-creation/instruction.md
+++ b/tasks/tempo-mcp-v1/stablecoin-creation/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 5, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise and state the observation time. Add one observation for each of the five tokens, with token/holder/transaction facts in `details`; put TIP-20 comparison in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/stablecoin-creation/instruction.md
+++ b/tasks/tempo-mcp-v1/stablecoin-creation/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/stablecoin-creation/tests/expected.json
+++ b/tasks/tempo-mcp-v1/stablecoin-creation/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["five","token","holder","transaction"],"required_patterns":[],"minimum_sources":3,"required_data_tools":["v1_tokens_get","v1_tokens_token_transactions"]}
+{
+  "minimum_sources": 3,
+  "required_data_tools": ["v1_tokens_get", "v1_tokens_token_transactions"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 5, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/tip20-transfer-memo/instruction.md
+++ b/tasks/tempo-mcp-v1/tip20-transfer-memo/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use the inspected address as an observation `subject`, distinguish transfer and balance-snapshot facts in `details`, and reserve protocol interpretation for `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/tip20-transfer-memo/instruction.md
+++ b/tasks/tempo-mcp-v1/tip20-transfer-memo/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
+++ b/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
+++ b/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
+++ b/tasks/tempo-mcp-v1/tip20-transfer-memo/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["transfer","balance","snapshot","block"],"required_patterns":[{"name":"an account address","pattern":"0x[a-fA-F0-9]{40}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_addresses_address_activities"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_addresses_address_activities"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{40}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/transaction-status/instruction.md
+++ b/tasks/tempo-mcp-v1/transaction-status/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/transaction-status/instruction.md
+++ b/tasks/tempo-mcp-v1/transaction-status/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Put block, transaction, and transfer facts in `observations`; put the T7 conclusion and any indexing uncertainty in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/transaction-status/tests/expected.json
+++ b/tasks/tempo-mcp-v1/transaction-status/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["block","transaction","transfer","t7"],"required_patterns":[],"minimum_sources":2,"required_data_tools":["v1_blocks_get"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_blocks_get"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}

--- a/tasks/tempo-mcp-v1/wallet-client/instruction.md
+++ b/tasks/tempo-mcp-v1/wallet-client/instruction.md
@@ -10,10 +10,12 @@ Write only `/app/answer.json` matching this schema:
 ```json
 {
   "type": "object",
-  "required": ["answer", "sources", "evidence"],
+  "required": ["summary", "observations", "inferences", "sources", "evidence"],
   "additionalProperties": false,
   "properties": {
-    "answer": { "type": "string" },
+    "summary": { "type": "string" },
+    "observations": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["subject", "details", "evidence_refs"], "additionalProperties": false, "properties": {"subject": {"type": "string"}, "details": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
+    "inferences": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["claim", "basis", "evidence_refs"], "additionalProperties": false, "properties": {"claim": {"type": "string"}, "basis": {"type": "string"}, "evidence_refs": {"type": "array", "items": {"type": "integer"}}}}},
     "sources": {
       "type": "array",
       "items": { "type": "string", "format": "uri" }
@@ -35,4 +37,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.
+Keep `summary` concise. Use the selected transaction hash as an observation `subject`, put observed transfer/account/token roles in `details`, and keep the matching client/protocol flow in `inferences`. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/wallet-client/instruction.md
+++ b/tasks/tempo-mcp-v1/wallet-client/instruction.md
@@ -35,4 +35,4 @@ Write only `/app/answer.json` matching this schema:
 }
 ```
 
-Keep `answer` concise. `sources` must include Tempo documentation URLs. `evidence` must link a substantive claim to an MCP data tool you used; omit purely exploratory calls.
+Keep `answer` concise. Put Tempo documentation URLs only in `sources`. Every `evidence.source` must be an MCP data-tool URI for a call you made (for example, `mcp://tempo/v1_transactions_get`); never put an `https://` documentation URL in `evidence`. Omit purely exploratory calls.

--- a/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
+++ b/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
+++ b/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
@@ -4,7 +4,7 @@
   "structured": {
     "required_fields": ["summary", "observations", "inferences"],
     "array_fields": {
-      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {}},
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
       "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
     }
   }

--- a/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
+++ b/tasks/tempo-mcp-v1/wallet-client/tests/expected.json
@@ -1,1 +1,11 @@
-{"required_terms":["transaction","transfer","account","inference"],"required_patterns":[{"name":"a transaction hash","pattern":"0x[a-fA-F0-9]{64}","min_matches":1}],"minimum_sources":2,"required_data_tools":["v1_transactions_get"]}
+{
+  "minimum_sources": 2,
+  "required_data_tools": ["v1_transactions_get"],
+  "structured": {
+    "required_fields": ["summary", "observations", "inferences"],
+    "array_fields": {
+      "observations": {"min_items": 1, "item_required_fields": ["subject", "details", "evidence_refs"], "item_patterns": {"subject": "0x[a-fA-F0-9]{64}"}},
+      "inferences": {"min_items": 1, "item_required_fields": ["claim", "basis", "evidence_refs"], "item_patterns": {}}
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Make MCP task grading depend on explicit, trace-backed evidence rather than brittle prose or URI formatting.

## Summary

- Normalize direct/code MCP data-tool URIs, including query and fragment metadata, before trace validation
- Separate documentation citations from MCP data evidence while accepting safe Tempo documentation URL forms
- Require structured `summary`, `observations`, and `inferences` fields across MCP task outputs
- Add deterministic diagnostics and regression coverage for URI and structured-output validation

## Key design considerations

- Documentation remains a required citation source but never substitutes for trace-backed MCP data evidence
- Normalization preserves the underlying tool identity, which must still appear in the recorded MCP trace
- Task fixtures specify the required structured findings without requiring incidental prose keywords