### PR TITLE
chore: stop idle Daytona sandboxes

### DIFF
--- a/config/generated/job.daytona-agent-dev.yaml
+++ b/config/generated/job.daytona-agent-dev.yaml
@@ -13,6 +13,8 @@ environment:
   kwargs:
     dind_image: docker:28.3.3-dind
     connection_pool_maxsize: null
+    auto_stop_interval_mins: 15
+    auto_delete_interval_mins: 0
 verifier:
   include_logs:
   - '*.json'

--- a/config/generated/job.daytona-agent.yaml
+++ b/config/generated/job.daytona-agent.yaml
@@ -13,6 +13,8 @@ environment:
   kwargs:
     dind_image: docker:28.3.3-dind
     connection_pool_maxsize: null
+    auto_stop_interval_mins: 15
+    auto_delete_interval_mins: 0
 verifier:
   include_logs:
   - '*.json'

--- a/config/generated/job.daytona-oracle.yaml
+++ b/config/generated/job.daytona-oracle.yaml
@@ -13,6 +13,8 @@ environment:
   kwargs:
     dind_image: docker:28.3.3-dind
     connection_pool_maxsize: null
+    auto_stop_interval_mins: 15
+    auto_delete_interval_mins: 0
 verifier:
   include_logs:
   - '*.json'

--- a/config/job.yaml.j2
+++ b/config/job.yaml.j2
@@ -16,6 +16,8 @@ environment:
   kwargs:
     dind_image: {{ dind_image | tojson }}
     connection_pool_maxsize: null
+    auto_stop_interval_mins: 15
+    auto_delete_interval_mins: 0
 {% endif %}
 verifier:
   include_logs:


### PR DESCRIPTION
## Motivation

Prevent abandoned Daytona benchmark sandboxes from consuming resources indefinitely.

## Summary

- Stop idle Daytona sandboxes after 15 minutes
- Delete sandboxes immediately after they stop
- Regenerate Daytona job configs

## Key design considerations

- Applies only to Daytona job environments through the shared template
- Keeps explicit Harbor cleanup enabled