### PR TITLE
Scope agent API keys by provider

### DIFF
--- a/config/job.yaml.j2
+++ b/config/job.yaml.j2
@@ -39,11 +39,11 @@ agents:
 {% if agent.get("concurrency_group") %}
     concurrency_group: {{ agent.concurrency_group | tojson }}
 {% endif %}
-{% if agent.name != "oracle" %}
+{% if agent.name == "claude-code" %}
     env:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-{% if agent.name == "codex" %}
+{% elif agent.name == "codex" %}
+    env:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-{% endif %}
 {% endif %}
 {% endfor %}

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -23,6 +23,7 @@ from scripts.run_benchmark import (
     parse_model_config,
     prepare_production_profiles,
     production_job,
+    render_job_config,
     run_benchmark_key,
     run_benchmark_variant,
     stage_filtered_config,
@@ -276,6 +277,35 @@ class RunBenchmarkTest(unittest.TestCase):
             production_job("test-run", model_config, {})["n_attempts"],
             3,
         )
+
+    def test_job_config_scopes_api_keys_to_each_agent_provider(self) -> None:
+        config = render_job_config(
+            {
+                "job_name": "auth-test",
+                "n_attempts": 1,
+                "n_concurrent_trials": 2,
+                "environment_type": "docker",
+                "force_build": False,
+                "agents": [
+                    {"name": "claude-code", "model_name": "claude-test"},
+                    {"name": "codex", "model_name": "gpt-test"},
+                    {"name": "oracle"},
+                ],
+                "datasets": [],
+            }
+        )
+        agents = {agent["name"]: agent for agent in config["agents"]}
+
+        self.assertEqual(
+            agents["claude-code"]["env"],
+            {"ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY:-}"},
+        )
+        self.assertEqual(
+            agents["codex"]["env"],
+            {"OPENAI_API_KEY": "${OPENAI_API_KEY:-}"},
+        )
+        self.assertNotIn("env", agents["oracle"])
+        self.assertIn("ANTHROPIC_API_KEY", config["verifier"]["env"])
 
     def test_mcp_profile_is_injected_at_job_level(self) -> None:
         config = {"agents": [{"name": "claude-code"}, {"name": "oracle"}]}


### PR DESCRIPTION
## Summary

- scope agent API keys to their provider
- keep the Anthropic key available only to Claude agents and the RewardKit verifier
- add a regression test for Claude, Codex, oracle, and verifier environment boundaries

## Root cause

The shared job template assigned `ANTHROPIC_API_KEY` to every non-oracle agent, then added `OPENAI_API_KEY` for Codex. Harbor carries agent environment variables into the Daytona agent process, so production Codex runs received both provider keys.

## Validation

- `npm run check`
- `npm run check:generated`
- direct production config render confirms Codex receives only `OPENAI_API_KEY`