### PR TITLE
Clarify Tempo v1 library requirements

### DIFF
--- a/tasks/tempo-v1/access-key-transfer/README.md
+++ b/tasks/tempo-v1/access-key-transfer/README.md
@@ -14,7 +14,7 @@ account and send a stablecoin payment signed by that key.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` access-key authorization and token transfer actions are required; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including:
   - The reported payer authorizes the reported access key.
   - The reported access key signs the transfer transaction for the payer.

--- a/tasks/tempo-v1/create-stablecoin-with-policy/README.md
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/README.md
@@ -14,5 +14,5 @@ policy, and link the policy to the new token.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` `Actions.token.create`, `Actions.policy.create`, and `Actions.token.changeTransferPolicy`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including onchain evidence of the reported token, policy account update, and policy-to-token link.

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,37 +11,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo-v1/access-key-transfer"
-digest = "sha256:fc81745aa04f5df898d92cd6285febd688e96f7aa634f79b24f4661fbcc85a7b"
+digest = "sha256:e5afa6a033962db7f8f05abed8c80187894a708b5d2f04f038eb87013b23e92d"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:7810b8bfeb94daf07ee1f414038e963726422986d5ac28a54350d958e679c33a"
+digest = "sha256:97101f20a2c1e2fb2f9e8422f56d8bf88d0c41b1303e76b5d4cde7645f3a961d"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:22cf474b1ead6304a02da0bf315797bc4f7383f6743fc4568192d0a73ca65f0b"
+digest = "sha256:ec13777fb6638526d800ecad52447bb91ff15b60139bd8a9ce3ab1b094d6c671"
 
 [[tasks]]
 name = "tempo-v1/receive-policy-held-transfer"
-digest = "sha256:7f03d2873c5c209477fac74b38505f39a22a2bcd61a273f9a8f549da29829616"
+digest = "sha256:c2bfb7c7793f128efcfdae334d46cc99652022d8fe51a13cefaa7b5f81acf4f5"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:b61b88a42c946972a49a99e1f4441734273d784b6462355c570771bf58ff44df"
+digest = "sha256:1101e224827574049fe2ee87ca65cf28ff2f4a1f7f30ecc85ecba1a60e40b7cb"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:2326e10cae65e644e2d9f7cbaf90395702e0cd67da9faa7234fc92b90d6a6045"
+digest = "sha256:d5770b56a1e3e69eef11876372ac8f21115d07d77be687dd662a4e0ecdc61ce0"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:732ca57a225a98b0f726a7a47b7521d371841f6a77a10964b9f335f01bb6b571"
+digest = "sha256:42c154cdbc71da4fa79b778efc444c5b0b1433fe4d5a146bb5a09c69d68eb7a0"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:03b579187051cb4a87787f82b3ecae7f246281852efc6c1992b9c9913eb73825"
+digest = "sha256:f09a33cab34ead7c9baba4bc09471ab76f13825689ebbf626b215f325385cb6c"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:b9b8ef303f762a5a525f0f59d0a3909ab1db1406cc3999d99ae88ce39b777d3a"
+digest = "sha256:412d6139475ec4db03e6e613fca94021ddb38c02b9ed38857284b570282a3169"
 

--- a/tasks/tempo-v1/faucet-funded-transfer/README.md
+++ b/tasks/tempo-v1/faucet-funded-transfer/README.md
@@ -14,5 +14,5 @@ send a stablecoin transfer from that funded wallet.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` `Actions.faucet.fund` and `Actions.token.transfer`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including onchain evidence that the faucet funded the reported payer before its configured transfer.

--- a/tasks/tempo-v1/receive-policy-held-transfer/README.md
+++ b/tasks/tempo-v1/receive-policy-held-transfer/README.md
@@ -14,6 +14,6 @@ receive policy and send a stablecoin transfer that the policy blocks and holds.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` receive-policy and token actions are required; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including the required policy, transaction order,
   blocked transfer, and exact balance held by the receive-policy guard.

--- a/tasks/tempo-v1/set-fee-token/README.md
+++ b/tasks/tempo-v1/set-fee-token/README.md
@@ -14,5 +14,5 @@ through the Fee Manager.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` `Actions.fee.setUserToken`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including onchain confirmation that the reported payer's default fee token matches the configured token.

--- a/tasks/tempo-v1/stablecoin-dex-swap/README.md
+++ b/tasks/tempo-v1/stablecoin-dex-swap/README.md
@@ -14,5 +14,5 @@ on testnet.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` `Actions.token.approve` and a Stablecoin DEX buy or sell action; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including an onchain DEX fill for the reported taker and configured input amount, with the configured input token spent in that transaction.

--- a/tasks/tempo-v1/transfer-batched/README.md
+++ b/tasks/tempo-v1/transfer-batched/README.md
@@ -13,7 +13,7 @@ Build a TypeScript integration that pays every recipient in a supplied list the 
 ## Verification
 
 - General file structure: `/app/package.json` and `/app/src/index.ts` are checked.
-- Usage of proper Tempo libraries: `viem/tempo` TIP-20 ABI utilities are required; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including:
   - Every configured recipient receives the configured stablecoin amount.
   - All transfers originate from the reported payer.

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/README.md
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/README.md
@@ -14,5 +14,5 @@ delegating transaction fees to a separate fee payer.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` `Actions.token.transfer`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including a memo transfer with the configured amount and a sponsored Tempo envelope for the reported fee payer and configured fee token.

--- a/tasks/tempo-v1/transfer-with-memo/README.md
+++ b/tasks/tempo-v1/transfer-with-memo/README.md
@@ -14,5 +14,5 @@ the required memo attached.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: `viem/tempo` `Actions.token.transfer`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including a TransferWithMemo event with the reported payer, recipient, amount, and memo.


### PR DESCRIPTION
## Summary

- remove stale claims that specific Tempo Actions helpers are required
- document the actual `viem` dependency and `viem/tempo` import checks across all Tempo v1 task READMEs
- refresh the affected Tempo v1 dataset digests

## Why

Action-specific quality criteria were removed, but the task READMEs still described those helpers as mandatory.

## Validation

- `npm run check`
- `npm run check:dataset`
- `npm run check:generated`
- `git diff --check`