### PR TITLE
feat: support paired production profiles

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -50,6 +50,7 @@ jobs:
             tag="main-$source_tag"
           fi
           echo "ref=$repository:$tag" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$repository:$source_tag" >> "$GITHUB_OUTPUT"
           echo "release_ref=$(sed -nE 's/^[[:space:]]*base_image:[[:space:]]*([^[:space:]#]+).*/\1/p' config/tasks.yaml)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3
@@ -65,7 +66,9 @@ jobs:
         with:
           context: .
           file: shared/global/docker/base/Dockerfile
-          tags: ${{ steps.image.outputs.ref }}
+          tags: |
+            ${{ steps.image.outputs.ref }}
+            ${{ steps.image.outputs.source_ref }}
           push: true
           cache-from: type=gha,scope=tempo-bench-base
           cache-to: type=gha,mode=max,scope=tempo-bench-base
@@ -80,3 +83,4 @@ jobs:
       - name: Publish image reference
         run: |
           echo "Base image: \`${{ steps.image.outputs.ref }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Immutable source image: \`${{ steps.image.outputs.source_ref }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ npm run bench:daytona:oracle -- --base-image "$(npm run -s base-image:ref)"
 # Full Claude Code matrix on Daytona.
 npm run bench:daytona:agent -- --base-image "$(npm run -s base-image:ref)"
 
-# One-attempt run over the configured production model matrix.
-npm run bench:matrix:dev -- --task-suite tempo --base-image "$(npm run -s base-image:ref)"
+# One-attempt Docs/MCP run over the configured production model matrix.
+npm run bench:matrix:dev -- --task-suite tempo --profile all --base-image "$(npm run -s base-image:ref)"
 
-# Three-attempt run over the configured production model matrix.
-npm run bench:matrix:production -- --task-suite tempo --base-image "$(npm run -s base-image:ref)"
+# Three-attempt Docs/MCP run over the configured production model matrix.
+npm run bench:matrix:production -- --task-suite tempo --profile all --base-image "$(npm run -s base-image:ref)"
 ```
 
 ## Authoring a New Task

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -622,7 +622,27 @@ def run_production_variant(
             "exit_status": status,
         },
     )
-    raise SystemExit(status)
+    if status != 0:
+        raise RuntimeError(f"Production benchmark {run_id} failed with status {status}")
+
+
+def prepare_profile_pair(variant: dict[str, Any], options: dict[str, Any]) -> None:
+    """Validate and stage shared inputs before profile workers run in parallel."""
+    load_env_file(options.get("env_file"))
+    preflight(variant, options)
+    if variant.get("production"):
+        models_config_path = (
+            options.get("models_config") or "config/models.production.yaml"
+        )
+        model_config = parse_model_config(
+            models_config_path, options.get("agent_concurrency")
+        )
+        preflight_production_agents(model_config)
+    if options.get("sync"):
+        sync_dataset(options)
+    source = {"mode": "live"} if uses_live_mcp_eval(options) else docs_source(options)
+    if source["mode"] != "live":
+        ensure_docs_bundle(source)
 
 
 def mpp_task_filter(task_filter: str) -> str | None:
@@ -1045,10 +1065,11 @@ def main(argv: list[str]) -> None:
         if not variant:
             usage()
             raise RuntimeError(f"Unknown variant: {variant_name}")
-        if not variant.get("job"):
+        if not variant.get("job") and not variant.get("production"):
             raise RuntimeError(
-                "The all profile requires a job-backed benchmark variant."
+                "The all profile requires a job-backed or production benchmark variant."
             )
+        prepare_profile_pair(variant, options)
         benchmark = run_benchmark_key(variant, options.get("task_suite"))
         prefix = versioned_name(benchmark, variant["prefix"])
         pair_id = options.get("job_name") or f"{prefix}-mcp-pair-{timestamp()}"
@@ -1058,9 +1079,9 @@ def main(argv: list[str]) -> None:
                 "profile": profile_id,
                 "job_name": f"{pair_id}-{profile_id}",
                 "pair_id": pair_id,
-                "sync": options["sync"] if index == 0 else False,
+                "sync": False,
             }
-            for index, profile_id in enumerate(
+            for profile_id in (
                 (MCP_DIRECT_PROFILE["id"], MCP_CODE_PROFILE["id"])
                 if options["profile"] == "mcp-both"
                 else DEFAULT_PROFILE_IDS
@@ -1086,12 +1107,19 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
         msg = f"Unknown variant: {variant_name}"
         raise RuntimeError(msg)
 
-    if options["profile"] in {
-        MCP_PROFILE["id"],
-        MCP_DIRECT_PROFILE["id"],
-        MCP_CODE_PROFILE["id"],
-    } and not variant.get("job"):
-        raise RuntimeError("The MCP profile requires a job-backed benchmark variant.")
+    if (
+        options["profile"]
+        in {
+            MCP_PROFILE["id"],
+            MCP_DIRECT_PROFILE["id"],
+            MCP_CODE_PROFILE["id"],
+        }
+        and not variant.get("job")
+        and not variant.get("production")
+    ):
+        raise RuntimeError(
+            "The MCP profile requires a job-backed or production benchmark variant."
+        )
 
     source = {"mode": "live"} if uses_live_mcp_eval(options) else docs_source(options)
     load_env_file(options.get("env_file"))
@@ -1111,6 +1139,7 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
     args = ["run", "harbor", "run"]
     if variant.get("production"):
         run_production_variant(run_id, options, source, docs_bundle)
+        return
 
     if variant.get("job"):
         job_config = load_compiled_config(variant_name)

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -18,10 +18,13 @@ from scripts.run_benchmark import (
     benchmark_provenance,
     daytona_base_image,
     finalize_config,
+    main,
     parse_args,
+    prepare_profile_pair,
     production_job,
     run_benchmark_key,
     run_benchmark_variant,
+    run_production_variant,
     stage_filtered_config,
     stage_pinned_docs_task,
     uses_live_mcp_eval,
@@ -143,6 +146,132 @@ class RunBenchmarkTest(unittest.TestCase):
         _, options = parse_args(["daytona-agent", "--profile", "all"])
 
         self.assertEqual(options["profile"], "all")
+
+    def test_production_all_profile_runs_paired_docs_and_mcp_jobs(self) -> None:
+        with (
+            patch("scripts.run_benchmark.prepare_profile_pair") as prepare_pair,
+            patch("scripts.run_benchmark.run_benchmark_variant") as run_variant,
+        ):
+            main(
+                [
+                    "production-daytona",
+                    "--profile",
+                    "all",
+                    "--job-name",
+                    "paired-run",
+                ]
+            )
+
+        prepare_pair.assert_called_once()
+        profiles = {
+            call.args[1]["profile"]: call.args[1] for call in run_variant.call_args_list
+        }
+        self.assertEqual(set(profiles), {"docs", "mcp"})
+        self.assertEqual(profiles["docs"]["job_name"], "paired-run-docs")
+        self.assertEqual(profiles["mcp"]["job_name"], "paired-run-mcp")
+        self.assertTrue(all(not options["sync"] for options in profiles.values()))
+        self.assertTrue(
+            all(options["pair_id"] == "paired-run" for options in profiles.values())
+        )
+
+    def test_profile_pair_prepares_shared_inputs_once(self) -> None:
+        source = {"mode": "pinned", "repo": "tempo/docs", "sha": "docs123"}
+        model_config = {"models": []}
+        options = {
+            "agent_concurrency": None,
+            "env_file": None,
+            "models_config": None,
+            "sync": True,
+            "task_suite": "tempo",
+        }
+        variant = {"production": True}
+        with (
+            patch("scripts.run_benchmark.load_env_file") as load_env,
+            patch("scripts.run_benchmark.preflight") as preflight,
+            patch(
+                "scripts.run_benchmark.parse_model_config",
+                return_value=model_config,
+            ) as parse_models,
+            patch(
+                "scripts.run_benchmark.preflight_production_agents"
+            ) as preflight_models,
+            patch("scripts.run_benchmark.sync_dataset") as sync_dataset,
+            patch("scripts.run_benchmark.docs_source", return_value=source),
+            patch("scripts.run_benchmark.ensure_docs_bundle") as ensure_bundle,
+        ):
+            prepare_profile_pair(variant, options)
+
+        load_env.assert_called_once_with(None)
+        preflight.assert_called_once_with(variant, options)
+        parse_models.assert_called_once_with("config/models.production.yaml", None)
+        preflight_models.assert_called_once_with(model_config)
+        sync_dataset.assert_called_once_with(options)
+        ensure_bundle.assert_called_once_with(source)
+
+    def test_production_failure_is_reported_to_profile_pair(self) -> None:
+        model_config = {
+            "models": [
+                {
+                    "agent": "claude-code",
+                    "model_name": "claude-haiku-4-5",
+                    "n_concurrent": None,
+                    "concurrency_group": None,
+                }
+            ]
+        }
+        job = {"n_attempts": 1, "n_concurrent_trials": 1}
+        options = {
+            "agent_concurrency": None,
+            "env_file": None,
+            "max_retries": None,
+            "models_config": None,
+            "profile": "docs",
+            "task_filter": None,
+            "task_suite": "tempo",
+        }
+        with (
+            patch(
+                "scripts.run_benchmark.parse_model_config", return_value=model_config
+            ),
+            patch("scripts.run_benchmark.preflight_production_agents"),
+            patch("scripts.run_benchmark.production_job", return_value=job),
+            patch("scripts.run_benchmark.render_job_config", return_value={}),
+            patch(
+                "scripts.run_benchmark.stage_daytona_config", return_value="job.yaml"
+            ),
+            patch("scripts.run_benchmark.write_production_metadata"),
+            patch("scripts.run_benchmark.run_output", return_value="test"),
+            patch("scripts.run_benchmark.run_status", return_value=7),
+            self.assertRaisesRegex(RuntimeError, "failed with status 7"),
+        ):
+            run_production_variant(
+                "failed-run",
+                options,
+                {"mode": "pinned", "sha": "docs123"},
+                "/tmp/docs",
+            )
+
+    def test_successful_production_run_does_not_fall_through(self) -> None:
+        options = {
+            "env_file": None,
+            "job_name": "production-run",
+            "profile": "mcp",
+            "sync": False,
+            "task_suite": "tempo",
+        }
+        with (
+            patch("scripts.run_benchmark.load_env_file"),
+            patch("scripts.run_benchmark.preflight"),
+            patch("scripts.run_benchmark.preflight_mcp_target"),
+            patch("scripts.run_benchmark.docs_source", return_value={"mode": "public"}),
+            patch("scripts.run_benchmark.ensure_docs_bundle", return_value=None),
+            patch("scripts.run_benchmark.run_production_variant") as run_production,
+            patch("scripts.run_benchmark.run") as run,
+        ):
+            run_benchmark_variant("production-daytona", options)
+
+        run_production.assert_called_once()
+        run.assert_not_called()
 
     def test_parse_args_accepts_production_attempts(self) -> None:
         _, options = parse_args(["production-daytona", "--n-attempts", "1"])


### PR DESCRIPTION
## Motivation

Allow the production model matrix to evaluate the same Tempo v1 tasks under both pinned documentation and MCP access with one command.

## Summary

- support `--profile all` for production matrix runs
- stage shared datasets and pinned docs once before parallel Docs/MCP jobs
- propagate worker failures without terminating inside a profile thread
- publish the immutable source-derived base-image tag printed by `base-image:ref`
- document the paired dev and production commands

## Key design considerations

- preserve separate Harbor jobs and a shared pair identifier for comparable profiles
- keep synchronization out of concurrent workers to avoid staging races
- keep the source-derived image reference content-addressed and branch-independent