### PR TITLE
Verify Stablecoin DEX swap calldata

### DIFF
--- a/shared/tempo/verifier/src/cases/stablecoin-dex-swap.js
+++ b/shared/tempo/verifier/src/cases/stablecoin-dex-swap.js
@@ -1,4 +1,4 @@
-const { parseAbiItem, parseUnits } = require("viem");
+const { decodeFunctionData, parseAbi, parseAbiItem, parseUnits } = require("viem");
 const { expectAddress, expectHash, expectObject, readResult } = require("../result");
 const { defaultRuntimeEnv } = require("../submission");
 const { findEvent, receiptAfter, sameAddress, waitForEvidence } = require("../tempo");
@@ -6,6 +6,9 @@ const { findEvent, receiptAfter, sameAddress, waitForEvidence } = require("../te
 const ORDER_FILLED = parseAbiItem(
   "event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)",
 );
+const SWAP = parseAbi([
+  "function swapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn, uint128 minAmountOut) returns (uint128 amountOut)",
+]);
 const TRANSFER = parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)");
 
 function result(config) {
@@ -45,13 +48,34 @@ async function verify({ client, config, fromBlock }) {
     );
     if (!receipt) return null;
 
+    const transaction = await client.getTransaction({ hash: transactionHash });
+    const calls = transaction.calls ?? [{ data: transaction.input, to: transaction.to }];
+    const requestedSwap = calls.some((call) => {
+      if (!sameAddress(call.to, config.stablecoinDex)) return false;
+      try {
+        const decoded = decodeFunctionData({ abi: SWAP, data: call.data });
+        return (
+          decoded.functionName === "swapExactAmountIn" &&
+          sameAddress(decoded.args[0], config.swapTokenIn) &&
+          sameAddress(decoded.args[1], config.swapTokenOut) &&
+          decoded.args[2] === amount &&
+          decoded.args[3] >= minimumAmountOut
+        );
+      } catch {
+        return false;
+      }
+    });
+    if (!requestedSwap) throw new Error("reported transaction does not request the configured swap");
+
     const fill = findEvent(receipt, config.stablecoinDex, ORDER_FILLED, (args) =>
-      sameAddress(args.taker, taker),
+      sameAddress(args.taker, taker) && args.amountFilled > 0n,
     );
     if (!fill) throw new Error("reported transaction does not fill a DEX order");
 
     const spent = findEvent(receipt, config.swapTokenIn, TRANSFER, (args) =>
-      sameAddress(args.from, taker) && args.value === amount,
+      sameAddress(args.from, taker) &&
+      sameAddress(args.to, config.stablecoinDex) &&
+      args.value === amount,
     );
     if (!spent) throw new Error("reported transaction does not spend the requested swap input");
 

--- a/shared/tempo/verifier/test/stablecoin-dex-swap.test.js
+++ b/shared/tempo/verifier/test/stablecoin-dex-swap.test.js
@@ -3,22 +3,26 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
-const { parseUnits } = require("viem");
+const { encodeFunctionData, parseAbi, parseUnits } = require("viem");
 
 const taker = "0x1111111111111111111111111111111111111111";
 const dex = "0x2222222222222222222222222222222222222222";
 const tokenIn = "0x3333333333333333333333333333333333333333";
 const tokenOut = "0x4444444444444444444444444444444444444444";
+const unrelated = "0x5555555555555555555555555555555555555555";
 const transactionHash = `0x${"01".repeat(32)}`;
 const amountIn = parseUnits("100", 6);
+const swapAbi = parseAbi([
+  "function swapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn, uint128 minAmountOut) returns (uint128 amountOut)",
+]);
 
 const tempoPath = require.resolve("../src/tempo");
 require.cache[tempoPath] = {
   exports: {
     findEvent(receipt, address, _event, matches) {
       const args = {
-        [dex]: { orderId: 1n, taker },
-        [tokenIn]: { from: taker, to: dex, value: amountIn },
+        [dex]: { amountFilled: receipt.amountFilled, orderId: 1n, taker },
+        [tokenIn]: { from: taker, to: receipt.inputRecipient, value: amountIn },
         [tokenOut]: { from: dex, to: taker, value: receipt.amountOut },
       }[address];
       return matches(args) ? { args } : null;
@@ -31,15 +35,29 @@ require.cache[tempoPath] = {
 delete require.cache[require.resolve("../src/cases/stablecoin-dex-swap")];
 const { verify } = require("../src/cases/stablecoin-dex-swap");
 
-function fixture({ amountOut, minimumAmountOut }) {
+function fixture({
+  amountFilled = amountIn,
+  amountOut,
+  inputRecipient = dex,
+  minimumAmountOut,
+  swapAmountIn = amountIn,
+}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tempo-verifier-"));
   const resultPath = path.join(dir, "out.json");
+  const data = encodeFunctionData({
+    abi: swapAbi,
+    functionName: "swapExactAmountIn",
+    args: [tokenIn, tokenOut, swapAmountIn, parseUnits(minimumAmountOut, 6)],
+  });
   fs.writeFileSync(
     resultPath,
     JSON.stringify({ taker: { address: taker }, swapTransactionHash: transactionHash }),
   );
   return {
-    client: { receipt: { amountOut, blockNumber: 2n } },
+    client: {
+      getTransaction: async () => ({ calls: [{ data, to: dex }] }),
+      receipt: { amountFilled, amountOut, blockNumber: 2n, inputRecipient },
+    },
     config: {
       decimals: 6,
       resultPath,
@@ -71,5 +89,25 @@ test("rejects zero swap output when the configured minimum is zero", async () =>
   await assert.rejects(
     verify(fixture({ amountOut: 0n, minimumAmountOut: "0" })),
     /does not receive the requested swap output/,
+  );
+});
+
+test("rejects an exact input transfer sent outside the DEX", async () => {
+  await assert.rejects(
+    verify(fixture({ amountOut: amountIn, inputRecipient: unrelated, minimumAmountOut: "0" })),
+    /does not spend the requested swap input/,
+  );
+});
+
+test("rejects a smaller swap call paired with an unrelated exact input transfer", async () => {
+  await assert.rejects(
+    verify(fixture({
+      amountFilled: 1n,
+      amountOut: 1n,
+      inputRecipient: unrelated,
+      minimumAmountOut: "0",
+      swapAmountIn: 1n,
+    })),
+    /does not request the configured swap/,
   );
 });


### PR DESCRIPTION
## Summary

- validate the reported `swapExactAmountIn` call against the configured DEX, token pair, exact input, and minimum output
- require a positive fill and require the exact input transfer to terminate at the DEX
- add regressions for redirected input and unrelated-transfer/tiny-fill false positives

## Why

The verifier previously matched independent receipt events without tying them to the requested swap call, so unrelated activity in the same transaction could satisfy the checks.

## Validation

- `npm run check`
- Stablecoin DEX oracle: correctness `1.0`