### PR TITLE
Emit complete metrics for every task suite

### DIFF
--- a/scripts/mcp_eval_check_test.py
+++ b/scripts/mcp_eval_check_test.py
@@ -109,6 +109,7 @@ class McpEvalCheckTest(unittest.TestCase):
             self.events,
         )
         self.assertEqual(result["reward"]["reward"], 1)
+        self.assertEqual(result["reward"]["quality"], 0)
         self.assertEqual(result["validation"]["errors"], [])
         self.assertEqual(len(result["validation"]["warnings"]), 1)
         self.assertEqual(result["reward"]["data_evidence_valid"], 1)
@@ -131,6 +132,7 @@ class McpEvalCheckTest(unittest.TestCase):
             self.events,
         )
         self.assertEqual(result["reward"]["reward"], 0.4)
+        self.assertEqual(result["reward"]["quality"], 0)
         self.assertEqual(result["reward"]["valid_answer"], 0)
         self.assertEqual(result["reward"]["mcp_tool_mix_valid"], 1)
         self.assertEqual(result["reward"]["data_evidence_valid"], 0)

--- a/scripts/tempo_reward_schema_test.py
+++ b/scripts/tempo_reward_schema_test.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ZERO_REWARD = {"correctness": 0, "quality": 0, "reward": 0}
+
+
+class TempoRewardSchemaTest(unittest.TestCase):
+    def test_every_gated_failure_emits_the_complete_reward_schema(self) -> None:
+        scripts = sorted(ROOT.glob("tasks/tempo-v1/*/tests/test.sh"))
+        self.assertTrue(scripts)
+
+        for script in scripts:
+            for failure in ("workspace", "verifier", "rewardkit"):
+                with self.subTest(task=script.parents[1].name, failure=failure):
+                    self._assert_gated_failure(script, failure)
+
+    def _assert_gated_failure(self, script: Path, failure: str) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            workspace = temporary / "workspace"
+            tests = temporary / "tests"
+            verifier = tests / "correctness" / "verify-tempo.sh"
+            logs = temporary / "logs"
+
+            tests.joinpath("correctness").mkdir(parents=True)
+            verifier.write_text(
+                "#!/usr/bin/env bash\nexit "
+                + ("1" if failure == "verifier" else "0")
+                + "\n"
+            )
+            if failure != "workspace":
+                workspace.mkdir()
+
+            env = os.environ.copy()
+            env.pop("ANTHROPIC_API_KEY", None)
+            env.update(
+                {
+                    "TEMPO_BENCH_LOG_DIR": str(logs),
+                    "TEMPO_BENCH_TESTS_DIR": str(tests),
+                    "TEMPO_BENCH_WORKSPACE": str(workspace),
+                    "tempo_bench_rewardkit_VENV": str(temporary / "missing-venv"),
+                }
+            )
+            result = subprocess.run(
+                ["bash", str(script)],
+                check=False,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads((logs / "reward.json").read_text()),
+                ZERO_REWARD,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tempo_reward_schema_test.py
+++ b/scripts/tempo_reward_schema_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,17 +12,101 @@ ROOT = Path(__file__).resolve().parents[1]
 ZERO_REWARD = {"correctness": 0, "quality": 0, "reward": 0}
 
 
-class TempoRewardSchemaTest(unittest.TestCase):
-    def test_every_gated_failure_emits_the_complete_reward_schema(self) -> None:
+class RewardSchemaTest(unittest.TestCase):
+    def test_every_tempo_gated_failure_emits_the_complete_reward_schema(
+        self,
+    ) -> None:
         scripts = sorted(ROOT.glob("tasks/tempo-v1/*/tests/test.sh"))
         self.assertTrue(scripts)
 
         for script in scripts:
             for failure in ("workspace", "verifier", "rewardkit"):
                 with self.subTest(task=script.parents[1].name, failure=failure):
-                    self._assert_gated_failure(script, failure)
+                    self._assert_tempo_gated_failure(script, failure)
 
-    def _assert_gated_failure(self, script: Path, failure: str) -> None:
+    def test_every_mpp_missing_rewardkit_failure_emits_the_complete_reward_schema(
+        self,
+    ) -> None:
+        scripts = sorted(ROOT.glob("tasks/mpp/*/tests/test.sh"))
+        self.assertTrue(scripts)
+
+        for script in scripts:
+            with self.subTest(task=script.parents[1].name):
+                self._assert_mpp_missing_rewardkit_failure(script)
+
+    def test_mpp_binary_fallback_emits_the_complete_reward_schema(self) -> None:
+        verifier_utils = (
+            ROOT
+            / "shared/global/rewardkit-lib/tempo_bench_rewardkit/mpp/verifier_utils.py"
+        )
+        for score in (0, 1):
+            with self.subTest(score=score), tempfile.TemporaryDirectory() as temporary:
+                temporary_path = Path(temporary)
+                details = temporary_path / "details.json"
+                scores = temporary_path / "scores.json"
+                rewardkit_output = temporary_path / "rewardkit-output.json"
+                reward = temporary_path / "reward.json"
+                scores.write_text(json.dumps({"reward": score}))
+
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(verifier_utils),
+                        "write-binary-reward",
+                        str(details),
+                        str(scores),
+                        str(rewardkit_output),
+                        str(reward),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(
+                    json.loads(reward.read_text()),
+                    {"correctness": score, "quality": 0, "reward": score},
+                )
+
+    def test_mpp_final_reward_preserves_native_dimension_scores(self) -> None:
+        verifier_utils = (
+            ROOT
+            / "shared/global/rewardkit-lib/tempo_bench_rewardkit/mpp/verifier_utils.py"
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            details = temporary_path / "details.json"
+            scores = temporary_path / "scores.json"
+            rewardkit_output = temporary_path / "rewardkit-output.json"
+            reward = temporary_path / "reward.json"
+            scores.write_text(json.dumps({"reward": 1}))
+            rewardkit_output.write_text(
+                json.dumps({"correctness": 0.75, "quality": 0.6, "reward": 0.7})
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(verifier_utils),
+                    "write-binary-reward",
+                    str(details),
+                    str(scores),
+                    str(rewardkit_output),
+                    str(reward),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(reward.read_text()),
+                {"correctness": 0.75, "quality": 0.6, "reward": 1},
+            )
+
+    def _assert_tempo_gated_failure(self, script: Path, failure: str) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
             workspace = temporary / "workspace"
@@ -40,6 +125,38 @@ class TempoRewardSchemaTest(unittest.TestCase):
 
             env = os.environ.copy()
             env.pop("ANTHROPIC_API_KEY", None)
+            env.update(
+                {
+                    "TEMPO_BENCH_LOG_DIR": str(logs),
+                    "TEMPO_BENCH_TESTS_DIR": str(tests),
+                    "TEMPO_BENCH_WORKSPACE": str(workspace),
+                    "tempo_bench_rewardkit_VENV": str(temporary / "missing-venv"),
+                }
+            )
+            result = subprocess.run(
+                ["bash", str(script)],
+                check=False,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads((logs / "reward.json").read_text()),
+                ZERO_REWARD,
+            )
+
+    def _assert_mpp_missing_rewardkit_failure(self, script: Path) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            workspace = temporary / "workspace"
+            tests = temporary / "tests"
+            logs = temporary / "logs"
+            workspace.mkdir()
+            tests.mkdir()
+
+            env = os.environ.copy()
             env.update(
                 {
                     "TEMPO_BENCH_LOG_DIR": str(logs),

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/mpp/verifier_utils.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/mpp/verifier_utils.py
@@ -65,7 +65,8 @@ def redact(text: str) -> str:
 def write_binary_reward(args: list[str]) -> int:
     details_path = Path(args[0])
     scores_path = Path(args[1])
-    reward_path = Path(args[2])
+    rewardkit_output_path = Path(args[2])
+    reward_path = Path(args[3])
     reward = 0
 
     scores = read_json(scores_path)
@@ -76,7 +77,20 @@ def write_binary_reward(args: list[str]) -> int:
         if isinstance(details, dict):
             reward = 1 if score_of(details.get("correctness", 0)) == 1.0 else 0
 
-    write_json(reward_path, {"reward": reward})
+    rewardkit_output = read_json(rewardkit_output_path)
+    rewardkit_output = rewardkit_output if isinstance(rewardkit_output, dict) else {}
+    correctness = rewardkit_output.get("correctness", reward)
+    quality = rewardkit_output.get("quality", 0)
+    write_json(
+        reward_path,
+        {
+            "correctness": correctness
+            if isinstance(correctness, int | float)
+            else reward,
+            "quality": quality if isinstance(quality, int | float) else 0,
+            "reward": reward,
+        },
+    )
     return 0
 
 
@@ -173,7 +187,7 @@ COMMANDS = {
     "check-reward": (check_reward, 1),
     "cleanup-server": (cleanup_server, 1),
     "emit-logs": (emit_logs, 2),
-    "write-binary-reward": (write_binary_reward, 3),
+    "write-binary-reward": (write_binary_reward, 4),
     "write-failure-score": (write_failure_score, 4),
 }
 

--- a/shared/mpp/tests/test.sh
+++ b/shared/mpp/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/shared/tempo/mcp-eval/check.py
+++ b/shared/tempo/mcp-eval/check.py
@@ -36,7 +36,14 @@ def write_result(
         + "\n"
     )
     (log_dir / "reward.json").write_text(
-        json.dumps({"reward": reward, "valid_answer": valid_answer, **components})
+        json.dumps(
+            {
+                "reward": reward,
+                "quality": 0,
+                "valid_answer": valid_answer,
+                **components,
+            }
+        )
         + "\n"
     )
     if evidence:

--- a/shared/tempo/mcp-eval/test.sh
+++ b/shared/tempo/mcp-eval/test.sh
@@ -21,6 +21,7 @@ reward = json.loads(reward_path.read_text()) if reward_path.exists() else {}
 reward.update(
     {
         "reward": 0,
+        "quality": 0,
         "valid_answer": 0,
         "quality_judge_available": 0,
         "quality_judge_unavailable": sys.argv[2],

--- a/tasks/mpp/client-access-keys/tests/test.sh
+++ b/tasks/mpp/client-access-keys/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/dataset.toml
+++ b/tasks/mpp/dataset.toml
@@ -11,37 +11,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo/mpp-client-access-keys"
-digest = "sha256:fc2353c582606a8c4bfeb42d67548723f5c808d10f5f65e00b1c9e2c5a1809b2"
+digest = "sha256:905778fa4647508fc87f04a461ac8a80100d19f0f6305ea8c4600dca65c85ca4"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-and-session"
-digest = "sha256:1252a93c63bb447fca26be55afd2d7192b4f7431ed808506cd9592ee012a5ee5"
+digest = "sha256:e24512c661d6a2c5ab8ef991ad223402afb8787e7249d9bea6c236411f02e28d"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd"
-digest = "sha256:b580a64399cdc4a95bc9daaa47c129221957c8ff18cad74f462a209f7535ab20"
+digest = "sha256:20cdee44aff260589dab5913e28e86ea2fcf36635e0dc07d8f7f9dbd05c2cf2b"
 
 [[tasks]]
 name = "tempo/mpp-server-charge-pathusd-usdc"
-digest = "sha256:6348f8e252ea055a67c3b4524f1c859b2a45c0c96f721c91c996b3a3385ba7d5"
+digest = "sha256:597243d24a5bbc6ecc6a13dd9bfaf74232b8251e8a4828228128a60d2fc1f38c"
 
 [[tasks]]
 name = "tempo/mpp-server-custom-payment-method"
-digest = "sha256:1b5c0d34a441f8a11f5497c97346ab795e42c5cb86dbec4b45a7d634fff746de"
+digest = "sha256:b5f8a8fff768eafb40bbae825b8536cb93be5cfdaeaa30a7663fb6fec062b88c"
 
 [[tasks]]
 name = "tempo/mpp-server-discovery-endpoint"
-digest = "sha256:55dc33d5fb73bcb54083f128e2377a2e13625590962853098cdd916673813dd6"
+digest = "sha256:877b49530eecad21e517a6fcf66723ff5f089d59eafea37749b8300819ba8b4e"
 
 [[tasks]]
 name = "tempo/mpp-server-hono-charge-pathusd"
-digest = "sha256:2b8bb0ba7abb7bf7a7e0c88f1417cdfb33d6eab65e3917babd612c5b295b2c48"
+digest = "sha256:eac9da04c471819a91fab6240e940be12e2cb82674fa05627c15b537bc933c14"
 
 [[tasks]]
 name = "tempo/mpp-server-mcp-pathusd"
-digest = "sha256:000865523832576e6654d2f86d0babc927a730c5fa6bbf9cc3568425b905907f"
+digest = "sha256:eeb731f1c63af08bece8084d64d9ead31df15e8d723d165515eeb2358ef84987"
 
 [[tasks]]
 name = "tempo/mpp-server-x402-mpp-charges"
-digest = "sha256:4ac5942be93bb57655e07e0d99bc9e79bed971b14917d2c252a5f7adc2dc9d8e"
+digest = "sha256:6c7b08255474476e3f598267a41a79b76d1c7e35d9d25d0daa3ba06ad7747cb0"
 

--- a/tasks/mpp/server-charge-and-session/tests/test.sh
+++ b/tasks/mpp/server-charge-and-session/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-charge-pathusd-usdc/tests/test.sh
+++ b/tasks/mpp/server-charge-pathusd-usdc/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-charge-pathusd/tests/test.sh
+++ b/tasks/mpp/server-charge-pathusd/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-custom-payment-method/tests/test.sh
+++ b/tasks/mpp/server-custom-payment-method/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-discovery-endpoint/tests/test.sh
+++ b/tasks/mpp/server-discovery-endpoint/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-hono-charge-pathusd/tests/test.sh
+++ b/tasks/mpp/server-hono-charge-pathusd/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-mcp-pathusd/tests/test.sh
+++ b/tasks/mpp/server-mcp-pathusd/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/mpp/server-x402-mpp-charges/tests/test.sh
+++ b/tasks/mpp/server-x402-mpp-charges/tests/test.sh
@@ -38,11 +38,11 @@ verifier_utils() {
 
 write_binary_reward() {
   verifier_utils write-binary-reward \
-    "$DETAILS_FILE" "$SCORES_FILE" "$REWARD_FILE"
+    "$DETAILS_FILE" "$SCORES_FILE" "$REWARDKIT_OUTPUT_FILE" "$REWARD_FILE"
 }
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$REWARD_FILE"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$REWARD_FILE"
 }
 
 cleanup_mpp_server() {

--- a/tasks/tempo-v1/access-key-transfer/tests/test.sh
+++ b/tasks/tempo-v1/access-key-transfer/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,37 +11,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo-v1/access-key-transfer"
-digest = "sha256:e5afa6a033962db7f8f05abed8c80187894a708b5d2f04f038eb87013b23e92d"
+digest = "sha256:e3396168c03df46693e39b6793606cbae1b2311dab7ed6e2505d949af3517b0b"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:97101f20a2c1e2fb2f9e8422f56d8bf88d0c41b1303e76b5d4cde7645f3a961d"
+digest = "sha256:df8f063c771a2189a4ef577d47bb95bdf421722f23cb14d5d308f60fdc53f0a2"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:ec13777fb6638526d800ecad52447bb91ff15b60139bd8a9ce3ab1b094d6c671"
+digest = "sha256:b5213b13fb8bc513f85eb70fd09273f4f4a022ed61bed66d7d0973179c5dd1df"
 
 [[tasks]]
 name = "tempo-v1/receive-policy-held-transfer"
-digest = "sha256:c2bfb7c7793f128efcfdae334d46cc99652022d8fe51a13cefaa7b5f81acf4f5"
+digest = "sha256:cfc6b92e0c1559d71227c3150735c4f3265145188afc96162f878a28a848feb1"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:1101e224827574049fe2ee87ca65cf28ff2f4a1f7f30ecc85ecba1a60e40b7cb"
+digest = "sha256:9866d99daae9498dd4b2b8132d91def467d11df21ea9cb50cdb89c6f34506a44"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:d5770b56a1e3e69eef11876372ac8f21115d07d77be687dd662a4e0ecdc61ce0"
+digest = "sha256:e89df04fde5f0acf835728e060f9a1006503a749bb8eec2817b41c8c4310d2e0"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:42c154cdbc71da4fa79b778efc444c5b0b1433fe4d5a146bb5a09c69d68eb7a0"
+digest = "sha256:74518142b0acce2fb9bfae1d3c6ed33aa9a10800166f139a098c4d373c78b22d"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:f09a33cab34ead7c9baba4bc09471ab76f13825689ebbf626b215f325385cb6c"
+digest = "sha256:f4994f0718f6c939cfc4ac087a9df7b6a83f4766ee39003220661c801c50fa66"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:412d6139475ec4db03e6e613fca94021ddb38c02b9ed38857284b570282a3169"
+digest = "sha256:06516ce44694d49fee2501853ce51c1f1defc6d04c0a818be2d41047333dc167"
 

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/receive-policy-held-transfer/tests/test.sh
+++ b/tasks/tempo-v1/receive-policy-held-transfer/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/set-fee-token/tests/test.sh
+++ b/tasks/tempo-v1/set-fee-token/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/transfer-batched/tests/test.sh
+++ b/tasks/tempo-v1/transfer-batched/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then

--- a/tasks/tempo-v1/transfer-with-memo/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo/tests/test.sh
@@ -13,7 +13,7 @@ rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
 trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
 
 write_zero_reward() {
-  printf '{"reward":0}\n' > "$LOG_DIR/reward.json"
+  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
 }
 
 if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then


### PR DESCRIPTION
## Motivation

Gated and fallback paths emitted partial reward dictionaries. Harbor Hub only averages attempts where a metric key is present, so missing correctness and quality keys excluded failed trials from those rollups.

## Summary

- emit complete reward dimensions across all 30 Tempo, MPP, and Tempo MCP tasks
- retain native MPP correctness and quality scores while preserving its existing binary overall reward
- refresh the affected Tempo and MPP task digests

## Key design considerations

- keep each suite's native schema: RewardKit suites emit correctness, quality, and reward; Tempo MCP retains its component metrics and seeds quality at zero
- leave hard gates, reward weights, and overall scoring behavior unchanged
