### PR TITLE
Support Tempo fee-token transactions

### DIFF
--- a/shared/tempo/verifier/src/cases/set-fee-token.js
+++ b/shared/tempo/verifier/src/cases/set-fee-token.js
@@ -37,15 +37,24 @@ async function verify({ client, config, fromBlock }) {
     if (!receipt) return null;
 
     const transaction = await client.getTransaction({ hash: transactionHash });
-    if (!sameAddress(transaction.to, config.feeManager)) {
+    const calls = transaction.calls ?? [{ data: transaction.input, to: transaction.to }];
+    const feeManagerCalls = calls.filter((call) => sameAddress(call.to, config.feeManager));
+    if (feeManagerCalls.length === 0) {
       throw new Error("reported transaction did not call the Fee Manager");
     }
-    try {
-      const call = decodeFunctionData({ abi: FEE_MANAGER, data: transaction.input });
-      if (call.functionName !== "setUserToken" || !sameAddress(call.args[0], config.feeToken)) {
-        throw new Error();
+
+    const requestedExpectedToken = feeManagerCalls.some((call) => {
+      try {
+        const decoded = decodeFunctionData({ abi: FEE_MANAGER, data: call.data });
+        return (
+          decoded.functionName === "setUserToken" &&
+          sameAddress(decoded.args[0], config.feeToken)
+        );
+      } catch {
+        return false;
       }
-    } catch {
+    });
+    if (!requestedExpectedToken) {
       throw new Error("reported transaction did not request the expected fee token");
     }
 

--- a/shared/tempo/verifier/test/set-fee-token.test.js
+++ b/shared/tempo/verifier/test/set-fee-token.test.js
@@ -14,9 +14,14 @@ const otherToken = "0x4444444444444444444444444444444444444444";
 const transactionHash = `0x${"01".repeat(32)}`;
 const feeManagerAbi = parseAbi(["function setUserToken(address token)"]);
 
-function fixture(token = feeToken) {
+function fixture({ tempo = false, token = feeToken } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tempo-verifier-"));
   const resultPath = path.join(dir, "out.json");
+  const data = encodeFunctionData({
+    abi: feeManagerAbi,
+    functionName: "setUserToken",
+    args: [token],
+  });
   fs.writeFileSync(
     resultPath,
     JSON.stringify({
@@ -26,10 +31,14 @@ function fixture(token = feeToken) {
   );
   return {
     client: {
-      getTransaction: async () => ({
-        input: encodeFunctionData({ abi: feeManagerAbi, functionName: "setUserToken", args: [token] }),
-        to: feeManager,
-      }),
+      getTransaction: async () =>
+        tempo
+          ? {
+              calls: [{ data, to: feeManager, value: 0n }],
+              type: "tempo",
+              typeHex: "0x76",
+            }
+          : { input: data, to: feeManager },
       getTransactionReceipt: async () => ({
         blockNumber: 2n,
         from: payer,
@@ -42,7 +51,7 @@ function fixture(token = feeToken) {
   };
 }
 
-test("accepts a successful idempotent fee-token call without an event", async () => {
+test("accepts a legacy fee-token call", async () => {
   const evidence = await verify(fixture());
 
   assert.equal(evidence.payer, payer);
@@ -50,6 +59,17 @@ test("accepts a successful idempotent fee-token call without an event", async ()
   assert.equal(evidence.transactionHash, transactionHash);
 });
 
-test("rejects a fee-token call with the wrong token", async () => {
-  await assert.rejects(verify(fixture(otherToken)), /did not request the expected fee token/);
+test("accepts a Tempo fee-token call", async () => {
+  const evidence = await verify(fixture({ tempo: true }));
+
+  assert.equal(evidence.payer, payer);
+  assert.equal(evidence.token, feeToken);
+  assert.equal(evidence.transactionHash, transactionHash);
+});
+
+test("rejects a Tempo fee-token call with the wrong token", async () => {
+  await assert.rejects(
+    verify(fixture({ tempo: true, token: otherToken })),
+    /did not request the expected fee token/,
+  );
 });


### PR DESCRIPTION
## Summary

- recognize Viem-normalized Tempo `0x76` transactions whose Fee Manager call is stored in `calls[]`
- keep compatibility with legacy top-level `to` / `input` transactions
- continue requiring both `setUserToken(configuredToken)` and the matching final onchain state
- add focused coverage for valid and wrong-token Tempo envelopes

## Why

The verifier assumed an Ethereum-style top-level call. Valid Tempo transactions expose the Fee Manager call as `calls[{ to, data }]`, so a correct solution could be rejected.

## Validation

- focused set-fee-token tests: 3/3
- full Tempo verifier suite: 16/16
- `npm run check`
- `npm run check:generated`
- `git diff --check`