### PR TITLE
Verify final stablecoin policy state

### DIFF
--- a/shared/tempo/verifier/src/cases/create-stablecoin-with-policy.js
+++ b/shared/tempo/verifier/src/cases/create-stablecoin-with-policy.js
@@ -1,4 +1,5 @@
 const { parseAbiItem } = require("viem");
+const { Abis } = require("viem/tempo");
 const {
   expectAddress,
   expectHash,
@@ -137,6 +138,28 @@ async function verify({ client, config, fromBlock }) {
       sameAddress(args.updater, output.payer) && args.newPolicyId.toString() === output.policyId,
     );
     if (!link) throw new Error("reported policy-link transaction does not link the output policy");
+
+    const linkedPolicyId = await client.readContract({
+      address: output.stablecoin.address,
+      abi: Abis.tip20,
+      functionName: "transferPolicyId",
+    });
+    if (linkedPolicyId.toString() !== output.policyId) {
+      throw new Error("output stablecoin is not currently linked to the output policy");
+    }
+
+    const accountAuthorized = await client.readContract({
+      address: config.tip403Registry,
+      abi: Abis.tip403Registry,
+      functionName: "isAuthorized",
+      args: [BigInt(output.policyId), config.policyAccount],
+    });
+    const expectedAuthorized = config.policyType === "whitelist";
+    if (accountAuthorized !== expectedAuthorized) {
+      throw new Error(
+        `required account is not currently ${expectedAuthorized ? "allowed" : "restricted"} by the output policy`,
+      );
+    }
 
     return {
       blockNumber: linkReceipt.blockNumber.toString(),

--- a/shared/tempo/verifier/test/create-stablecoin-with-policy.test.js
+++ b/shared/tempo/verifier/test/create-stablecoin-with-policy.test.js
@@ -8,56 +8,109 @@ const payer = "0x1111111111111111111111111111111111111111";
 const token = "0x2222222222222222222222222222222222222222";
 const salt = `0x${"01".repeat(32)}`;
 const hash = (digit) => `0x${digit.repeat(64)}`;
+const output = {
+  payer: { address: payer },
+  stablecoin: { address: token, name: "Agent Dollar", symbol: "AGD", salt },
+  policy: { id: "1" },
+  tokenCreateTransactionHash: hash("1"),
+  policyCreateTransactionHash: hash("2"),
+  policyAccountTransactionHash: hash("3"),
+  linkPolicyTransactionHash: hash("4"),
+};
 
-test("rejects a stablecoin with the wrong configured currency", async () => {
-  const tempoPath = require.resolve("../src/tempo");
-  require.cache[tempoPath] = {
-    exports: {
-      findEvent(_receipt, _address, event, matches) {
-        const args = {
-          TokenCreated: { token, name: "Agent Dollar", symbol: "AGD", currency: "EUR", admin: payer, salt },
-          PolicyCreated: { policyId: 1n, updater: payer, policyType: 1 },
-          BlacklistUpdated: { policyId: 1n, updater: payer, account: payer, restricted: true },
-          TransferPolicyUpdate: { updater: payer, newPolicyId: 1n },
-        }[event.name];
-        return matches(args) ? { args } : null;
-      },
-      receiptAfter: async () => ({ blockNumber: 2n }),
-      sameAddress: (left, right) => left.toLowerCase() === right.toLowerCase(),
-      waitForEvidence: async (_config, check) => check(),
+const tempoPath = require.resolve("../src/tempo");
+require.cache[tempoPath] = {
+  exports: {
+    findEvent(receipt, _address, event, matches) {
+      const args = {
+        TokenCreated: {
+          token,
+          name: "Agent Dollar",
+          symbol: "AGD",
+          currency: receipt.currency,
+          admin: payer,
+          salt,
+        },
+        PolicyCreated: {
+          policyId: 1n,
+          updater: payer,
+          policyType: receipt.policyType === "whitelist" ? 0 : 1,
+        },
+        BlacklistUpdated: { policyId: 1n, updater: payer, account: payer, restricted: true },
+        WhitelistUpdated: { policyId: 1n, updater: payer, account: payer, allowed: true },
+        TransferPolicyUpdate: { updater: payer, newPolicyId: 1n },
+      }[event.name];
+      return matches(args) ? { args } : null;
     },
-  };
-  delete require.cache[require.resolve("../src/cases/create-stablecoin-with-policy")];
-  const { verify } = require("../src/cases/create-stablecoin-with-policy");
+    receiptAfter: async (client) => ({
+      blockNumber: 2n,
+      currency: client.currency,
+      policyType: client.policyType,
+    }),
+    sameAddress: (left, right) => left.toLowerCase() === right.toLowerCase(),
+    waitForEvidence: async (_config, check) => check(),
+  },
+};
+const { verify } = require("../src/cases/create-stablecoin-with-policy");
 
+function fixture({
+  accountAuthorized,
+  currency = "USD",
+  linkedPolicyId = 1n,
+  policyType = "blacklist",
+} = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tempo-verifier-"));
   const resultPath = path.join(dir, "out.json");
-  fs.writeFileSync(
-    resultPath,
-    JSON.stringify({
-      payer: { address: payer },
-      stablecoin: { address: token, name: "Agent Dollar", symbol: "AGD", salt },
-      policy: { id: "1" },
-      tokenCreateTransactionHash: hash("1"),
-      policyCreateTransactionHash: hash("2"),
-      policyAccountTransactionHash: hash("3"),
-      linkPolicyTransactionHash: hash("4"),
-    }),
-  );
+  fs.writeFileSync(resultPath, JSON.stringify(output));
 
-  await assert.rejects(
-    verify({
-      client: {},
-      config: {
-        resultPath,
-        stablecoinCurrency: "USD",
-        policyType: "blacklist",
-        policyAccount: payer,
-        tip20Factory: payer,
-        tip403Registry: payer,
+  return {
+    client: {
+      currency,
+      policyType,
+      readContract: async ({ functionName }) => {
+        if (functionName === "transferPolicyId") return linkedPolicyId;
+        if (functionName === "isAuthorized") {
+          return accountAuthorized ?? policyType === "whitelist";
+        }
+        throw new Error(`unexpected contract read: ${functionName}`);
       },
-      fromBlock: 1n,
-    }),
+    },
+    config: {
+      resultPath,
+      stablecoinCurrency: "USD",
+      policyType,
+      policyAccount: payer,
+      tip20Factory: payer,
+      tip403Registry: payer,
+    },
+    fromBlock: 1n,
+  };
+}
+
+test("rejects a stablecoin with the wrong configured currency", async () => {
+  await assert.rejects(
+    verify(fixture({ currency: "EUR" })),
     /does not create the output stablecoin/,
+  );
+});
+
+test("rejects a policy that was linked and then unlinked", async () => {
+  await assert.rejects(
+    verify(fixture({ linkedPolicyId: 0n })),
+    /stablecoin is not currently linked to the output policy/,
+  );
+});
+
+test("rejects a blacklist account that was restricted and then unrestricted", async () => {
+  await assert.rejects(
+    verify(fixture({ accountAuthorized: true })),
+    /account is not currently restricted by the output policy/,
+  );
+});
+
+test("rejects a whitelist account that was allowed and then removed", async () => {
+  await assert.rejects(
+    verify(fixture({ accountAuthorized: false, policyType: "whitelist" })),
+    /account is not currently allowed by the output policy/,
   );
 });


### PR DESCRIPTION
## Summary

- verify the token's current `transferPolicyId` after matching the policy-link event
- verify the policy account's current TIP-403 authorization state for both blacklist and whitelist policies
- add regressions for linked-then-unlinked and account-state reversals

## Why

Historical events alone could pass after the required policy link or account restriction had been undone.

## Validation

- `npm run check`
- Create-stablecoin-with-policy oracle: correctness `1.0`