### PR TITLE
Gate Tempo rewards on functional correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Harbor terms used throughout this repository:
   and the verifier accepts a correct submission. It is not shown to agents.
 - **Verifier** — the independent test script under `tests/` that checks the
   submission programmatically and writes the Harbor reward. Correctness must
-  be deterministic; RewardKit quality checks are diagnostic signals layered on
-  top, never a substitute.
+  be deterministic. Where RewardKit quality contributes to a reward, it is
+  gated by correctness and remains a separately reported score.
 - **Dataset** — a versioned collection of tasks; each suite here is one
   dataset (e.g. `tempo/tempo-bench-v1`) with a checked-in generated manifest
   (`dataset.toml`). A dataset major is an immutable evaluation contract.

--- a/scripts/tempo_reward_schema_test.py
+++ b/scripts/tempo_reward_schema_test.py
@@ -9,20 +9,82 @@ import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "shared" / "global" / "rewardkit-lib"))
+
+from tempo_bench_rewardkit.common.tempo_reward import compose_reward  # noqa: E402
+
 ZERO_REWARD = {"correctness": 0, "quality": 0, "reward": 0}
 
 
 class RewardSchemaTest(unittest.TestCase):
-    def test_every_tempo_gated_failure_emits_the_complete_reward_schema(
-        self,
-    ) -> None:
+    def test_every_tempo_verifier_uses_the_shared_wrapper(self) -> None:
         scripts = sorted(ROOT.glob("tasks/tempo-v1/*/tests/test.sh"))
-        self.assertTrue(scripts)
+        self.assertEqual(len(scripts), 9)
+        contents = {script.read_text() for script in scripts}
+        self.assertEqual(len(contents), 1)
+        wrapper = contents.pop()
+        self.assertLessEqual(len(wrapper.splitlines()), 9)
+        self.assertIn("tempo_bench_rewardkit.tempo.verifier", wrapper)
 
-        for script in scripts:
-            for failure in ("workspace", "verifier", "rewardkit"):
-                with self.subTest(task=script.parents[1].name, failure=failure):
-                    self._assert_tempo_gated_failure(script, failure)
+    def test_tempo_reward_is_correctness_gated_and_evenly_weighted(self) -> None:
+        for quality, expected in ((0, 0.5), (0.6, 0.8), (1, 1)):
+            with self.subTest(quality=quality):
+                self.assertEqual(
+                    compose_reward(
+                        {"correctness": 1, "quality": quality, "reward": 0.123}
+                    ),
+                    {"correctness": 1, "quality": quality, "reward": expected},
+                )
+        self.assertEqual(
+            compose_reward({"correctness": 0.75, "quality": 1}), ZERO_REWARD
+        )
+        with self.assertRaises(ValueError):
+            compose_reward({"correctness": 1, "reward": 1})
+
+    def test_tempo_functional_failure_emits_zero(self) -> None:
+        result, reward, _ = self._run_tempo(
+            'printf \'{"reward":0}\\n\' > "$TEMPO_BENCH_LOG_DIR/'
+            'tempo-bench-scores.json"\nexit 1\n'
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(reward, ZERO_REWARD)
+
+    def test_tempo_verifier_error_does_not_emit_a_reward(self) -> None:
+        result, reward, _ = self._run_tempo("exit 1\n")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIsNone(reward)
+
+    def test_tempo_static_failure_skips_quality(self) -> None:
+        quality_check = (
+            "import os\nfrom pathlib import Path\nimport rewardkit as rk\n"
+            "@rk.criterion\ndef quality(workspace: Path) -> float:\n"
+            '    Path(os.environ["TEMPO_TEST_QUALITY_MARKER"]).touch()\n'
+            "    return 1\n"
+        )
+        result, reward, quality_ran = self._run_tempo(
+            "exit 0\n", correctness=0, quality_check=quality_check
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(reward, ZERO_REWARD)
+        self.assertFalse(quality_ran)
+
+    def test_tempo_missing_quality_config_is_a_verifier_error(self) -> None:
+        result, reward, _ = self._run_tempo(
+            "exit 0\n",
+            correctness=1,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIsNone(reward)
+        self.assertIn("Missing quality configuration", result.stderr)
+
+    def test_tempo_quality_config_failure_is_a_verifier_error(self) -> None:
+        result, reward, _ = self._run_tempo(
+            "exit 0\n",
+            correctness=1,
+            quality_config="[judge\n",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIsNone(reward)
 
     def test_every_mpp_missing_rewardkit_failure_emits_the_complete_reward_schema(
         self,
@@ -106,45 +168,67 @@ class RewardSchemaTest(unittest.TestCase):
                 {"correctness": 0.75, "quality": 0.6, "reward": 1},
             )
 
-    def _assert_tempo_gated_failure(self, script: Path, failure: str) -> None:
+    def _run_tempo(
+        self,
+        verifier_body: str,
+        *,
+        correctness: float | None = None,
+        quality_config: str | None = None,
+        quality_check: str | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], dict[str, float] | None, bool]:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
             workspace = temporary / "workspace"
             tests = temporary / "tests"
             verifier = tests / "correctness" / "verify-tempo.sh"
             logs = temporary / "logs"
+            marker = temporary / "quality-ran"
 
+            workspace.mkdir()
             tests.joinpath("correctness").mkdir(parents=True)
-            verifier.write_text(
-                "#!/usr/bin/env bash\nexit "
-                + ("1" if failure == "verifier" else "0")
-                + "\n"
-            )
-            if failure != "workspace":
-                workspace.mkdir()
+            verifier.write_text(f"#!/usr/bin/env bash\n{verifier_body}")
+            if correctness is not None:
+                tests.joinpath("correctness", "criteria.py").write_text(
+                    "from pathlib import Path\nimport rewardkit as rk\n"
+                    "@rk.criterion\n"
+                    "def static_gate(workspace: Path) -> float:\n"
+                    f"    return {correctness!r}\n"
+                )
+            if quality_config is not None or quality_check is not None:
+                tests.joinpath("quality").mkdir()
+            if quality_config is not None:
+                tests.joinpath("quality", "reward.toml").write_text(quality_config)
+            if quality_check is not None:
+                tests.joinpath("quality", "check.py").write_text(quality_check)
 
             env = os.environ.copy()
             env.pop("ANTHROPIC_API_KEY", None)
+            env.pop("REWARDKIT_JUDGE", None)
             env.update(
                 {
+                    "PYTHONPATH": str(ROOT / "shared/global/rewardkit-lib"),
                     "TEMPO_BENCH_LOG_DIR": str(logs),
                     "TEMPO_BENCH_TESTS_DIR": str(tests),
                     "TEMPO_BENCH_WORKSPACE": str(workspace),
-                    "tempo_bench_rewardkit_VENV": str(temporary / "missing-venv"),
+                    "TEMPO_TEST_QUALITY_MARKER": str(marker),
+                    "tempo_bench_rewardkit_VENV": sys.prefix,
                 }
             )
             result = subprocess.run(
-                ["bash", str(script)],
+                [
+                    "bash",
+                    str(sorted(ROOT.glob("tasks/tempo-v1/*/tests/test.sh"))[0]),
+                ],
                 check=False,
                 capture_output=True,
                 env=env,
                 text=True,
             )
-
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(
-                json.loads((logs / "reward.json").read_text()),
-                ZERO_REWARD,
+            reward_path = logs / "reward.json"
+            return (
+                result,
+                json.loads(reward_path.read_text()) if reward_path.is_file() else None,
+                marker.is_file(),
             )
 
     def _assert_mpp_missing_rewardkit_failure(self, script: Path) -> None:

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/common/tempo_reward.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/common/tempo_reward.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+ZERO_REWARD = {"correctness": 0, "quality": 0, "reward": 0}
+
+
+def _score(output: dict[str, Any], key: str) -> float:
+    value = output.get(key)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(value)
+        or not 0 <= value <= 1
+    ):
+        raise ValueError(f"RewardKit output must contain a finite {key} from 0 to 1")
+    return round(float(value), 4)
+
+
+def compose_reward(
+    rewardkit_output: dict[str, Any],
+) -> dict[str, float | int]:
+    correctness = _score(rewardkit_output, "correctness")
+    if correctness != 1:
+        return dict(ZERO_REWARD)
+
+    # RewardKit's aggregate `reward` is intentionally ignored because it also
+    # includes the correctness dimension and would count it twice here.
+    quality = _score(rewardkit_output, "quality")
+    return {
+        "correctness": 1,
+        "quality": quality,
+        "reward": round(0.5 + 0.5 * quality, 4),
+    }
+
+
+def write_reward(
+    rewardkit_path: Path,
+    output_path: Path,
+) -> None:
+    rewardkit_output = json.loads(rewardkit_path.read_text())
+    if not isinstance(rewardkit_output, dict):
+        raise ValueError("RewardKit output must be a JSON object")
+    output_path.write_text(f"{json.dumps(compose_reward(rewardkit_output))}\n")
+
+
+def write_correctness_gate(rewardkit_path: Path, output_path: Path) -> None:
+    rewardkit_output = json.loads(rewardkit_path.read_text())
+    if not isinstance(rewardkit_output, dict):
+        raise ValueError("RewardKit output must be a JSON object")
+    output_path.unlink(missing_ok=True)
+    if _score(rewardkit_output, "correctness") != 1:
+        output_path.write_text(f"{json.dumps(ZERO_REWARD)}\n")

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/tempo/__init__.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/tempo/__init__.py
@@ -1,0 +1,1 @@
+"""Tempo-v1 verifier orchestration."""

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/tempo/verifier.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/tempo/verifier.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from tempo_bench_rewardkit.common.tempo_reward import (
+    ZERO_REWARD,
+    write_correctness_gate,
+    write_reward,
+)
+
+
+def _run_rewardkit(tests: Path, workspace: Path, output: Path) -> bool:
+    return (
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "rewardkit",
+                str(tests),
+                "--workspace",
+                str(workspace),
+                "--output",
+                str(output),
+            ],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def run() -> int:
+    log_dir = Path(os.environ.get("TEMPO_BENCH_LOG_DIR", "/logs/verifier"))
+    workspace = Path(os.environ.get("TEMPO_BENCH_WORKSPACE", "/app"))
+    tests = Path(os.environ.get("TEMPO_BENCH_TESTS_DIR", "/tests"))
+    reward = log_dir / "reward.json"
+    details = log_dir / "reward-details.json"
+    correctness_output = log_dir / "correctness-reward.json"
+    rewardkit_output = log_dir / "rewardkit-output.json"
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    for path in (reward, details, correctness_output, rewardkit_output):
+        path.unlink(missing_ok=True)
+
+    def verifier_error(message: str) -> int:
+        print(message, file=sys.stderr)
+        for path in (reward, details, correctness_output, rewardkit_output):
+            path.unlink(missing_ok=True)
+        return 1
+
+    with (
+        tempfile.TemporaryDirectory() as workspace_dir,
+        tempfile.TemporaryDirectory() as correctness_dir,
+    ):
+        rewardkit_workspace = Path(workspace_dir)
+        try:
+            shutil.copytree(workspace, rewardkit_workspace, dirs_exist_ok=True)
+        except OSError as error:
+            return verifier_error(f"Could not copy verifier workspace: {error}")
+
+        verifier_result = subprocess.run(
+            ["bash", str(tests / "correctness" / "verify-tempo.sh")], check=False
+        )
+        if verifier_result.returncode != 0:
+            if (log_dir / "tempo-bench-scores.json").is_file():
+                reward.write_text(f"{json.dumps(ZERO_REWARD)}\n")
+                return 0
+            return verifier_result.returncode or 1
+
+        correctness_tests = Path(correctness_dir) / "correctness"
+        try:
+            shutil.copytree(tests / "correctness", correctness_tests)
+        except OSError as error:
+            return verifier_error(f"Could not stage correctness tests: {error}")
+        if not _run_rewardkit(
+            Path(correctness_dir), rewardkit_workspace, correctness_output
+        ):
+            return verifier_error("RewardKit correctness checks failed to run.")
+        try:
+            write_correctness_gate(correctness_output, reward)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            return verifier_error(f"Invalid RewardKit correctness output: {error}")
+        correctness_output.unlink(missing_ok=True)
+        if reward.is_file():
+            return 0
+
+        quality_config = tests / "quality" / "reward.toml"
+        if not quality_config.is_file():
+            return verifier_error(f"Missing quality configuration: {quality_config}")
+        if not _run_rewardkit(tests, rewardkit_workspace, rewardkit_output):
+            return verifier_error("RewardKit quality grading failed to run.")
+        try:
+            write_reward(rewardkit_output, reward)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            return verifier_error(f"Invalid RewardKit output: {error}")
+        rewardkit_output.unlink(missing_ok=True)
+        return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -38,10 +38,14 @@ tasks/tempo-v1/<task>/
     └── quality/             # RewardKit quality checks and weights
 ```
 
-The task test script first runs the independent onchain verifier. A failed
-onchain check writes a zero Harbor reward and skips RewardKit. On success,
-RewardKit aggregates the available static and LLM quality criteria into the
-primary reward.
+The task test script first runs the independent onchain verifier. A scored
+onchain failure writes a zero Harbor reward and skips RewardKit. On success,
+RewardKit's static correctness criteria run first and must all pass or the
+complete reward is zero without invoking the quality judge. The published
+`correctness` is therefore binary. Passing submissions receive 50% correctness
+plus 50% of RewardKit's aggregate `quality` score, which includes the LLM rubric
+and trajectory diagnostics. Missing quality configuration or a RewardKit
+execution/configuration error produces no reward.
 
 The benchmark job injects access rather than changing task source:
 
@@ -106,6 +110,6 @@ Edit task directories directly. `npm run sync` does not rewrite Tempo task
 files; it only refreshes shared MPP assets and generated job configurations.
 
 The shared Tempo verifier is installed in the base image and selects the case
-named by `TEMPO_BENCH_CASE`. Keep task-specific correctness criteria and
-onchain checks in the task directory. Refresh `dataset.toml` after a task
-change; the manifest is a required checked-in artifact.
+named by `TEMPO_BENCH_CASE`. Keep task-specific correctness criteria and onchain
+checks in the task directory. Refresh `dataset.toml` after a task change; the
+manifest is a required checked-in artifact.

--- a/tasks/tempo-v1/access-key-transfer/tests/test.sh
+++ b/tasks/tempo-v1/access-key-transfer/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,37 +11,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo-v1/access-key-transfer"
-digest = "sha256:e3396168c03df46693e39b6793606cbae1b2311dab7ed6e2505d949af3517b0b"
+digest = "sha256:359f3a95a22ff757ed460b374b241d7c65ad4da4afe6e4338220e1b260476ac6"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:df8f063c771a2189a4ef577d47bb95bdf421722f23cb14d5d308f60fdc53f0a2"
+digest = "sha256:3a15318b5a8a4caea7059dfdb36fbe40b3150e191260e71fb87c397652c48bd9"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:b5213b13fb8bc513f85eb70fd09273f4f4a022ed61bed66d7d0973179c5dd1df"
+digest = "sha256:529ec0d8a1ee49ad9f8399f2b5091a8edff38076d52af321bd95a6c40b9cf530"
 
 [[tasks]]
 name = "tempo-v1/receive-policy-held-transfer"
-digest = "sha256:cfc6b92e0c1559d71227c3150735c4f3265145188afc96162f878a28a848feb1"
+digest = "sha256:895ed9685a9296556befa6e26b6570d96f87c68a85b4212c3e30d52a2f2d1696"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:9866d99daae9498dd4b2b8132d91def467d11df21ea9cb50cdb89c6f34506a44"
+digest = "sha256:05353a30f7a19102ed7dd93d3db5c683dd18153928925414738c1a13ed7eb6ab"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:e89df04fde5f0acf835728e060f9a1006503a749bb8eec2817b41c8c4310d2e0"
+digest = "sha256:b341a90df2b7b4ef86fbf8475b27d17023838053915a07587afb8e18a6dc5ba8"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:74518142b0acce2fb9bfae1d3c6ed33aa9a10800166f139a098c4d373c78b22d"
+digest = "sha256:4930665f5a249af26248f55ec749d44aaaff382379de883dbd7f7818e431d371"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:f4994f0718f6c939cfc4ac087a9df7b6a83f4766ee39003220661c801c50fa66"
+digest = "sha256:f5cdd73140f6fcd6e002c8b82ef611d1d44cdbdeb741aab6555fe75bf9fdaf08"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:06516ce44694d49fee2501853ce51c1f1defc6d04c0a818be2d41047333dc167"
+digest = "sha256:919dda1cb50960c7d43b93285f4de1b22ddd228e3a3abbf87c4998d0cd8a09bf"
 

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/receive-policy-held-transfer/tests/test.sh
+++ b/tasks/tempo-v1/receive-policy-held-transfer/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/set-fee-token/tests/test.sh
+++ b/tasks/tempo-v1/set-fee-token/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/transfer-batched/tests/test.sh
+++ b/tasks/tempo-v1/transfer-batched/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier

--- a/tasks/tempo-v1/transfer-with-memo/tests/test.sh
+++ b/tasks/tempo-v1/transfer-with-memo/tests/test.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
-set -u -o pipefail
+set -u
 
-LOG_DIR="${TEMPO_BENCH_LOG_DIR:-/logs/verifier}"
-WORKSPACE="${TEMPO_BENCH_WORKSPACE:-/app}"
-TESTS_DIR="${TEMPO_BENCH_TESTS_DIR:-/tests}"
 REWARDKIT_PYTHON="${tempo_bench_rewardkit_VENV:-/opt/tempo-bench-rewardkit-venv}/bin/python"
-REWARDKIT_TESTS_DIR="$TESTS_DIR"
-REWARDKIT_WORKSPACE="$(mktemp -d)"
 
-mkdir -p "$LOG_DIR"
-rm -f "$LOG_DIR/reward.json" "$LOG_DIR/reward-details.json"
-trap 'rm -rf "$REWARDKIT_WORKSPACE"' EXIT
-
-write_zero_reward() {
-  printf '{"correctness":0,"quality":0,"reward":0}\n' > "$LOG_DIR/reward.json"
-}
-
-if ! cp -R "$WORKSPACE/." "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-  exit 0
+if [ ! -x "$REWARDKIT_PYTHON" ]; then
+  exit 1
 fi
-
-if ! bash "$TESTS_DIR/correctness/verify-tempo.sh"; then
-  write_zero_reward
-  exit 0
-fi
-
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$TESTS_DIR/quality/reward.toml" ]; then
-  REWARDKIT_TESTS_DIR="$(mktemp -d)"
-  cp -R "$TESTS_DIR/." "$REWARDKIT_TESTS_DIR"
-  rm -f "$REWARDKIT_TESTS_DIR/quality/reward.toml"
-  printf '%s\n' 'Skipping LLM quality reward because ANTHROPIC_API_KEY is not set.' \
-    > "$LOG_DIR/quality-skipped.txt"
-fi
-
-if [ ! -x "$REWARDKIT_PYTHON" ] || ! "$REWARDKIT_PYTHON" -m rewardkit \
-  "$REWARDKIT_TESTS_DIR" --workspace "$REWARDKIT_WORKSPACE"; then
-  write_zero_reward
-fi
+exec "$REWARDKIT_PYTHON" -m tempo_bench_rewardkit.tempo.verifier


### PR DESCRIPTION
## What

- Run Tempo v1 quality grading only after the onchain verifier and RewardKit correctness checks pass.
- Publish binary correctness: any functional or static correctness failure emits `{correctness: 0, quality: 0, reward: 0}`.
- For correct submissions, preserve RewardKit’s native qualitative aggregation and publish `reward = 0.5 + 0.5 * quality`.
- Share the orchestration behind nine thin task wrappers while preserving RewardKit grader details and existing trajectory diagnostics.
- Keep verifier and RewardKit execution/configuration errors distinct from scored failures.

This revision intentionally leaves result exporting and Harbor pass@k behavior unchanged.

## Checks

- `uv run python -m unittest scripts.tempo_reward_schema_test`
- `npm run check`
- `npm run check:generated`
- `npm run check:dataset`
