### PR TITLE
chore: rename private project metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tempo-bench",
+  "name": "tempo-evals",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tempo-bench",
+      "name": "tempo-evals",
       "version": "0.1.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tempo-bench",
+  "name": "tempo-evals",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "tempo-bench"
+name = "tempo-evals"
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -2391,7 +2391,7 @@ wheels = [
 ]
 
 [[package]]
-name = "tempo-bench"
+name = "tempo-evals"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Motivation

Align private project metadata with the Tempo Evals brand without changing benchmark contracts.

## Summary

- Rename the root Node package metadata
- Rename the root Python project metadata
- Refresh matching lockfile metadata

## Key design considerations

- Preserve dataset IDs, runtime environment variables, verifier namespaces, and base-image references