### PR TITLE
chore: configure production evaluation matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ npm run bench:daytona:oracle -- --base-image "$(npm run -s base-image:ref)"
 
 # Full Claude Code matrix on Daytona.
 npm run bench:daytona:agent -- --base-image "$(npm run -s base-image:ref)"
+
+# One-attempt run over the configured production model matrix.
+npm run bench:matrix:dev -- --task-suite tempo --base-image "$(npm run -s base-image:ref)"
+
+# Three-attempt run over the configured production model matrix.
+npm run bench:matrix:production -- --task-suite tempo --base-image "$(npm run -s base-image:ref)"
 ```
 
 ## Authoring a New Task

--- a/config/models.production.yaml
+++ b/config/models.production.yaml
@@ -1,19 +1,23 @@
 # Production model matrix for `npm run bench:production`.
 #
-# Supported forms:
-#   - claude-haiku-4-5
-#     Shorthand for:
-#       agent: claude-code
-#       model_name: claude-haiku-4-5
-#
-#   - agent: codex
-#     model_name: gpt-5
-#     Explicit agent/model entry. Optional fields:
-#       n_concurrent: 8
-#       concurrency_group: openai
-#
 # `--agent-concurrency N` overrides per-entry n_concurrent for the run.
 models:
-  - claude-haiku-4-5
+  - agent: claude-code
+    model_name: claude-haiku-4-5-20251001
+    n_concurrent: 8
+    concurrency_group: anthropic
+
+  - agent: claude-code
+    model_name: claude-sonnet-5
+    n_concurrent: 8
+    concurrency_group: anthropic
+
   - agent: codex
-    model_name: gpt-5
+    model_name: gpt-5.4-mini-2026-03-17
+    n_concurrent: 8
+    concurrency_group: openai
+
+  - agent: codex
+    model_name: gpt-5.4-2026-03-05
+    n_concurrent: 8
+    concurrency_group: openai

--- a/config/tempo-docs.lock.json
+++ b/config/tempo-docs.lock.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "repo": "https://github.com/tempoxyz/docs.git",
-  "sha": "21227e5d949fe33c3e1af07d03bf4fe6346f486c"
+  "sha": "9aa9de6399970f31a688a08de3287f8f18415d42"
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "bench:daytona:oracle": "uv run python scripts/run_benchmark.py daytona-oracle",
     "bench:daytona:agent": "uv run python scripts/run_benchmark.py daytona-agent",
     "bench:daytona:agent:dev": "uv run python scripts/run_benchmark.py daytona-agent-dev",
+    "bench:matrix:dev": "uv run python scripts/run_benchmark.py production-daytona --n-attempts 1",
+    "bench:matrix:production": "uv run python scripts/run_benchmark.py production-daytona --n-attempts 3",
     "bench:production": "uv run python scripts/run_benchmark.py production-daytona",
     "results:export": "uv run python scripts/export_results.py",
     "results:compare": "uv run python scripts/compare_mcp_results.py",

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -86,6 +86,8 @@ Options:
   --job-name NAME          Override generated job name
   --models-config PATH     Production model matrix config
                            (default: config/models.production.yaml)
+  --n-attempts N          Override production attempts per task and model
+                          (default: 3)
   --concurrency N         Override n_concurrent_trials
   --agent-concurrency N   Override per-agent n_concurrent
   --max-retries N         Retry transient trial/setup failures
@@ -125,6 +127,10 @@ def parse_args(argv: list[str]) -> tuple[str | None, dict[str, Any]]:
     parser.add_argument("--env-file", default=".env" if Path(".env").exists() else None)
     parser.add_argument("--job-name")
     parser.add_argument("--models-config")
+    parser.add_argument(
+        "--n-attempts",
+        type=lambda value: read_positive_integer(value, "--n-attempts"),
+    )
     parser.add_argument(
         "--concurrency",
         type=lambda value: read_positive_integer(value, "--concurrency"),
@@ -543,7 +549,7 @@ def production_job(
     return {
         "job_name": "harbor-job",
         "jobs_dir": str(production_run_root(run_id)),
-        "n_attempts": 3,
+        "n_attempts": int(options.get("n_attempts") or "3"),
         "n_concurrent_trials": int(options.get("concurrency") or "32"),
         "environment_type": "daytona",
         "force_build": False,

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -19,6 +19,7 @@ from scripts.run_benchmark import (
     daytona_base_image,
     finalize_config,
     parse_args,
+    production_job,
     run_benchmark_key,
     run_benchmark_variant,
     stage_filtered_config,
@@ -142,6 +143,32 @@ class RunBenchmarkTest(unittest.TestCase):
         _, options = parse_args(["daytona-agent", "--profile", "all"])
 
         self.assertEqual(options["profile"], "all")
+
+    def test_parse_args_accepts_production_attempts(self) -> None:
+        _, options = parse_args(["production-daytona", "--n-attempts", "1"])
+
+        self.assertEqual(options["n_attempts"], "1")
+
+    def test_production_job_uses_requested_attempts(self) -> None:
+        model_config = {
+            "models": [
+                {
+                    "agent": "claude-code",
+                    "model_name": "claude-haiku-4-5",
+                    "n_concurrent": None,
+                    "concurrency_group": None,
+                }
+            ]
+        }
+
+        self.assertEqual(
+            production_job("test-run", model_config, {"n_attempts": "1"})["n_attempts"],
+            1,
+        )
+        self.assertEqual(
+            production_job("test-run", model_config, {})["n_attempts"],
+            3,
+        )
 
     def test_mcp_profile_is_injected_at_job_level(self) -> None:
         config = {"agents": [{"name": "claude-code"}, {"name": "oracle"}]}


### PR DESCRIPTION
## Motivation

Define the intended cheap/expensive Anthropic and OpenAI comparison on a reproducible Tempo docs snapshot.

## Summary

- configure Haiku 4.5 and Sonnet 5 through Claude Code
- configure GPT-5.4 mini and GPT-5.4 through Codex
- pin the Tempo docs bundle to `9aa9de6399970f31a688a08de3287f8f18415d42`

## Key design considerations

- use Harbor-native agent and concurrency-group configuration
- use dated model identifiers where the provider publishes stable snapshots