### PR TITLE
Use live Tempo docs MCP for the MCP profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Harbor terms used throughout this repository:
 - **Trial and job** — a trial is one agent attempt at a task producing a
   reward; a job is a batch of trials. Jobs here are compiled from `config/`
   into `config/generated/` rather than written by hand.
-- **Access profile** — run-time injection of pinned documentation alone or
-  pinned documentation plus MCP access into a job, configured in
+- **Access profile** — run-time injection of either the pinned documentation
+  website or the live Tempo docs MCP into a job, configured in
   `config/tasks.yaml`, so the same task artifact can be evaluated under
   different capabilities.
 
@@ -97,10 +97,10 @@ Three shared layers keep the suites consistent:
 - **One base image.** Every task environment extends the base image configured
   in `config/tasks.yaml`, which bundles the RewardKit environment and the
   shared Tempo verifier.
-- **Injected access profiles.** Benchmark jobs grant pinned documentation
-  alone or pinned documentation plus MCP access at run time instead of baking
-  it into task source, so the same task artifact can be evaluated under
-  different profiles. Profiles are configured centrally in
+- **Injected access profiles.** Benchmark jobs grant either the pinned
+  documentation website or the live Tempo docs MCP at run time instead of
+  baking access into task source, so the same task artifact can be evaluated
+  under different profiles. Profiles are configured centrally in
   `config/tasks.yaml`; see the suite guides for profile-specific behavior.
 - **Immutable benchmark majors.** A dataset version fixes its task set,
   prompts, verifier behavior, and scoring. Changes that make results
@@ -151,7 +151,7 @@ npm run bench:matrix:dev -- \
 npm run bench:matrix:dev -- \
   --task-suite tempo --profile docs --base-image "$BASE_IMAGE"
 
-# Haiku, one attempt, all Tempo tasks, pinned Docs plus Tempo MCP.
+# Haiku, one attempt, all Tempo tasks, live Tempo docs MCP only.
 npm run bench:matrix:dev -- \
   --task-suite tempo --profile mcp --base-image "$BASE_IMAGE"
 
@@ -163,18 +163,19 @@ npm run bench:matrix:production -- \
 npm run bench:matrix:production -- \
   --task-suite tempo --profile docs --base-image "$BASE_IMAGE"
 
-# All production models, three attempts, pinned Docs plus Tempo MCP.
+# All production models, three attempts, live Tempo docs MCP only.
 npm run bench:matrix:production -- \
   --task-suite tempo --profile mcp --base-image "$BASE_IMAGE"
 ```
 
 `bench:matrix:dev` reads `config/models.dev.yaml`; the production command reads
 `config/models.production.yaml`. Both commands include every matching task
-unless `--task-filter` is provided. The `docs` profile provides pinned Docs;
-the `mcp` profile provides the same pinned Docs plus the Tempo MCP server.
+unless `--task-filter` is provided. The `docs` profile provides the pinned
+website. The `mcp` profile provides the live Tempo docs MCP server at
+`https://mcp.tempo.xyz/` and does not stage the pinned website.
 
 `--concurrency` is the concurrent-trial limit for each profile job, not a
-combined limit. `--profile all` runs the Docs and Docs-plus-MCP jobs in
+combined limit. `--profile all` runs the Docs and MCP jobs in
 parallel, so `--concurrency 32` permits up to 32 trials in each job, or 64
 across the pair. The model configs cap agent phases at 16 per provider and
 profile; `--agent-concurrency` overrides those caps.

--- a/config/tasks.yaml
+++ b/config/tasks.yaml
@@ -10,15 +10,14 @@
 base_image: ghcr.io/tempoxyz/tempo-bench-base:v1
 
 # Run-time access profiles. Tempo tasks are authored directly; benchmark jobs
-# inject the MCP server for the MCP profile. A pinned docs SHA transparently
-# routes docs.tempo.xyz to the staged bundle at run time.
+# either route docs.tempo.xyz to the pinned bundle or inject the live docs MCP.
 profiles:
   - id: docs
   - id: mcp
     mcp_servers:
       - name: tempo
         transport: streamable-http
-        url: https://api.tempo.xyz/mcp
+        url: https://mcp.tempo.xyz/
   - id: mcp-direct
     mcp_servers:
       - name: tempo-direct

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -256,6 +256,10 @@ def uses_live_mcp_eval(options: dict[str, Any]) -> bool:
     return options.get("task_suite") == "tempo-mcp"
 
 
+def docs_source_label(source: dict[str, str]) -> str:
+    return source.get("sha", source["mode"])
+
+
 def ensure_docs_bundle(source: dict[str, str]) -> str | None:
     if source["mode"] == "public":
         return None
@@ -266,6 +270,18 @@ def ensure_docs_bundle(source: dict[str, str]) -> str | None:
         msg = f"Pinned Tempo docs bundle was not created at {bundle_path}"
         raise RuntimeError(msg)
     return str(bundle_path)
+
+
+def prepare_docs_access(
+    options: dict[str, Any],
+) -> tuple[dict[str, str], str | None]:
+    source = (
+        {"mode": "live"}
+        if uses_live_mcp_eval(options) or options.get("profile") == MCP_PROFILE["id"]
+        else docs_source(options)
+    )
+    bundle = None if source["mode"] == "live" else ensure_docs_bundle(source)
+    return source, bundle
 
 
 def preflight(variant: dict[str, Any], options: dict[str, Any]) -> None:
@@ -597,7 +613,7 @@ def run_production_variant(
         "n_attempts": job["n_attempts"],
         "n_concurrent_trials": str(job["n_concurrent_trials"]),
         "max_retries": max_retries,
-        "docs_source": source.get("sha", "public"),
+        "docs_source": docs_source_label(source),
         "docs_bundle": docs_bundle,
         "profile": options["profile"],
         "git_sha": run_output("git", ["rev-parse", "HEAD"]),
@@ -640,9 +656,7 @@ def prepare_production_profiles(
     preflight_production_agents(model_config)
     if options.get("sync"):
         sync_dataset(options)
-    source = {"mode": "live"} if uses_live_mcp_eval(options) else docs_source(options)
-    if source["mode"] != "live":
-        ensure_docs_bundle(source)
+    prepare_docs_access(options)
 
 
 def mpp_task_filter(task_filter: str) -> str | None:
@@ -1123,7 +1137,6 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
             "The MCP profile requires a job-backed or production benchmark variant."
         )
 
-    source = {"mode": "live"} if uses_live_mcp_eval(options) else docs_source(options)
     load_env_file(options.get("env_file"))
     preflight(variant, options)
     preflight_mcp_target(options)
@@ -1131,7 +1144,7 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
         sync_dataset(options)
     if not variant.get("needs_daytona_auth"):
         build_base_image()
-    docs_bundle = None if source["mode"] == "live" else ensure_docs_bundle(source)
+    source, docs_bundle = prepare_docs_access(options)
 
     benchmark = run_benchmark_key(variant, options.get("task_suite"))
     default_run_name = versioned_name(benchmark, variant["prefix"])

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -11,16 +11,17 @@ from unittest.mock import patch
 from scripts.run_benchmark import (
     MCP_CODE_PROFILE,
     MCP_DIRECT_PROFILE,
-    MCP_PROFILE,
     BenchmarkKey,
     apply_pair_id,
     apply_profile,
     benchmark_provenance,
     daytona_base_image,
+    docs_source_label,
     finalize_config,
     main,
     parse_args,
     parse_model_config,
+    prepare_docs_access,
     prepare_production_profiles,
     production_job,
     run_benchmark_key,
@@ -67,6 +68,27 @@ class RunBenchmarkTest(unittest.TestCase):
         self.assertTrue(uses_live_mcp_eval({"task_suite": "tempo-mcp"}))
         self.assertFalse(uses_live_mcp_eval({"task_suite": "tempo"}))
 
+    def test_tempo_profiles_prepare_distinct_docs_access(self) -> None:
+        pinned = {"mode": "pinned", "repo": "tempo/docs", "sha": "docs123"}
+        with (
+            patch("scripts.run_benchmark.docs_source", return_value=pinned),
+            patch(
+                "scripts.run_benchmark.ensure_docs_bundle", return_value="docs-bundle"
+            ) as ensure_bundle,
+        ):
+            self.assertEqual(
+                prepare_docs_access({"task_suite": "tempo", "profile": "docs"}),
+                (pinned, "docs-bundle"),
+            )
+            self.assertEqual(
+                prepare_docs_access({"task_suite": "tempo", "profile": "mcp"}),
+                ({"mode": "live"}, None),
+            )
+
+        ensure_bundle.assert_called_once_with(pinned)
+        self.assertEqual(docs_source_label(pinned), "docs123")
+        self.assertEqual(docs_source_label({"mode": "live"}), "live")
+
     def test_live_mcp_eval_skips_pinned_docs_preparation(self) -> None:
         options = {
             "profile": "mcp-direct",
@@ -102,14 +124,18 @@ class RunBenchmarkTest(unittest.TestCase):
             patch("scripts.run_benchmark.load_env_file"),
             patch("scripts.run_benchmark.preflight"),
             patch("scripts.run_benchmark.preflight_mcp_target"),
-            patch("scripts.run_benchmark.docs_source", return_value={"mode": "public"}),
-            patch("scripts.run_benchmark.ensure_docs_bundle", return_value=None),
+            patch("scripts.run_benchmark.docs_source") as docs_source,
+            patch("scripts.run_benchmark.ensure_docs_bundle") as ensure_bundle,
             patch("scripts.run_benchmark.run_production_variant") as run_production,
             patch("scripts.run_benchmark.run") as run,
         ):
             run_benchmark_variant("production-daytona", options)
 
-        run_production.assert_called_once()
+        docs_source.assert_not_called()
+        ensure_bundle.assert_not_called()
+        run_production.assert_called_once_with(
+            "production-mcp-test", options, {"mode": "live"}, None
+        )
         run.assert_not_called()
 
     def test_production_all_profile_runs_docs_and_mcp_jobs(self) -> None:
@@ -171,6 +197,7 @@ class RunBenchmarkTest(unittest.TestCase):
             "agent_concurrency": None,
             "env_file": None,
             "models_config": "config/models.dev.yaml",
+            "profile": "all",
             "sync": True,
             "task_suite": "tempo",
         }
@@ -278,13 +305,29 @@ class RunBenchmarkTest(unittest.TestCase):
         )
 
     def test_mcp_profile_is_injected_at_job_level(self) -> None:
-        config = {"agents": [{"name": "claude-code"}, {"name": "oracle"}]}
+        config = {
+            "agents": [
+                {"name": "claude-code"},
+                {"name": "codex"},
+                {"name": "oracle"},
+            ]
+        }
+
+        agents = apply_profile(config, "mcp")["agents"]
+        expected_server = [
+            {
+                "name": "tempo",
+                "transport": "streamable-http",
+                "url": "https://mcp.tempo.xyz/",
+            }
+        ]
 
         self.assertEqual(
-            apply_profile(config, "mcp")["agents"],
+            [(agent["name"], agent.get("mcp_servers")) for agent in agents],
             [
-                {"name": "claude-code", "mcp_servers": MCP_PROFILE["mcp_servers"]},
-                {"name": "oracle"},
+                ("claude-code", expected_server),
+                ("codex", expected_server),
+                ("oracle", None),
             ],
         )
 

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -14,8 +14,8 @@ that performs a variety of operations on the Tempo blockchain.
 - Reading task-specific configuration from the environment and producing the
   required output artifact.
 - Submitting valid transactions whose onchain effects match the task contract.
-- Working effectively with pinned documentation, with or without the Tempo MCP
-  server.
+- Working effectively with either the pinned documentation website or the live
+  Tempo docs MCP server.
 
 Current tasks cover access-key authorization, batched, memo, and
 receive-policy-held transfers, fee payment, stablecoin and transfer-policy
@@ -46,7 +46,8 @@ primary reward.
 The benchmark job injects access rather than changing task source:
 
 - `docs` serves the revision pinned in `config/tempo-docs.lock.json`.
-- `mcp` serves the same pinned revision and also adds the Tempo API MCP server.
+- `mcp` adds the live Tempo docs MCP server at `https://mcp.tempo.xyz/` and does
+  not stage the pinned website.
 
 Use `--profile all` to launch paired Docs and MCP jobs. Use `--profile docs` or
 `--profile mcp` when only one access profile is needed; each profile remains an
@@ -84,7 +85,7 @@ npm run bench:matrix:dev -- --task-suite tempo --profile all \
 npm run bench:matrix:dev -- --task-suite tempo --profile docs \
   --task-filter transfer-with-memo --base-image "$BASE_IMAGE"
 
-# One-task Haiku smoke with pinned Docs plus Tempo MCP.
+# One-task Haiku smoke with the live Tempo docs MCP only.
 npm run bench:matrix:dev -- --task-suite tempo --profile mcp \
   --task-filter transfer-with-memo --base-image "$BASE_IMAGE"
 


### PR DESCRIPTION
## Summary

- make the Tempo v1 `docs` and `mcp` cohorts use distinct documentation access
- keep the pinned website only for `docs`
- inject the live docs MCP at `https://mcp.tempo.xyz/` only for `mcp`
- record the MCP cohort's documentation source as live
- update the runner coverage and profile documentation

## Why

The current `mcp` profile points at the broader Tempo API MCP and also stages the pinned docs website. The Tempo v1 comparison is intended to be pinned web docs versus the live Tempo docs MCP.

## Validation

- live endpoint exposes `search`, `find_pages`, `read_page`, and `code`
- focused runner tests: 24/24
- `npm run check`
- `npm run check:generated`
- `git diff --check`