### PR TITLE
Proxy Tempo API routes from pinned docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "results:export": "uv run python scripts/export_results.py",
     "results:compare": "uv run python scripts/compare_mcp_results.py",
     "harbor:view": "uv run harbor view jobs",
-    "check": "npm run check:scripts && npm run test:results && npm run test:tempo-verifier && npm run test:mcp-bridge && npm run check:shell && npm run task:lint && npm run check:docs && npm run check:format && npm run check:lint",
+    "check": "npm run check:scripts && npm run test:results && npm run test:tempo-verifier && npm run test:mcp-bridge && npm run test:tempo-docs && npm run check:shell && npm run task:lint && npm run check:docs && npm run check:format && npm run check:lint",
     "check:dataset": "uv run python scripts/run_benchmark.py check-dataset",
     "check:docs": "npm run docs:prepare && npm run docs:check",
     "check:generated": "uv run python scripts/run_benchmark.py check-generated",
@@ -43,6 +43,7 @@
     "check:scripts": "uv run python -m compileall -q scripts",
     "test:results": "uv run python -m unittest discover -s scripts -p '*_test.py'",
     "test:mcp-bridge": "node --test shared/tempo/mcp-bridge/server.test.mjs",
+    "test:tempo-docs": "node --test shared/tempo/docs/tempo-docs/server.test.mjs",
     "test:tempo-verifier": "npm ci --ignore-scripts --no-audit --no-fund --prefix shared/tempo/verifier && npm test --prefix shared/tempo/verifier",
     "clean": "uv run python scripts/run_benchmark.py clean",
     "clean:jobs": "uv run python scripts/run_benchmark.py clean-jobs"

--- a/shared/tempo/docs/tempo-docs/server.mjs
+++ b/shared/tempo/docs/tempo-docs/server.mjs
@@ -6,8 +6,8 @@ import {
   readFileSync,
   statSync,
 } from "node:fs";
-import { createServer as createHttpServer } from "node:http";
-import { createServer as createHttpsServer } from "node:https";
+import { createServer as createHttpServer, request as createHttpRequest } from "node:http";
+import { createServer as createHttpsServer, request as createHttpsRequest } from "node:https";
 import path from "node:path";
 
 const port = Number(process.env.PORT ?? "3000");
@@ -16,6 +16,18 @@ const docsRoot = path.resolve(process.env.TEMPO_DOCS_ROOT ?? "/tempo-docs");
 const tlsCertFile = process.env.TLS_CERT_FILE ?? "/tls/docs.crt";
 const tlsKeyFile = process.env.TLS_KEY_FILE ?? "/tls/docs.key";
 const accessLogPath = process.env.ACCESS_LOG_PATH ?? "/var/log/tempo-docs/access.log";
+const apiUpstreamOrigin = process.env.TEMPO_API_UPSTREAM_ORIGIN ?? "https://developers.tempo.xyz";
+const apiPrefix = "/developers/api/";
+const hopByHopHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
 
 const contentTypes = new Map([
   [".html", "text/html; charset=utf-8"],
@@ -95,10 +107,55 @@ function logRequest(request, url) {
   );
 }
 
+function proxyHeaders(headers, { omitHost = false } = {}) {
+  const forwarded = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (hopByHopHeaders.has(name) || (omitHost && name === "host") || value === undefined) continue;
+    forwarded[name] = value;
+  }
+  return forwarded;
+}
+
+export function apiUpstreamUrl(url) {
+  const upstreamPath = url.pathname.slice("/developers".length);
+  return new URL(`${upstreamPath}${url.search}`, `${apiUpstreamOrigin}/`);
+}
+
+export function proxyApiRequest(request, response, url) {
+  const upstreamUrl = apiUpstreamUrl(url);
+  const send = upstreamUrl.protocol === "https:" ? createHttpsRequest : createHttpRequest;
+  const upstreamRequest = send(
+    upstreamUrl,
+    {
+      method: request.method,
+      headers: proxyHeaders(request.headers, { omitHost: true }),
+    },
+    (upstreamResponse) => {
+      response.writeHead(
+        upstreamResponse.statusCode ?? 502,
+        proxyHeaders(upstreamResponse.headers),
+      );
+      upstreamResponse.on("error", (error) => response.destroy(error));
+      upstreamResponse.pipe(response);
+    },
+  );
+  upstreamRequest.on("error", (error) => {
+    console.error("Tempo API proxy error:", error);
+    if (response.headersSent) {
+      response.destroy(error);
+      return;
+    }
+    response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    response.end("Tempo API upstream unavailable\n");
+  });
+  request.on("aborted", () => upstreamRequest.destroy());
+  request.pipe(upstreamRequest);
+}
+
 mkdirSync(path.dirname(accessLogPath), { recursive: true });
 appendFileSync(accessLogPath, "");
 
-function serveDocs(request, response) {
+export function serveDocs(request, response) {
   const url = new URL(request.url ?? "/", "https://docs.tempo.xyz");
 
   if (url.pathname === "/health") {
@@ -113,6 +170,11 @@ function serveDocs(request, response) {
   }
 
   logRequest(request, url);
+
+  if (url.pathname.startsWith(apiPrefix)) {
+    proxyApiRequest(request, response, url);
+    return;
+  }
 
   if (request.method !== "GET" && request.method !== "HEAD") {
     response.writeHead(405, { "content-type": "text/plain; charset=utf-8" });
@@ -136,33 +198,35 @@ function serveDocs(request, response) {
   createReadStream(filePath).pipe(response);
 }
 
-const httpServer = createHttpServer((request, response) => {
-  if (new URL(request.url ?? "/", "http://docs.tempo.xyz").pathname === "/health") {
-    serveDocs(request, response);
-    return;
-  }
-  const host = (request.headers.host ?? "docs.tempo.xyz").replace(/:80$/, "");
-  response.writeHead(308, { location: `https://${host}${request.url ?? "/"}` });
-  response.end();
-});
+if (process.env.NODE_ENV !== "test") {
+  const httpServer = createHttpServer((request, response) => {
+    if (new URL(request.url ?? "/", "http://docs.tempo.xyz").pathname === "/health") {
+      serveDocs(request, response);
+      return;
+    }
+    const host = (request.headers.host ?? "docs.tempo.xyz").replace(/:80$/, "");
+    response.writeHead(308, { location: `https://${host}${request.url ?? "/"}` });
+    response.end();
+  });
 
-const httpsServer = createHttpsServer(
-  { cert: readFileSync(tlsCertFile), key: readFileSync(tlsKeyFile) },
-  serveDocs,
-);
+  const httpsServer = createHttpsServer(
+    { cert: readFileSync(tlsCertFile), key: readFileSync(tlsKeyFile) },
+    serveDocs,
+  );
 
-httpServer.listen(port, (error) => {
-  if (error) {
-    console.error("Failed to start Tempo docs HTTP server:", error);
-    process.exit(1);
-  }
-  console.log(`Tempo docs HTTP server serving ${docsRoot} on port ${port}`);
-});
+  httpServer.listen(port, (error) => {
+    if (error) {
+      console.error("Failed to start Tempo docs HTTP server:", error);
+      process.exit(1);
+    }
+    console.log(`Tempo docs HTTP server serving ${docsRoot} on port ${port}`);
+  });
 
-httpsServer.listen(httpsPort, (error) => {
-  if (error) {
-    console.error("Failed to start Tempo docs HTTPS server:", error);
-    process.exit(1);
-  }
-  console.log(`Tempo docs HTTPS server serving ${docsRoot} on port ${httpsPort}`);
-});
+  httpsServer.listen(httpsPort, (error) => {
+    if (error) {
+      console.error("Failed to start Tempo docs HTTPS server:", error);
+      process.exit(1);
+    }
+    console.log(`Tempo docs HTTPS server serving ${docsRoot} on port ${httpsPort}`);
+  });
+}

--- a/shared/tempo/docs/tempo-docs/server.test.mjs
+++ b/shared/tempo/docs/tempo-docs/server.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = mkdtempSync(path.join(tmpdir(), "tempo-docs-test-"));
+const docsRoot = path.join(root, "docs");
+mkdirSync(path.join(docsRoot, "developers"), { recursive: true });
+writeFileSync(path.join(docsRoot, "manifest.json"), '{"sha":"test-sha"}\n');
+writeFileSync(path.join(docsRoot, "developers", "llms.txt"), "Pinned Tempo docs\n");
+
+const upstreamRequests = [];
+const upstream = createServer(async (request, response) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  upstreamRequests.push({
+    method: request.method,
+    url: request.url,
+    contentType: request.headers["content-type"],
+    apiToken: request.headers["x-api-token"],
+    host: request.headers.host,
+    body: Buffer.concat(chunks).toString(),
+  });
+  response.writeHead(201, {
+    "access-control-allow-origin": "https://tempo.xyz",
+    "content-type": "application/json",
+    "x-tempo-test": "forwarded",
+  });
+  response.end('{"ok":true}\n');
+});
+await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+const upstreamAddress = upstream.address();
+
+process.env.NODE_ENV = "test";
+process.env.TEMPO_DOCS_ROOT = docsRoot;
+process.env.ACCESS_LOG_PATH = path.join(root, "access.log");
+process.env.TEMPO_API_UPSTREAM_ORIGIN = `http://127.0.0.1:${upstreamAddress.port}`;
+
+const { serveDocs } = await import("./server.mjs");
+const sidecar = createServer(serveDocs);
+await new Promise((resolve) => sidecar.listen(0, "127.0.0.1", resolve));
+const sidecarAddress = sidecar.address();
+const sidecarOrigin = `http://127.0.0.1:${sidecarAddress.port}`;
+
+test.after(async () => {
+  await Promise.all([
+    new Promise((resolve, reject) => sidecar.close((error) => (error ? reject(error) : resolve()))),
+    new Promise((resolve, reject) => upstream.close((error) => (error ? reject(error) : resolve()))),
+  ]);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("proxies Tempo API routes without changing the method, path, query, or body", async () => {
+  const response = await fetch(`${sidecarOrigin}/developers/api/faucet?source=benchmark`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-token": "test-token",
+    },
+    body: '{"address":"0x1234"}',
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.headers.get("x-tempo-test"), "forwarded");
+  assert.equal(response.headers.get("access-control-allow-origin"), "https://tempo.xyz");
+  assert.deepEqual(await response.json(), { ok: true });
+  assert.deepEqual(upstreamRequests[0], {
+    method: "POST",
+    url: "/api/faucet?source=benchmark",
+    contentType: "application/json",
+    apiToken: "test-token",
+    host: `127.0.0.1:${upstreamAddress.port}`,
+    body: '{"address":"0x1234"}',
+  });
+});
+
+test("proxies GET requests within the API namespace", async () => {
+  const response = await fetch(`${sidecarOrigin}/developers/api/og?size=large`);
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(upstreamRequests[1], {
+    method: "GET",
+    url: "/api/og?size=large",
+    contentType: undefined,
+    apiToken: undefined,
+    host: `127.0.0.1:${upstreamAddress.port}`,
+    body: "",
+  });
+});
+
+test("continues to serve the pinned documentation bundle", async () => {
+  const response = await fetch(`${sidecarOrigin}/llms.txt`);
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "Pinned Tempo docs\n");
+});
+
+test("does not proxy the API base path or unrelated POST requests", async () => {
+  const baseResponse = await fetch(`${sidecarOrigin}/developers/api`);
+  assert.equal(baseResponse.status, 404);
+
+  const nearPrefixResponse = await fetch(`${sidecarOrigin}/developers/apiary`);
+  assert.equal(nearPrefixResponse.status, 404);
+
+  const docsResponse = await fetch(`${sidecarOrigin}/developers/docs/quickstart`, {
+    method: "POST",
+  });
+  assert.equal(docsResponse.status, 405);
+  assert.equal(upstreamRequests.length, 2);
+});


### PR DESCRIPTION
## Summary

- proxy `/developers/api/*` from the pinned docs sidecar to `https://developers.tempo.xyz/api/*`
- preserve request methods, bodies, query strings, headers, and upstream responses
- keep all other documentation traffic pinned to the configured docs SHA
- add offline coverage for proxy behavior and route boundaries

## Why

The sidecar aliases `tempo.xyz` so agents use the pinned documentation bundle, but it also intercepted the dynamic API endpoints documented by that bundle and returned `405` for POST requests. This keeps documentation deterministic while allowing the documented API routes to function.

## Validation

- `npm run check`