### PR TITLE
Retry transient Tempo RPC failures

### DIFF
--- a/shared/tempo/verifier/bin/tempo-bench-verify.js
+++ b/shared/tempo/verifier/bin/tempo-bench-verify.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // SYNCED FROM shared/tempo/verifier/bin/tempo-bench-verify.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
+require("../src/rpc-retry").installRpcRetry();
 const { main } = require("../src/index");
 
 main().catch((error) => {

--- a/shared/tempo/verifier/src/index.js
+++ b/shared/tempo/verifier/src/index.js
@@ -2,7 +2,8 @@
 const fs = require("node:fs");
 const { readConfig, redactedConfig } = require("./config");
 const { writeException, writeJson, writeReward } = require("./logs");
-const { assertSubmissionShape, runStep } = require("./submission");
+const { isRpcRetryExhausted } = require("./rpc-retry");
+const { assertSubmissionShape, runStep, withRpcRetryEnv } = require("./submission");
 const { createTempoClient, waitForRpc } = require("./tempo");
 const cases = require("./cases");
 
@@ -26,6 +27,10 @@ function failureDetails(config, error, context, scores) {
     scores,
     fixture: redactedConfig(config),
   };
+}
+
+function isRetryableVerifierFailure(error, details) {
+  return details.phase === "rpc" || isRpcRetryExhausted(error);
 }
 
 async function main() {
@@ -81,7 +86,7 @@ async function main() {
       "submission-eval",
       "npm",
       ["run", "eval"],
-      verifier.runtimeEnv(config),
+      withRpcRetryEnv(verifier.runtimeEnv(config)),
     );
     scores.build = 1;
     scores.run = 1;
@@ -105,10 +110,12 @@ async function main() {
     const details = failureDetails(config, error, context, scores);
     writeJson(config, "details.json", details);
     writeException(config, details);
+    if (isRetryableVerifierFailure(error, details)) throw error;
     writeReward(config, { reward: 0, ...scores });
   }
 }
 
 module.exports = {
+  isRetryableVerifierFailure,
   main,
 };

--- a/shared/tempo/verifier/src/rpc-retry-preload.js
+++ b/shared/tempo/verifier/src/rpc-retry-preload.js
@@ -1,0 +1,1 @@
+require("./rpc-retry").installRpcRetry();

--- a/shared/tempo/verifier/src/rpc-retry.js
+++ b/shared/tempo/verifier/src/rpc-retry.js
@@ -1,0 +1,126 @@
+const { setTimeout: wait } = require("node:timers/promises");
+
+const INSTALLED = Symbol.for("tempo-bench.rpc-retry");
+const MAX_RETRIES = 5;
+const RETRY_EXHAUSTED = "TEMPO_RPC_RETRY_EXHAUSTED";
+const RETRYABLE_READ_STATUSES = new Set([408, 500, 502, 503, 504]);
+const RATE_LIMIT_MESSAGE = /rate.?limit|too many requests|try again|exceeds? (?:the )?defined limit/i;
+const TEMPO_RPC_HOST = "rpc.moderato.tempo.xyz";
+// These are retried only after an explicit rate-limit rejection, never an ambiguous 5xx.
+const RATE_LIMIT_ONLY_METHODS = new Set([
+  "eth_sendRawTransaction",
+  "eth_sendRawTransactionSync",
+  "tempo_fundAddress",
+]);
+const READ_METHODS = new Set([
+  "eth_blockNumber",
+  "eth_call",
+  "eth_chainId",
+  "eth_estimateGas",
+  "eth_feeHistory",
+  "eth_gasPrice",
+  "eth_maxPriorityFeePerGas",
+  "eth_syncing",
+  "web3_clientVersion",
+]);
+
+function isReadMethod(method) {
+  return (
+    (method.startsWith("eth_get") && method !== "eth_getFilterChanges") ||
+    method.startsWith("net_") ||
+    READ_METHODS.has(method)
+  );
+}
+
+function requestKind(body) {
+  if (typeof body !== "string") return null;
+  try {
+    const payload = JSON.parse(body);
+    const requests = Array.isArray(payload) ? payload : [payload];
+    if (requests.length === 0 || requests.some(({ method }) => typeof method !== "string")) {
+      return null;
+    }
+    if (requests.every(({ method }) => isReadMethod(method))) return "read";
+    if (requests.length === 1 && RATE_LIMIT_ONLY_METHODS.has(requests[0].method)) {
+      return "rate-limit-only";
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isTempoRpc(input) {
+  try {
+    const value = typeof input === "object" && input?.url ? input.url : input;
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === TEMPO_RPC_HOST;
+  } catch {
+    return false;
+  }
+}
+
+function isRateLimitError(error) {
+  return (
+    (error?.code === -32005 || error?.code === 429) &&
+    RATE_LIMIT_MESSAGE.test(String(error.message))
+  );
+}
+
+async function isRetryableResponse(response, kind) {
+  if (response.status === 429) return true;
+  if (kind === "read" && RETRYABLE_READ_STATUSES.has(response.status)) return true;
+  try {
+    const payload = await response.clone().json();
+    const replies = Array.isArray(payload) ? payload : [payload];
+    return replies.length > 0 && replies.every((reply) => isRateLimitError(reply?.error));
+  } catch {
+    return false;
+  }
+}
+
+function isRpcRetryExhausted(error) {
+  const seen = new Set();
+  let current = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    if (current.code === RETRY_EXHAUSTED) return true;
+    seen.add(current);
+    current = current.cause;
+  }
+  return false;
+}
+
+function withRpcRetries(
+  fetchFn,
+  sleep = (ms, signal) => wait(ms, undefined, { signal }),
+) {
+  return async (input, init) => {
+    const kind = requestKind(init?.body);
+    if (!isTempoRpc(input) || !kind) return fetchFn(input, init);
+
+    for (let attempt = 0; ; attempt += 1) {
+      const response = await fetchFn(input, init);
+      if (!(await isRetryableResponse(response, kind))) return response;
+      if (attempt >= MAX_RETRIES) {
+        const error = new Error(`Tempo RPC remained unavailable after ${attempt + 1} attempts`);
+        error.code = RETRY_EXHAUSTED;
+        throw error;
+      }
+      const backoff = 100 * 2 ** attempt;
+      await sleep(backoff + Math.floor(Math.random() * backoff), init?.signal);
+    }
+  };
+}
+
+function installRpcRetry() {
+  if (typeof globalThis.fetch !== "function" || globalThis.fetch[INSTALLED]) return;
+  const fetchWithRetries = withRpcRetries(globalThis.fetch);
+  Object.defineProperty(fetchWithRetries, INSTALLED, { value: true });
+  globalThis.fetch = fetchWithRetries;
+}
+
+module.exports = {
+  installRpcRetry,
+  isRpcRetryExhausted,
+  withRpcRetries,
+};

--- a/shared/tempo/verifier/src/submission.js
+++ b/shared/tempo/verifier/src/submission.js
@@ -76,8 +76,19 @@ function defaultRuntimeEnv(config) {
   };
 }
 
+function withRpcRetryEnv(env) {
+  const retryPreload = `--require=${path.join(__dirname, "rpc-retry-preload.js")}`;
+  return {
+    ...env,
+    NODE_OPTIONS: [env.NODE_OPTIONS ?? process.env.NODE_OPTIONS, retryPreload]
+      .filter(Boolean)
+      .join(" "),
+  };
+}
+
 module.exports = {
   assertSubmissionShape,
   defaultRuntimeEnv,
   runStep,
+  withRpcRetryEnv,
 };

--- a/shared/tempo/verifier/src/tempo.js
+++ b/shared/tempo/verifier/src/tempo.js
@@ -1,6 +1,7 @@
 // SYNCED FROM shared/tempo/verifier/src/tempo.js BY npm run sync. DO NOT EDIT COPIES IN tasks/.
 const { createPublicClient, decodeEventLog, http, pad, stringToHex } = require("viem");
 const { tempoTestnet } = require("viem/tempo/chains");
+const { isRpcRetryExhausted } = require("./rpc-retry");
 
 function createTempoClient() {
   return createPublicClient({ chain: tempoTestnet, transport: http() });
@@ -51,7 +52,8 @@ async function receiptAfter(client, fromBlock, hash, from, label) {
   let receipt;
   try {
     receipt = await client.getTransactionReceipt({ hash });
-  } catch {
+  } catch (error) {
+    if (isRpcRetryExhausted(error)) throw error;
     return null;
   }
   if (receipt.status !== "success") throw new Error(`${label} did not succeed`);

--- a/shared/tempo/verifier/test/index.test.js
+++ b/shared/tempo/verifier/test/index.test.js
@@ -1,0 +1,14 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { isRetryableVerifierFailure } = require("../src/index");
+
+test("distinguishes RPC infrastructure failures from incorrect evidence", () => {
+  const exhausted = new Error("retry exhausted");
+  exhausted.code = "TEMPO_RPC_RETRY_EXHAUSTED";
+  const wrapped = new Error("HTTP request failed", { cause: exhausted });
+
+  assert.equal(isRetryableVerifierFailure(wrapped, { phase: "onchain-verification" }), true);
+  assert.equal(isRetryableVerifierFailure(new Error("wrong recipient"), { phase: "onchain-verification" }), false);
+  assert.equal(isRetryableVerifierFailure(new Error("unreachable"), { phase: "rpc" }), true);
+});

--- a/shared/tempo/verifier/test/rpc-retry.test.js
+++ b/shared/tempo/verifier/test/rpc-retry.test.js
@@ -1,0 +1,208 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+const test = require("node:test");
+
+const { withRpcRetryEnv } = require("../src/submission");
+const { isRpcRetryExhausted, withRpcRetries } = require("../src/rpc-retry");
+const { receiptAfter } = require("../src/tempo");
+
+const RPC_URL = "https://rpc.moderato.tempo.xyz";
+
+function rpcResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function rpcRequest(fetch, method, { params = ["0x01"], signal, url = RPC_URL } = {}) {
+  return fetch(url, {
+    body: JSON.stringify({ method, params }),
+    method: "POST",
+    signal,
+  });
+}
+
+test("retries transient read-only JSON-RPC failures", async () => {
+  const delays = [];
+  let calls = 0;
+  const fetch = withRpcRetries(
+    async () => {
+      calls += 1;
+      if (calls === 1) return rpcResponse({ error: { code: -32005, message: "rate limited" } });
+      if (calls === 2) return rpcResponse({ error: "unavailable" }, 503);
+      return rpcResponse({ result: { status: "0x1" } });
+    },
+    async (ms) => delays.push(ms),
+  );
+
+  const response = await rpcRequest(fetch, "eth_getTransactionReceipt");
+
+  assert.equal(calls, 3);
+  assert.ok(delays[0] >= 100 && delays[0] < 200);
+  assert.ok(delays[1] >= 200 && delays[1] < 400);
+  assert.deepEqual(await response.json(), { result: { status: "0x1" } });
+});
+
+test("retries an identical signed transaction after an explicit rate limit", async () => {
+  const bodies = [];
+  const fetch = withRpcRetries(
+    async (_input, init) => {
+      bodies.push(init.body);
+      return bodies.length < 3
+        ? rpcResponse({ error: { code: -32005, message: "rate limited, try again" } })
+        : rpcResponse({ result: { status: "0x1" } });
+    },
+    async () => {},
+  );
+
+  const response = await rpcRequest(fetch, "eth_sendRawTransactionSync");
+
+  assert.equal(bodies.length, 3);
+  assert.equal(new Set(bodies).size, 1);
+  assert.deepEqual(await response.json(), { result: { status: "0x1" } });
+});
+
+test("retries an explicit faucet rate limit", async () => {
+  let calls = 0;
+  const fetch = withRpcRetries(
+    async () => {
+      calls += 1;
+      return calls === 1
+        ? rpcResponse({ error: { code: -32005, message: "Request exceeds defined limit." } })
+        : rpcResponse({ result: "0x01" });
+    },
+    async () => {},
+  );
+
+  await rpcRequest(fetch, "tempo_fundAddress");
+  assert.equal(calls, 2);
+});
+
+test("does not retry requests outside the safe scope", async () => {
+  const rateLimit = () => rpcResponse({ error: { code: -32005, message: "rate limited" } });
+  const cases = [
+    { name: "higher-level write", method: "eth_sendTransaction", params: [{}], response: rateLimit },
+    { name: "other RPC", method: "eth_getTransactionReceipt", response: rateLimit, url: "https://rpc.example" },
+    {
+      name: "non-rate-limit error",
+      method: "eth_getTransactionReceipt",
+      response: () => rpcResponse({ error: { code: -32005, message: "sequencer only" } }),
+    },
+    {
+      name: "ambiguous raw write",
+      method: "eth_sendRawTransactionSync",
+      response: () => rpcResponse({ error: "unavailable" }, 503),
+    },
+    {
+      name: "stateful filter read",
+      method: "eth_getFilterChanges",
+      response: () => rpcResponse({ error: "unavailable" }, 503),
+    },
+  ];
+
+  for (const scenario of cases) {
+    let calls = 0;
+    const fetch = withRpcRetries(async () => {
+      calls += 1;
+      return scenario.response();
+    });
+    await rpcRequest(fetch, scenario.method, scenario);
+    assert.equal(calls, 1, scenario.name);
+  }
+});
+
+test("does not retry a partially successful batch", async () => {
+  let calls = 0;
+  const fetch = withRpcRetries(async () => {
+    calls += 1;
+    return rpcResponse([
+      { result: "0x01" },
+      { error: { code: -32005, message: "rate limited" } },
+    ]);
+  });
+
+  await fetch(RPC_URL, {
+    body: JSON.stringify([
+      { method: "eth_getBlockByNumber", params: ["latest", false] },
+      { method: "eth_getTransactionReceipt", params: ["0x01"] },
+    ]),
+    method: "POST",
+  });
+  assert.equal(calls, 1);
+});
+
+test("bounds retries and marks exhaustion", async () => {
+  let calls = 0;
+  const fetch = withRpcRetries(
+    async () => {
+      calls += 1;
+      return rpcResponse({ error: { code: -32005, message: "try again" } });
+    },
+    async () => {},
+  );
+
+  await assert.rejects(
+    rpcRequest(fetch, "eth_getTransactionReceipt"),
+    (error) => isRpcRetryExhausted(error),
+  );
+  assert.equal(calls, 6);
+});
+
+test("receipt polling propagates only exhausted RPC retries", async () => {
+  const exhausted = new Error("retry exhausted");
+  exhausted.code = "TEMPO_RPC_RETRY_EXHAUSTED";
+  const wrapped = new Error("HTTP request failed", { cause: exhausted });
+  const client = {
+    getTransactionReceipt: async () => {
+      throw wrapped;
+    },
+  };
+
+  await assert.rejects(
+    receiptAfter(client, 0n, "0x01", null, "reported transaction"),
+    (error) => isRpcRetryExhausted(error),
+  );
+  client.getTransactionReceipt = async () => {
+    throw new Error("transaction not found");
+  };
+  assert.equal(await receiptAfter(client, 0n, "0x01", null, "reported transaction"), null);
+});
+
+test("stops retrying when the request is aborted", async () => {
+  const controller = new AbortController();
+  let calls = 0;
+  const fetch = withRpcRetries(async () => {
+    calls += 1;
+    return rpcResponse({ error: { code: -32005, message: "rate limited" } });
+  });
+
+  const request = rpcRequest(fetch, "eth_getTransactionReceipt", { signal: controller.signal });
+  controller.abort();
+
+  await assert.rejects(request, { name: "AbortError" });
+  assert.equal(calls, 1);
+});
+
+test("preloads retries into submission Node processes", () => {
+  const previous = process.env.NODE_OPTIONS;
+  process.env.NODE_OPTIONS = "--trace-warnings";
+  try {
+    const env = withRpcRetryEnv({});
+    assert.equal(
+      env.NODE_OPTIONS,
+      `--trace-warnings --require=${path.join(__dirname, "../src/rpc-retry-preload.js")}`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      ["-e", "process.stdout.write(String(Boolean(fetch[Symbol.for('tempo-bench.rpc-retry')])))"],
+      { encoding: "utf8", env: { ...process.env, ...env } },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "true");
+  } finally {
+    if (previous === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = previous;
+  }
+});


### PR DESCRIPTION
## Summary

- Retry transient Tempo RPC failures in the shared verifier and submission runtime.
- Use bounded backoff for safe reads and explicit rate-limit rejections.
- Avoid replaying ambiguous writes, stateful filter reads, or partially successful batches.
- After retry exhaustion, preserve diagnostics and return a verifier error instead of a false correctness zero.

## Why

Concurrent Tempo-v1 runs could receive correctness zeroes when the RPC returned `-32005` during receipt polling or raw transaction submission, even though the task implementation was valid.

## Validation

- `npm run check`
- `npm run check:generated`
- `npm run check:dataset`
- 31 shared-verifier tests
- Real viem smoke: six bounded attempts and the exhaustion marker survives viem's nested error
- 9/9 Tempo-v1 oracle tasks at concurrency 9
