### PR TITLE
fix: verify set fee token transactions without event dependence

### DIFF
--- a/shared/tempo/verifier/src/cases/set-fee-token.js
+++ b/shared/tempo/verifier/src/cases/set-fee-token.js
@@ -1,10 +1,12 @@
-const { parseAbi, parseAbiItem } = require("viem");
+const { decodeFunctionData, parseAbi } = require("viem");
 const { expectAddress, expectHash, expectObject, readResult } = require("../result");
 const { defaultRuntimeEnv } = require("../submission");
-const { findEvent, receiptAfter, sameAddress, waitForEvidence } = require("../tempo");
+const { receiptAfter, sameAddress, waitForEvidence } = require("../tempo");
 
-const USER_TOKEN_SET = parseAbiItem("event UserTokenSet(address indexed user, address indexed token)");
-const FEE_MANAGER = parseAbi(["function userTokens(address user) view returns (address)"]);
+const FEE_MANAGER = parseAbi([
+  "function setUserToken(address token)",
+  "function userTokens(address user) view returns (address)",
+]);
 
 function result(config) {
   return readResult(config, (value) => {
@@ -34,10 +36,18 @@ async function verify({ client, config, fromBlock }) {
     );
     if (!receipt) return null;
 
-    const event = findEvent(receipt, config.feeManager, USER_TOKEN_SET, (args) =>
-      sameAddress(args.user, payer) && sameAddress(args.token, config.feeToken),
-    );
-    if (!event) throw new Error("reported transaction did not set the requested fee token");
+    const transaction = await client.getTransaction({ hash: transactionHash });
+    if (!sameAddress(transaction.to, config.feeManager)) {
+      throw new Error("reported transaction did not call the Fee Manager");
+    }
+    try {
+      const call = decodeFunctionData({ abi: FEE_MANAGER, data: transaction.input });
+      if (call.functionName !== "setUserToken" || !sameAddress(call.args[0], config.feeToken)) {
+        throw new Error();
+      }
+    } catch {
+      throw new Error("reported transaction did not request the expected fee token");
+    }
 
     const token = await client.readContract({
       address: config.feeManager,

--- a/shared/tempo/verifier/test/set-fee-token.test.js
+++ b/shared/tempo/verifier/test/set-fee-token.test.js
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { encodeFunctionData, parseAbi } = require("viem");
+
+const { verify } = require("../src/cases/set-fee-token");
+
+const payer = "0x1111111111111111111111111111111111111111";
+const feeManager = "0x2222222222222222222222222222222222222222";
+const feeToken = "0x3333333333333333333333333333333333333333";
+const otherToken = "0x4444444444444444444444444444444444444444";
+const transactionHash = `0x${"01".repeat(32)}`;
+const feeManagerAbi = parseAbi(["function setUserToken(address token)"]);
+
+function fixture(token = feeToken) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tempo-verifier-"));
+  const resultPath = path.join(dir, "out.json");
+  fs.writeFileSync(
+    resultPath,
+    JSON.stringify({
+      payer: { address: payer },
+      setFeeTokenTransactionHash: transactionHash,
+    }),
+  );
+  return {
+    client: {
+      getTransaction: async () => ({
+        input: encodeFunctionData({ abi: feeManagerAbi, functionName: "setUserToken", args: [token] }),
+        to: feeManager,
+      }),
+      getTransactionReceipt: async () => ({
+        blockNumber: 2n,
+        from: payer,
+        status: "success",
+      }),
+      readContract: async () => feeToken,
+    },
+    config: { feeManager, feeToken, logWaitMs: 10, resultPath },
+    fromBlock: 1n,
+  };
+}
+
+test("accepts a successful idempotent fee-token call without an event", async () => {
+  const evidence = await verify(fixture());
+
+  assert.equal(evidence.payer, payer);
+  assert.equal(evidence.token, feeToken);
+  assert.equal(evidence.transactionHash, transactionHash);
+});
+
+test("rejects a fee-token call with the wrong token", async () => {
+  await assert.rejects(verify(fixture(otherToken)), /did not request the expected fee token/);
+});


### PR DESCRIPTION
## Summary

- validate that the reported transaction calls the Fee Manager's `setUserToken` function with the configured token
- retain successful-receipt, reported-payer, evaluation-block, and final on-chain state checks
- remove the `UserTokenSet` event requirement so idempotent calls are graded correctly
- cover no-event success and wrong-token rejection in verifier tests

## Root cause

An agent can successfully set its fee token while testing the submission before the verifier reruns it. The repeated call succeeds and leaves the expected state in place, but does not necessarily emit another `UserTokenSet` event.

## Validation

- `npm run check`
- `npm run bench:local:oracle:dev -- --task-filter set-fee-token --concurrency 1`
