### PR TITLE
chore: simplify Tempo source checks

### DIFF
--- a/scripts/rewardkit_criteria_test.py
+++ b/scripts/rewardkit_criteria_test.py
@@ -1,0 +1,38 @@
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "shared" / "global" / "rewardkit-lib"))
+
+from tempo_bench_rewardkit import criteria  # noqa: E402
+
+
+class ViemTempoCriterionTests(unittest.TestCase):
+    def workspace(self, source: str) -> Path:
+        workspace = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, workspace)
+        (workspace / "src").mkdir()
+        (workspace / "package.json").write_text('{"dependencies":{"viem":"^2.53.1"}}')
+        (workspace / "src" / "index.ts").write_text(source)
+        criteria.LOG_DIR = workspace / "logs"
+        return workspace
+
+    def test_accepts_dynamic_import_and_destructured_actions(self) -> None:
+        workspace = self.workspace(
+            'const tempo = await import("viem/tempo");\n'
+            "const { transferSync } = tempo.Actions.token;\n"
+        )
+
+        self.assertTrue(criteria._uses_viem_tempo(workspace))
+
+    def test_rejects_missing_tempo_import(self) -> None:
+        workspace = self.workspace('import { createPublicClient } from "viem";\n')
+
+        self.assertFalse(criteria._uses_viem_tempo(workspace))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/__init__.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/__init__.py
@@ -5,7 +5,7 @@ from .criteria import (
     tempo_mcp_tool_used,
     tempo_rejects_other_blockchains,
     tempo_trajectory_matches,
-    tempo_uses_viem_tempo_actions,
+    tempo_uses_viem_tempo,
 )
 
 __all__ = [
@@ -13,5 +13,5 @@ __all__ = [
     "tempo_mcp_tool_used",
     "tempo_rejects_other_blockchains",
     "tempo_trajectory_matches",
-    "tempo_uses_viem_tempo_actions",
+    "tempo_uses_viem_tempo",
 ]

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
@@ -275,11 +275,7 @@ def tempo_rejects_other_blockchains(workspace: Path) -> bool:
     return all(result["passed"] for result in results)
 
 
-@criterion(shared=True)
-def tempo_uses_viem_tempo_actions(
-    workspace: Path,
-    actions: list[str],
-) -> bool:
+def _uses_viem_tempo(workspace: Path) -> bool:
     patterns = [
         {
             "name": "package_depends_on_viem",
@@ -290,20 +286,11 @@ def tempo_uses_viem_tempo_actions(
             "name": "source_imports_viem_tempo",
             "pattern": (
                 r"from\s+['\"]viem/tempo(?:/chains)?['\"]|"
-                r"require\(\s*['\"]viem/tempo"
+                r"require\(\s*['\"]viem/tempo|"
+                r"import\(\s*['\"]viem/tempo"
             ),
         },
     ]
-    patterns.extend(
-        {
-            "name": f"source_uses_actions_{action.replace('.', '_')}",
-            # Accept both the namespace form Actions.token.transferSync(client,
-            # ...) and the decorated client form client.token.transferSync(...),
-            # plus Sync/non-Sync action variants.
-            "pattern": rf"\w+\.{re.escape(action)}",
-        }
-        for action in actions
-    )
     results = [
         _pattern_check(
             workspace,
@@ -315,6 +302,11 @@ def tempo_uses_viem_tempo_actions(
     ]
     _write_json("tempo-actions.json", {"checks": results})
     return all(result["passed"] for result in results)
+
+
+@criterion(shared=True)
+def tempo_uses_viem_tempo(workspace: Path) -> bool:
+    return _uses_viem_tempo(workspace)
 
 
 @criterion(shared=True)

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/correctness/criteria.py
@@ -6,13 +6,7 @@ from tempo_bench_rewardkit.common.checks import (
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
-rk.tempo_uses_viem_tempo_actions(
-    [
-        "token.create",
-        "policy.create",
-        "token.changeTransferPolicy",
-    ]
-)
+rk.tempo_uses_viem_tempo()
 register_source_patterns(
     [
         {

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,29 +11,29 @@ name = "Tempo"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:056983683e660fda0eb06ca4a0ee970787c288867adba5a1096ea7ab85869cf5"
+digest = "sha256:e99ac33fd545bcf9b42c84241558750f774ff4bb1798c388666699853bd8fc18"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:c774917a2480f2c981947acbf15f949d2ccb1acb3cb8caaa0b1d667cb8e24163"
+digest = "sha256:40739279cf5cfabc54c215f59df454a22e39f9f91963ef1f65ddea46ad7ba255"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:9468a0a5ba9cdbb1fa3d31ea10baf5df0856e4218d2703f6fe1919f42adf4bd2"
+digest = "sha256:209c36d9c2980c3ff183f425b3d0939b9585b4e03559e9e308d21dfae3805f17"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:1d93a58e8850d366e8a1a81e8b41e7971ccdc7a4a94a87303024e82e84e0807a"
+digest = "sha256:c2624da0862a738f8a41b61a5cab40b43b652210375173485f5d9775efe97fb7"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:9a968be9ab05d160e56a2baacc0e4b45c28ad287614f8d0d01e32821ee4c0bf5"
+digest = "sha256:6e410f282147cd1af5c20f5d152857b83afa60d585aa3a81bfcd147d364ea665"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:cf7d53ccb46511610b723c8359c08a5fd6438dc6098f105f77475946f25a472e"
+digest = "sha256:ae65f78cb9d79fd22f3be58a18d0fda0f2ad6ea7e2282e74054de1a9a6479fa7"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:3723ec6467cfde2f0d378acdba471dd531cc3ee35a3b2c4e34a5530443c7dca9"
+digest = "sha256:e663965ecb4d7d5d387093d2b3578b5f972f4eefa8b668576f90ea9039b4d84f"
 

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/correctness/criteria.py
@@ -3,4 +3,4 @@ from tempo_bench_rewardkit.common.checks import register_tempo_eval_contract
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
-rk.tempo_uses_viem_tempo_actions(["faucet.fund", "token.transfer"])
+rk.tempo_uses_viem_tempo()

--- a/tasks/tempo-v1/set-fee-token/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/set-fee-token/tests/correctness/criteria.py
@@ -6,7 +6,7 @@ from tempo_bench_rewardkit.common.checks import (
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
-rk.tempo_uses_viem_tempo_actions(["fee.setUserToken"])
+rk.tempo_uses_viem_tempo()
 register_source_patterns(
     [
         {

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/correctness/criteria.py
@@ -6,13 +6,9 @@ from tempo_bench_rewardkit.common.checks import (
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
-rk.tempo_uses_viem_tempo_actions(["token.approve"])
+rk.tempo_uses_viem_tempo()
 register_source_patterns(
     [
-        {
-            "name": "source_executes_dex_swap",
-            "pattern": r"\w+\.dex\.(sell|buy)",
-        },
         {
             "name": "source_reads_swap_token_env",
             "pattern": (

--- a/tasks/tempo-v1/transfer-batched/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-batched/tests/correctness/criteria.py
@@ -6,28 +6,12 @@ from tempo_bench_rewardkit.common.checks import (
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
+rk.tempo_uses_viem_tempo()
 register_source_patterns(
     [
         {
-            "name": "package_depends_on_viem",
-            "file": "package.json",
-            "pattern": r'"viem"\s*:',
-        },
-        {
-            "name": "source_imports_viem_tempo",
-            "pattern": r"from\s+['\"]viem/tempo['\"]",
-        },
-        {
             "name": "source_reads_tempo_recipients",
             "pattern": r"TEMPO_RECIPIENTS",
-        },
-        {
-            "name": "source_encodes_tip20_transfers",
-            "pattern": r"Abis\.tip20|encodeFunctionData",
-        },
-        {
-            "name": "source_submits_tempo_batch_calls",
-            "pattern": r"sendTransaction\s*\(\s*\{\s*calls\b",
         },
     ]
 )

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/correctness/criteria.py
@@ -6,20 +6,12 @@ from tempo_bench_rewardkit.common.checks import (
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
-rk.tempo_uses_viem_tempo_actions(["token.transfer"])
+rk.tempo_uses_viem_tempo()
 register_source_patterns(
     [
         {
             "name": "source_reads_tempo_memo",
             "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
-        },
-        {
-            "name": "source_passes_fee_payer",
-            "pattern": r"feePayer",
         },
         {
             "name": "source_reads_fee_token",

--- a/tasks/tempo-v1/transfer-with-memo/tests/correctness/criteria.py
+++ b/tasks/tempo-v1/transfer-with-memo/tests/correctness/criteria.py
@@ -6,16 +6,12 @@ from tempo_bench_rewardkit.common.checks import (
 
 register_tempo_eval_contract()
 rk.tempo_rejects_other_blockchains()
-rk.tempo_uses_viem_tempo_actions(["token.transfer"])
+rk.tempo_uses_viem_tempo()
 register_source_patterns(
     [
         {
             "name": "source_reads_tempo_memo",
             "pattern": r"TEMPO_MEMO",
-        },
-        {
-            "name": "source_parses_token_units",
-            "pattern": r"parseUnits",
         },
     ]
 )


### PR DESCRIPTION
## Summary

- replace action-specific Tempo source checks with a broad `viem` dependency and `viem/tempo` import criterion
- accept static, CommonJS, and dynamic Tempo imports
- remove binary checks for exact action names, `parseUnits`, `feePayer`, DEX helper spelling, and batch call formatting
- retain the runnable eval contract, environment usage, non-Tempo SDK rejection, task-specific environment checks, and independent on-chain verification

## Root cause

Correct submissions could fail because their source used equivalent TypeScript structure, such as destructured Tempo actions or a request object passed to `sendTransaction`, without matching an exact regex. These checks graded implementation spelling rather than observable behavior.

## Validation

- `npm run check`
- `npm run check:dataset`
- all seven local oracle correctness checks passed; one concurrent testnet request was rate-limited and passed on isolated retry
