### PR TITLE
Scope the Docs sidecar to docs.tempo.xyz

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -821,14 +821,14 @@ def generate_docs_tls_assets(environment_dir: Path) -> Path:
             "-out",
             str(leaf_csr),
             "-subj",
-            "/CN=tempo.xyz",
+            "/CN=docs.tempo.xyz",
         ]
     )
     extensions.write_text(
         "basicConstraints=critical,CA:FALSE\n"
         "keyUsage=critical,digitalSignature,keyEncipherment\n"
         "extendedKeyUsage=serverAuth\n"
-        "subjectAltName=DNS:docs.tempo.xyz,DNS:tempo.xyz\n"
+        "subjectAltName=DNS:docs.tempo.xyz\n"
     )
     run_openssl(
         [

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -433,12 +433,12 @@ class RunBenchmarkTest(unittest.TestCase):
                 text=True,
             )
             self.assertIn("DNS:docs.tempo.xyz", certificate.stdout)
-            self.assertIn("DNS:tempo.xyz", certificate.stdout)
+            self.assertNotIn("DNS:tempo.xyz", certificate.stdout)
             self.assertIn(
                 "- docs.tempo.xyz",
                 (environment_dir / "docker-compose.yaml").read_text(),
             )
-            self.assertIn(
+            self.assertNotIn(
                 "- tempo.xyz",
                 (environment_dir / "docker-compose.yaml").read_text(),
             )

--- a/shared/tempo/docker/compose/tempo-docs.yaml
+++ b/shared/tempo/docker/compose/tempo-docs.yaml
@@ -44,7 +44,6 @@ services:
       default:
         aliases:
           - docs.tempo.xyz
-          - tempo.xyz
     expose:
       - "80"
       - "443"


### PR DESCRIPTION
## What

- Route only `docs.tempo.xyz` to the pinned Docs sidecar.
- Issue the sidecar certificate only for that hostname.
- Assert that the apex `tempo.xyz` alias and SAN stay absent.

## Why only this host

Publicly, `docs.tempo.xyz` redirects into the `tempo.xyz/developers` tree. Inside the benchmark, Docker resolves `docs.tempo.xyz` directly to the sidecar, so that public redirect is never involved; the sidecar already maps `/`, `/docs`, and `/developers/docs` to the pinned bundle.

A Docker network alias is hostname-wide, not path-scoped. Keeping `tempo.xyz` would also capture unrelated API and blog requests. In the audited jobs, `/developers/api/faucet` alone hit the sidecar 15 and 29 times, and that route is not part of the pinned docs bundle.

## Checks

- `npm run check`
- `npm run check:dataset`
- `npm run check:generated`
