### PR TITLE
fix: align Tempo quality rubric with task contracts

### DIFF
--- a/shared/global/rewardkit/quality/reward.toml
+++ b/shared/global/rewardkit/quality/reward.toml
@@ -3,7 +3,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -22,7 +21,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,29 +11,29 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:90cde3e9ed6a8a012d12f812f3a931dd2b899b40b284d4d20e9912793cfc6933"
+digest = "sha256:056983683e660fda0eb06ca4a0ee970787c288867adba5a1096ea7ab85869cf5"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:9edbe623f460ee4a00b725e6ca17e90beead6a634554357a7db705e2e85ba57e"
+digest = "sha256:c774917a2480f2c981947acbf15f949d2ccb1acb3cb8caaa0b1d667cb8e24163"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:5b4b954bac592456fcd064bb6970aad5f2613b2136a1aeb5f0e8c242e3dcd49e"
+digest = "sha256:9468a0a5ba9cdbb1fa3d31ea10baf5df0856e4218d2703f6fe1919f42adf4bd2"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:c3c5e347296cc097b57038da9b893e8ff259d8c24e99b49f126198398e649089"
+digest = "sha256:1d93a58e8850d366e8a1a81e8b41e7971ccdc7a4a94a87303024e82e84e0807a"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:b501252f4d6b46a29bb79ef554366c28868f71c1ea4077ee9e7734cc1843a782"
+digest = "sha256:9a968be9ab05d160e56a2baacc0e4b45c28ad287614f8d0d01e32821ee4c0bf5"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:0f4d80d63d074d84ec7db4a8249749369929d616d3e5f83c5692911d947858db"
+digest = "sha256:cf7d53ccb46511610b723c8359c08a5fd6438dc6098f105f77475946f25a472e"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:e4fb0f61f75a9ba349ab3b1bd8aa829f7c43af5897af76ea2cc97c2c7d15a061"
+digest = "sha256:3723ec6467cfde2f0d378acdba471dd531cc3ee35a3b2c4e34a5530443c7dca9"
 

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
+++ b/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/transfer-batched/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-batched/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"

--- a/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
@@ -2,7 +2,6 @@
 judge = "anthropic/claude-haiku-4-5"
 mode = "individual"
 files = ["package.json", "tsconfig.json", "src/index.ts"]
-atif-trajectory = "/logs/agent/trajectory.json"
 timeout = 300
 
 [[criterion]]
@@ -21,7 +20,7 @@ description = "The code uses appropriate Tempo or TIP-20 transaction primitives 
 name = "is_minimal_and_maintainable"
 type = "likert"
 points = 5
-description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code."
+description = "The solution is a focused TypeScript implementation with simple dependencies, readable structure, and no unrelated scaffolding or dead code. Task-required files and fixed output contracts such as /app/out.json are expected and must not be treated as hard-coding or unnecessary scaffolding."
 
 [scoring]
 aggregation = "weighted_mean"


### PR DESCRIPTION
## Summary

- evaluate Tempo code-quality criteria from the submitted project files without passing agent trajectory data to the LLM judge
- clarify that task-required files and fixed output contracts such as `/app/out.json` are expected implementation details
- retain the existing programmatic turn-count and token-efficiency scoring
- refresh all Tempo task digests

## Root cause

The source-quality judge could penalize oracle submissions for a missing agent trajectory and could treat the required `/app/out.json` path as inflexible hard-coding. Neither observation reflects submission quality under the task contract.

## Validation

- `npm run check`
- full seven-task Daytona oracle run: correctness `1.000`, quality `0.952`, no exceptions
