### PR TITLE
feat: add evaluation matrix run modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ npm run bench:daytona:oracle -- --base-image "$(npm run -s base-image:ref)"
 
 # Full Claude Code matrix on Daytona.
 npm run bench:daytona:agent -- --base-image "$(npm run -s base-image:ref)"
+
+# One-attempt run over the configured production model matrix.
+npm run bench:matrix:dev -- --task-suite tempo --base-image "$(npm run -s base-image:ref)"
+
+# Three-attempt run over the configured production model matrix.
+npm run bench:matrix:production -- --task-suite tempo --base-image "$(npm run -s base-image:ref)"
 ```
 
 ## Authoring a New Task

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "bench:daytona:oracle": "uv run python scripts/run_benchmark.py daytona-oracle",
     "bench:daytona:agent": "uv run python scripts/run_benchmark.py daytona-agent",
     "bench:daytona:agent:dev": "uv run python scripts/run_benchmark.py daytona-agent-dev",
+    "bench:matrix:dev": "uv run python scripts/run_benchmark.py production-daytona --n-attempts 1",
+    "bench:matrix:production": "uv run python scripts/run_benchmark.py production-daytona --n-attempts 3",
     "bench:production": "uv run python scripts/run_benchmark.py production-daytona",
     "results:export": "uv run python scripts/export_results.py",
     "results:compare": "uv run python scripts/compare_mcp_results.py",

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -86,6 +86,8 @@ Options:
   --job-name NAME          Override generated job name
   --models-config PATH     Production model matrix config
                            (default: config/models.production.yaml)
+  --n-attempts N          Override production attempts per task and model
+                          (default: 3)
   --concurrency N         Override n_concurrent_trials
   --agent-concurrency N   Override per-agent n_concurrent
   --max-retries N         Retry transient trial/setup failures
@@ -125,6 +127,10 @@ def parse_args(argv: list[str]) -> tuple[str | None, dict[str, Any]]:
     parser.add_argument("--env-file", default=".env" if Path(".env").exists() else None)
     parser.add_argument("--job-name")
     parser.add_argument("--models-config")
+    parser.add_argument(
+        "--n-attempts",
+        type=lambda value: read_positive_integer(value, "--n-attempts"),
+    )
     parser.add_argument(
         "--concurrency",
         type=lambda value: read_positive_integer(value, "--concurrency"),
@@ -543,7 +549,7 @@ def production_job(
     return {
         "job_name": "harbor-job",
         "jobs_dir": str(production_run_root(run_id)),
-        "n_attempts": 3,
+        "n_attempts": int(options.get("n_attempts") or "3"),
         "n_concurrent_trials": int(options.get("concurrency") or "32"),
         "environment_type": "daytona",
         "force_build": False,

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -19,6 +19,7 @@ from scripts.run_benchmark import (
     daytona_base_image,
     finalize_config,
     parse_args,
+    production_job,
     run_benchmark_key,
     run_benchmark_variant,
     stage_filtered_config,
@@ -142,6 +143,32 @@ class RunBenchmarkTest(unittest.TestCase):
         _, options = parse_args(["daytona-agent", "--profile", "all"])
 
         self.assertEqual(options["profile"], "all")
+
+    def test_parse_args_accepts_production_attempts(self) -> None:
+        _, options = parse_args(["production-daytona", "--n-attempts", "1"])
+
+        self.assertEqual(options["n_attempts"], "1")
+
+    def test_production_job_uses_requested_attempts(self) -> None:
+        model_config = {
+            "models": [
+                {
+                    "agent": "claude-code",
+                    "model_name": "claude-haiku-4-5",
+                    "n_concurrent": None,
+                    "concurrency_group": None,
+                }
+            ]
+        }
+
+        self.assertEqual(
+            production_job("test-run", model_config, {"n_attempts": "1"})["n_attempts"],
+            1,
+        )
+        self.assertEqual(
+            production_job("test-run", model_config, {})["n_attempts"],
+            3,
+        )
 
     def test_mcp_profile_is_injected_at_job_level(self) -> None:
         config = {"agents": [{"name": "claude-code"}, {"name": "oracle"}]}


### PR DESCRIPTION
## Motivation

Make the configured production model matrix usable for both inexpensive iteration and full evaluation without maintaining separate job definitions.

## Summary

- add a validated `--n-attempts` production-runner option
- add `bench:matrix:dev` for one attempt per task and model
- add `bench:matrix:production` for three attempts per task and model
- document both Daytona commands

## Key design considerations

- keep one Harbor-native model matrix as the source of truth
- retain three attempts as the production default