### PR TITLE
Standardize production job naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,35 +143,19 @@ npm run bench:daytona:agent -- --base-image "$(npm run -s base-image:ref)"
 
 BASE_IMAGE="$(npm run -s base-image:ref)"
 
-# Haiku, one attempt, all Tempo tasks, both Docs and MCP profiles.
+# Development smoke: Haiku, one attempt, both Tempo profiles.
 npm run bench:matrix:dev -- \
   --task-suite tempo --profile all --base-image "$BASE_IMAGE"
 
-# Haiku, one attempt, all Tempo tasks, pinned Docs only.
-npm run bench:matrix:dev -- \
-  --task-suite tempo --profile docs --base-image "$BASE_IMAGE"
-
-# Haiku, one attempt, all Tempo tasks, pinned Docs plus Tempo MCP.
-npm run bench:matrix:dev -- \
-  --task-suite tempo --profile mcp --base-image "$BASE_IMAGE"
-
-# All production models, three attempts, both profiles.
+# Production: configured models, three attempts, both Tempo profiles.
 npm run bench:matrix:production -- \
   --task-suite tempo --profile all --base-image "$BASE_IMAGE"
-
-# All production models, three attempts, pinned Docs only.
-npm run bench:matrix:production -- \
-  --task-suite tempo --profile docs --base-image "$BASE_IMAGE"
-
-# All production models, three attempts, pinned Docs plus Tempo MCP.
-npm run bench:matrix:production -- \
-  --task-suite tempo --profile mcp --base-image "$BASE_IMAGE"
 ```
 
 `bench:matrix:dev` reads `config/models.dev.yaml`; the production command reads
 `config/models.production.yaml`. Both commands include every matching task
-unless `--task-filter` is provided. The `docs` profile provides pinned Docs;
-the `mcp` profile provides the same pinned Docs plus the Tempo MCP server.
+unless `--task-filter` is provided. For Tempo, `docs` uses pinned Docs and `mcp`
+adds the Tempo MCP server.
 
 `--concurrency` is the concurrent-trial limit for each profile job, not a
 combined limit. `--profile all` runs the Docs and Docs-plus-MCP jobs in
@@ -179,19 +163,28 @@ parallel, so `--concurrency 32` permits up to 32 trials in each job, or 64
 across the pair. The model configs cap agent phases at 16 per provider and
 profile; `--agent-concurrency` overrides those caps.
 
-## Cataloging Production Runs
+## Production Jobs
 
-After a production run completes, upload its full Harbor job to Harbor Hub and
-add a small, Git-tracked run record under `results/<benchmark>/runs/<run-id>/`.
-The Harbor Hub job is the canonical archive for raw results, logs, artifacts,
-and configuration; the local record is a human-readable index and place for
-optional derived analysis.
+Production writes local Harbor jobs under `jobs/<job-name>` and does not upload
+them automatically:
 
-Start each run record from
-[`results/RUN_TEMPLATE.md`](results/RUN_TEMPLATE.md). Keep the published
-dataset digest, Harbor Hub job link, run configuration, and headline metrics in
-the record. Do not add run records beneath `tasks/`, because production history
-must not change a benchmark dataset's digest.
+| Suite | Production profile | Job names |
+| --- | --- | --- |
+| `tempo` | `all` | `tempo-bench-v1-production-<YYYYMMDDTHHMMSSZ>-{docs,mcp}` |
+| `mpp` | `docs` | `mpp-bench-v1-production-<YYYYMMDDTHHMMSSZ>-docs` |
+| `tempo-mcp` | `mcp-both` | `tempo-mcp-bench-v1-production-<YYYYMMDDTHHMMSSZ>-{mcp-direct,mcp-code}` |
+
+`--job-name` sets the shared run group, and the profile suffix is always added.
+
+```bash
+npm run harbor:view
+uv run harbor auth login # Skip when already authenticated
+uv run harbor upload --public "jobs/<job-name>"
+uv run harbor job download "<job-id>" --output-dir jobs
+```
+
+The upload prints a public Harbor Hub URL. Downloaded jobs can be viewed
+locally; resuming them requires the original staged task cache.
 
 ## Authoring a New Task
 
@@ -233,6 +226,7 @@ see [AGENTS.md](AGENTS.md) for versioning and contribution rules.
 | `DAYTONA_API_KEY` | Daytona authentication; JWT variables are an alternative |
 | `DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID` | Daytona JWT authentication |
 | `DAYTONA_TARGET` | Optional Daytona target |
+| `HARBOR_API_KEY` | Optional noninteractive Harbor Hub authentication |
 | `TEMPO_MCP_EVAL_URL` | Optional upstream endpoint for the MCP efficiency bridge |
 
 ## References

--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -125,22 +124,11 @@ def read_json(file_path: Path) -> JsonObject | None:
 
 
 def read_metadata(job_dir: Path) -> JsonObject:
-    return read_json(job_dir.parent / "metadata.json") or {}
-
-
-def command_output(command: str, args: list[str]) -> str:
-    result = subprocess.run(
-        [command, *args],
-        check=False,
-        capture_output=True,
-        text=True,
+    return (
+        read_json(job_dir / "metadata.json")
+        or read_json(job_dir.parent / "metadata.json")
+        or {}
     )
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def default_docs_source() -> str:
-    sha = (read_json(Path("config/tempo-docs.lock.json")) or {}).get("sha")
-    return str(sha) if sha else "public"
 
 
 def default_run_id(job_dir: Path, metadata: JsonObject) -> str:
@@ -158,15 +146,11 @@ def default_out_dir(job_dir: Path) -> Path:
 
 
 def build_context(job_dir: Path, run_id: str, metadata: JsonObject) -> JsonObject:
-    source = metadata.get("docs_source")
     return {
         "run_id": run_id,
         "job_name": job_dir.name,
-        "git_sha": metadata.get("git_sha")
-        or command_output("git", ["rev-parse", "HEAD"]),
-        "docs_source": source
-        if isinstance(source, str) and source
-        else default_docs_source(),
+        "git_sha": as_string(metadata.get("git_sha")),
+        "docs_source": as_string(metadata.get("docs_source")),
         "mcp_target_id": metadata.get("mcp_target_id", ""),
     }
 
@@ -692,7 +676,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--job",
         required=True,
-        help="Harbor job directory, for example runs/<run_id>/harbor-job",
+        help="Harbor job directory, for example jobs/<job-name>",
     )
     parser.add_argument("--run-id", help="Run id to write into exports")
     parser.add_argument("--out-dir", help="Output directory")

--- a/scripts/export_results_test.py
+++ b/scripts/export_results_test.py
@@ -74,15 +74,7 @@ class ExportResultsTest(unittest.TestCase):
     def test_export_results_writes_trial_and_summary_outputs(self) -> None:
         with tempfile.TemporaryDirectory(prefix="tempo-bench-export-") as root:
             root_path = Path(root)
-            job_dir = root_path / "run-1" / "harbor-job"
-            write_json(
-                root_path / "run-1" / "metadata.json",
-                {
-                    "run_id": "run-1",
-                    "git_sha": "abc123",
-                    "docs_source": "docs123",
-                },
-            )
+            job_dir = root_path / "jobs" / "run-1"
             write_json(
                 job_dir / "trial-a" / "result.json", trial({"trial_name": "trial-a"})
             )
@@ -121,12 +113,13 @@ class ExportResultsTest(unittest.TestCase):
             self.assertEqual(len(result["summary"]), 2)
             self.assertEqual(result["trials"][0]["attempt_index"], 1)
             self.assertEqual(result["trials"][1]["attempt_index"], 2)
-            self.assertEqual(result["trials"][0]["git_sha"], "abc123")
-            self.assertEqual(result["trials"][0]["docs_source"], "docs123")
+            self.assertEqual(result["trials"][0]["git_sha"], "")
+            self.assertEqual(result["trials"][0]["docs_source"], "")
             self.assertEqual(result["trials"][0]["duration_sec"], 60)
             self.assertEqual(result["trials"][0]["agent_execution_duration_sec"], 30)
 
             out_dir = Path(result["out_dir"])
+            self.assertEqual(out_dir, (job_dir / "exports").resolve())
             trials_csv = (out_dir / "trials.csv").read_text()
             self.assertIn("verifier_reward_correctness", trials_csv)
             self.assertIn("transfer-with-memo-fee-payer", trials_csv)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
@@ -83,7 +83,8 @@ Variants:
 Options:
   --env-file PATH          Load env file for Harbor and preflight checks
                            (default: .env when present)
-  --job-name NAME          Override generated job name
+  --job-name NAME          Override generated job name; production runs use it
+                           as the run group and include the profile suffix
   --models-config PATH     Model matrix config
                            (default: config/models.production.yaml)
   --n-attempts N          Override production attempts per task and model
@@ -191,6 +192,10 @@ def timestamp() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
+def production_timestamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
 def run(command: str, args: list[str]) -> None:
     result = subprocess.run([command, *args], env=os.environ, check=False)
     if result.returncode != 0:
@@ -199,19 +204,6 @@ def run(command: str, args: list[str]) -> None:
 
 def run_status(command: str, args: list[str]) -> int:
     return subprocess.run([command, *args], env=os.environ, check=False).returncode
-
-
-def run_output(command: str, args: list[str]) -> str | None:
-    result = subprocess.run(
-        [command, *args],
-        env=os.environ,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip() or None
 
 
 def run_python(script: str, args: list[str] | None = None) -> None:
@@ -410,34 +402,14 @@ def validate_optional_positive_integer(value: str | None, option: str) -> str | 
     return None if value is None else read_positive_integer(value, option)
 
 
-def production_run_root(run_id: str) -> Path:
-    return Path("runs") / run_id
-
-
-def production_job_dir(run_id: str) -> Path:
-    return production_run_root(run_id) / "harbor-job"
-
-
-def write_production_metadata(run_id: str, metadata: dict[str, Any]) -> None:
-    run_root = production_run_root(run_id)
-    run_root.mkdir(parents=True, exist_ok=True)
-    (run_root / "metadata.json").write_text(f"{json.dumps(metadata, indent=2)}\n")
+def production_job_dir(job_name: str) -> Path:
+    if job_name in {"", ".", ".."} or Path(job_name).name != job_name:
+        raise RuntimeError("Production job name must be one path component")
+    return Path("jobs") / job_name
 
 
 def benchmark_key(value: str | BenchmarkKey | None) -> BenchmarkKey:
     return BenchmarkKey(value or BenchmarkKey.TEMPO)
-
-
-def benchmark_provenance(task_suite: str | None) -> list[dict[str, str]]:
-    keys = (
-        (BenchmarkKey.TEMPO, BenchmarkKey.TEMPO_MCP, BenchmarkKey.MPP)
-        if task_suite == "all"
-        else (benchmark_key(task_suite),)
-    )
-    return [
-        {"id": BENCHMARKS[key]["id"], "dataset": BENCHMARKS[key]["dataset"]}
-        for key in keys
-    ]
 
 
 def run_benchmark_key(variant: dict[str, Any], task_suite: str | None) -> BenchmarkKey:
@@ -501,7 +473,7 @@ def versioned_name(benchmark: BenchmarkKey, suffix: str) -> str:
 
 
 def render_job_config(
-    job: dict[str, Any], benchmark: BenchmarkKey = BenchmarkKey.TEMPO
+    job: dict[str, Any], benchmark: BenchmarkKey | None = BenchmarkKey.TEMPO
 ) -> dict[str, Any]:
     environment = jinja2.Environment(
         loader=jinja2.FileSystemLoader("config"),
@@ -511,7 +483,11 @@ def render_job_config(
         keep_trailing_newline=True,
     )
     rendered = environment.get_template("job.yaml.j2").render(
-        job_name=versioned_name(benchmark, job["job_name"]),
+        job_name=(
+            versioned_name(benchmark, job["job_name"])
+            if benchmark is not None
+            else job["job_name"]
+        ),
         jobs_dir=job.get("jobs_dir", "jobs"),
         n_attempts=job["n_attempts"],
         n_concurrent_trials=job["n_concurrent_trials"],
@@ -547,9 +523,10 @@ def production_job(
     model_config: dict[str, Any],
     options: dict[str, Any],
 ) -> dict[str, Any]:
+    job_dir = production_job_dir(run_id)
     return {
-        "job_name": "harbor-job",
-        "jobs_dir": str(production_run_root(run_id)),
+        "job_name": job_dir.name,
+        "jobs_dir": str(job_dir.parent),
         "n_attempts": int(options.get("n_attempts") or "3"),
         "n_concurrent_trials": int(options.get("concurrency") or "32"),
         "environment_type": "daytona",
@@ -562,7 +539,6 @@ def production_job(
 def run_production_variant(
     run_id: str,
     options: dict[str, Any],
-    source: dict[str, str],
     docs_bundle: str | None,
 ) -> None:
     models_config_path = options.get("models_config") or "config/models.production.yaml"
@@ -571,58 +547,17 @@ def run_production_variant(
     )
     preflight_production_agents(model_config)
     job = production_job(run_id, model_config, options)
-    config = stage_daytona_config(render_job_config(job), run_id, docs_bundle, options)
+    config = stage_daytona_config(
+        render_job_config(job, benchmark=None), run_id, docs_bundle, options
+    )
     max_retries = options.get("max_retries") or "2"
-    started_at = datetime.now().astimezone().isoformat()
-    metadata = {
-        "schema_version": 1,
-        "run_id": run_id,
-        "started_at": started_at,
-        "finished_at": None,
-        "status": "running",
-        "harbor_job_dir": str(production_job_dir(run_id)),
-        "models_config": models_config_path,
-        "models": [
-            {
-                "agent": model["agent"],
-                "model_name": model["model_name"],
-                "n_concurrent": model.get("n_concurrent"),
-                "concurrency_group": model.get("concurrency_group"),
-            }
-            for model in model_config["models"]
-        ],
-        "benchmarks": benchmark_provenance(options.get("task_suite")),
-        "task_suite": options.get("task_suite") or "tempo",
-        "task_filter": options.get("task_filter"),
-        "n_attempts": job["n_attempts"],
-        "n_concurrent_trials": str(job["n_concurrent_trials"]),
-        "max_retries": max_retries,
-        "docs_source": source.get("sha", "public"),
-        "docs_bundle": docs_bundle,
-        "profile": options["profile"],
-        "git_sha": run_output("git", ["rev-parse", "HEAD"]),
-        "git_branch": run_output("git", ["branch", "--show-current"]),
-        "harbor_version": run_output("uv", ["run", "harbor", "--version"]),
-    }
-
-    write_production_metadata(run_id, metadata)
     args = ["run", "harbor", "run", "-c", config]
     if options.get("env_file"):
         args.extend(["--env-file", options["env_file"]])
     args.extend(["--max-retries", max_retries])
     os.environ["TEMPO_DOCS_BUNDLE_PATH"] = ""
     args.append("-y")
-
     status = run_status("uv", args)
-    write_production_metadata(
-        run_id,
-        {
-            **metadata,
-            "finished_at": datetime.now().astimezone().isoformat(),
-            "status": "completed" if status == 0 else "failed",
-            "exit_status": status,
-        },
-    )
     if status != 0:
         raise RuntimeError(f"Production benchmark {run_id} failed with status {status}")
 
@@ -1074,12 +1009,18 @@ def main(argv: list[str]) -> None:
         first_profile_sync = False if variant.get("production") else options["sync"]
         benchmark = run_benchmark_key(variant, options.get("task_suite"))
         prefix = versioned_name(benchmark, variant["prefix"])
-        pair_id = options.get("job_name") or f"{prefix}-mcp-pair-{timestamp()}"
+        pair_id = options.get("job_name") or (
+            f"{prefix}-{production_timestamp()}"
+            if variant.get("production")
+            else f"{prefix}-mcp-pair-{timestamp()}"
+        )
         profile_options = [
             options
             | {
                 "profile": profile_id,
-                "job_name": f"{pair_id}-{profile_id}",
+                "job_name": (
+                    pair_id if variant.get("production") else f"{pair_id}-{profile_id}"
+                ),
                 "pair_id": pair_id,
                 "sync": first_profile_sync if index == 0 else False,
             }
@@ -1135,12 +1076,15 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
 
     benchmark = run_benchmark_key(variant, options.get("task_suite"))
     default_run_name = versioned_name(benchmark, variant["prefix"])
-    run_id = options.get("job_name") or (
-        f"{default_run_name}-{options['profile']}-{timestamp()}"
-    )
+    run_group = options.get("job_name")
+    if variant.get("production"):
+        run_group = run_group or f"{default_run_name}-{production_timestamp()}"
+        run_id = f"{run_group}-{options['profile']}"
+    else:
+        run_id = run_group or f"{default_run_name}-{options['profile']}-{timestamp()}"
     args = ["run", "harbor", "run"]
     if variant.get("production"):
-        run_production_variant(run_id, options, source, docs_bundle)
+        run_production_variant(run_id, options, docs_bundle)
         return
 
     if variant.get("job"):

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -15,7 +15,6 @@ from scripts.run_benchmark import (
     BenchmarkKey,
     apply_pair_id,
     apply_profile,
-    benchmark_provenance,
     daytona_base_image,
     finalize_config,
     main,
@@ -26,6 +25,7 @@ from scripts.run_benchmark import (
     render_job_config,
     run_benchmark_key,
     run_benchmark_variant,
+    run_production_variant,
     stage_filtered_config,
     stage_pinned_docs_task,
     uses_live_mcp_eval,
@@ -35,6 +35,10 @@ from scripts.run_benchmark import (
 
 def base_config() -> dict[str, Any]:
     return {"agents": [{"name": "oracle"}], "datasets": []}
+
+
+def production_model_config() -> dict[str, Any]:
+    return {"models": [{"agent": "claude-code", "model_name": "claude-haiku-4-5"}]}
 
 
 class RunBenchmarkTest(unittest.TestCase):
@@ -91,10 +95,10 @@ class RunBenchmarkTest(unittest.TestCase):
         self.assertIsNone(stage.call_args.args[2])
         run.assert_called_once()
 
-    def test_production_variant_accepts_explicit_mcp_profile(self) -> None:
+    def test_production_profile_appends_to_explicit_run_group(self) -> None:
         options = {
             "env_file": None,
-            "job_name": "production-mcp-test",
+            "job_name": "production-mcp",
             "profile": "mcp",
             "sync": False,
             "task_suite": "tempo",
@@ -111,10 +115,42 @@ class RunBenchmarkTest(unittest.TestCase):
             run_benchmark_variant("production-daytona", options)
 
         run_production.assert_called_once()
+        self.assertEqual(run_production.call_args.args[0], "production-mcp-mcp")
         run.assert_not_called()
 
-    def test_production_all_profile_runs_docs_and_mcp_jobs(self) -> None:
+    def test_production_single_profile_uses_timestamped_run_name(self) -> None:
+        options = {
+            "env_file": None,
+            "job_name": None,
+            "profile": "docs",
+            "sync": False,
+            "task_suite": "tempo",
+        }
         with (
+            patch("scripts.run_benchmark.load_env_file"),
+            patch("scripts.run_benchmark.preflight"),
+            patch("scripts.run_benchmark.preflight_mcp_target"),
+            patch("scripts.run_benchmark.docs_source", return_value={"mode": "public"}),
+            patch("scripts.run_benchmark.ensure_docs_bundle", return_value=None),
+            patch(
+                "scripts.run_benchmark.production_timestamp",
+                return_value="20260714T202823Z",
+            ),
+            patch("scripts.run_benchmark.run_production_variant") as run_production,
+        ):
+            run_benchmark_variant("production-daytona", options)
+
+        self.assertEqual(
+            run_production.call_args.args[0],
+            "tempo-bench-v1-production-20260714T202823Z-docs",
+        )
+
+    def test_production_profiles_share_one_timestamped_run_group(self) -> None:
+        with (
+            patch(
+                "scripts.run_benchmark.production_timestamp",
+                return_value="20260714T202823Z",
+            ),
             patch("scripts.run_benchmark.prepare_production_profiles") as prepare,
             patch("scripts.run_benchmark.run_benchmark_variant") as run_variant,
         ):
@@ -125,8 +161,6 @@ class RunBenchmarkTest(unittest.TestCase):
                     "all",
                     "--models-config",
                     "config/models.dev.yaml",
-                    "--job-name",
-                    "paired-run",
                 ]
             )
 
@@ -135,13 +169,15 @@ class RunBenchmarkTest(unittest.TestCase):
             invocation.args[1]["profile"]: invocation.args[1]
             for invocation in run_variant.call_args_list
         }
+        run_group = "tempo-bench-v1-production-20260714T202823Z"
         self.assertEqual(set(profiles), {"docs", "mcp"})
-        self.assertEqual(profiles["docs"]["job_name"], "paired-run-docs")
-        self.assertEqual(profiles["mcp"]["job_name"], "paired-run-mcp")
-        self.assertTrue(all(not options["sync"] for options in profiles.values()))
         self.assertTrue(
-            all(options["pair_id"] == "paired-run" for options in profiles.values())
+            all(options["job_name"] == run_group for options in profiles.values())
         )
+        self.assertTrue(
+            all(options["pair_id"] == run_group for options in profiles.values())
+        )
+        self.assertTrue(all(not options["sync"] for options in profiles.values()))
 
     def test_dev_and_production_model_configs_are_distinct(self) -> None:
         dev = parse_model_config("config/models.dev.yaml", None)
@@ -229,12 +265,6 @@ class RunBenchmarkTest(unittest.TestCase):
             ],
         )
 
-    def test_benchmark_provenance_uses_versioned_dataset_identity(self) -> None:
-        self.assertEqual(
-            benchmark_provenance("tempo"),
-            [{"id": "tempo-bench-v1", "dataset": "tempo/tempo-bench-v1"}],
-        )
-
     def test_run_names_resolve_from_catalog(self) -> None:
         self.assertEqual(
             versioned_name(BenchmarkKey.TEMPO, "oracle-local"),
@@ -242,6 +272,10 @@ class RunBenchmarkTest(unittest.TestCase):
         )
         self.assertEqual(
             run_benchmark_key({"benchmark": "tempo"}, "mpp"), BenchmarkKey.MPP
+        )
+        self.assertEqual(
+            run_benchmark_key({"benchmark": "tempo"}, "tempo-mcp"),
+            BenchmarkKey.TEMPO_MCP,
         )
         self.assertEqual(
             run_benchmark_key({"benchmark": "tempo"}, "all"), BenchmarkKey.TEMPO
@@ -257,26 +291,44 @@ class RunBenchmarkTest(unittest.TestCase):
 
         self.assertEqual(options["n_attempts"], "1")
 
-    def test_production_job_uses_requested_attempts(self) -> None:
-        model_config = {
-            "models": [
-                {
-                    "agent": "claude-code",
-                    "model_name": "claude-haiku-4-5",
-                    "n_concurrent": None,
-                    "concurrency_group": None,
-                }
-            ]
-        }
-
-        self.assertEqual(
-            production_job("test-run", model_config, {"n_attempts": "1"})["n_attempts"],
-            1,
+    def test_production_job_uses_native_name_and_requested_attempts(self) -> None:
+        run_id = "mpp-bench-v1-production-20260714T202823Z-docs"
+        job = production_job(
+            run_id,
+            production_model_config(),
+            {"n_attempts": "1", "task_suite": "mpp"},
         )
+        config = render_job_config(job, benchmark=None)
+
+        self.assertEqual(job["job_name"], run_id)
+        self.assertEqual(job["jobs_dir"], "jobs")
+        self.assertEqual(config["job_name"], run_id)
         self.assertEqual(
-            production_job("test-run", model_config, {})["n_attempts"],
+            Path(config["jobs_dir"]) / config["job_name"], Path("jobs") / run_id
+        )
+        self.assertEqual(job["n_attempts"], 1)
+        self.assertEqual(
+            production_job("test-run", production_model_config(), {})["n_attempts"],
             3,
         )
+        with (
+            patch(
+                "scripts.run_benchmark.parse_model_config",
+                return_value=production_model_config(),
+            ),
+            patch("scripts.run_benchmark.preflight_production_agents"),
+            patch(
+                "scripts.run_benchmark.stage_daytona_config", return_value="job.yaml"
+            ) as stage,
+            patch("scripts.run_benchmark.run_status", return_value=0),
+        ):
+            run_production_variant(run_id, {"task_suite": "mpp"}, None)
+
+        self.assertEqual(stage.call_args.args[0]["job_name"], run_id)
+
+    def test_production_job_rejects_run_id_paths(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "one path component"):
+            production_job("nested/run", production_model_config(), {})
 
     def test_job_config_scopes_api_keys_to_each_agent_provider(self) -> None:
         config = render_job_config(


### PR DESCRIPTION
## Summary

- give production jobs UTC, profile-qualified names under jobs/
- document native Harbor viewing, public upload, and authenticated download
- align result exports with the flat job layout and avoid guessing missing provenance

Production runs do not upload automatically. Downloaded jobs can be viewed locally; resuming them requires the original staged task cache.