### PR TITLE
Accept supported Tempo imports and documented defaults

### DIFF
--- a/scripts/rewardkit_criteria_test.py
+++ b/scripts/rewardkit_criteria_test.py
@@ -28,6 +28,35 @@ class ViemTempoCriterionTests(unittest.TestCase):
 
         self.assertTrue(criteria._uses_viem_tempo(workspace))
 
+    def test_accepts_supported_tempo_modules_in_all_import_forms(self) -> None:
+        for module in (
+            "viem/tempo",
+            "viem/tempo/actions",
+            "viem/tempo/chains",
+            "viem/tempo/zones",
+        ):
+            for source in (
+                f'import {{ value }} from "{module}";\n',
+                f'const tempo = await import("{module}");\n',
+                f'const tempo = require("{module}");\n',
+            ):
+                with self.subTest(module=module, source=source):
+                    workspace = self.workspace(source)
+
+                    self.assertTrue(criteria._uses_viem_tempo(workspace))
+
+    def test_rejects_unsupported_tempo_module_prefixes(self) -> None:
+        for module in ("viem/tempography", "viem/tempo/not-real"):
+            for source in (
+                f'import {{ value }} from "{module}";\n',
+                f'const tempo = await import("{module}");\n',
+                f'const tempo = require("{module}");\n',
+            ):
+                with self.subTest(module=module, source=source):
+                    workspace = self.workspace(source)
+
+                    self.assertFalse(criteria._uses_viem_tempo(workspace))
+
     def test_rejects_missing_tempo_import(self) -> None:
         workspace = self.workspace('import { createPublicClient } from "viem";\n')
 

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/criteria.py
@@ -275,6 +275,9 @@ def tempo_rejects_other_blockchains(workspace: Path) -> bool:
     return all(result["passed"] for result in results)
 
 
+VIEM_TEMPO_MODULE_PATTERN = r"viem/tempo(?:/(?:actions|chains|zones))?"
+
+
 def _uses_viem_tempo(workspace: Path) -> bool:
     patterns = [
         {
@@ -285,9 +288,9 @@ def _uses_viem_tempo(workspace: Path) -> bool:
         {
             "name": "source_imports_viem_tempo",
             "pattern": (
-                r"from\s+['\"]viem/tempo(?:/chains)?['\"]|"
-                r"require\(\s*['\"]viem/tempo|"
-                r"import\(\s*['\"]viem/tempo"
+                rf"from\s+['\"]{VIEM_TEMPO_MODULE_PATTERN}['\"]|"
+                rf"require\(\s*['\"]{VIEM_TEMPO_MODULE_PATTERN}['\"]|"
+                rf"import\(\s*['\"]{VIEM_TEMPO_MODULE_PATTERN}['\"]"
             ),
         },
     ]

--- a/tasks/tempo-v1/access-key-transfer/README.md
+++ b/tasks/tempo-v1/access-key-transfer/README.md
@@ -14,7 +14,7 @@ account and send a stablecoin payment signed by that key.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including:
   - The reported payer authorizes the reported access key.
   - The reported access key signs the transfer transaction for the payer.

--- a/tasks/tempo-v1/access-key-transfer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/access-key-transfer/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/create-stablecoin-with-policy/README.md
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/README.md
@@ -14,5 +14,5 @@ policy, and link the policy to the new token.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including onchain evidence of the reported token, policy account update, and policy-to-token link.

--- a/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
+++ b/tasks/tempo-v1/create-stablecoin-with-policy/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/dataset.toml
+++ b/tasks/tempo-v1/dataset.toml
@@ -11,37 +11,37 @@ name = "Tempo Labs"
 
 [[tasks]]
 name = "tempo-v1/access-key-transfer"
-digest = "sha256:359f3a95a22ff757ed460b374b241d7c65ad4da4afe6e4338220e1b260476ac6"
+digest = "sha256:0174045c0cdce1c0228476a520aaa7fcded589eac79d206703ce518a65342ef6"
 
 [[tasks]]
 name = "tempo-v1/create-stablecoin-with-policy"
-digest = "sha256:3a15318b5a8a4caea7059dfdb36fbe40b3150e191260e71fb87c397652c48bd9"
+digest = "sha256:618fad772ff6c9b1439c5fefb954dd370116d4e3dbcee3b2b8da3048f1681ed0"
 
 [[tasks]]
 name = "tempo-v1/faucet-funded-transfer"
-digest = "sha256:529ec0d8a1ee49ad9f8399f2b5091a8edff38076d52af321bd95a6c40b9cf530"
+digest = "sha256:001f2235806ade29ab8fb980b61526bf69c685c2ebb03d3eb7e21e6cf5ce9a8e"
 
 [[tasks]]
 name = "tempo-v1/receive-policy-held-transfer"
-digest = "sha256:895ed9685a9296556befa6e26b6570d96f87c68a85b4212c3e30d52a2f2d1696"
+digest = "sha256:77fe83ed6c464cba760f27939b4c13d69a5cba19a8d970198cbeadc10c47c6ef"
 
 [[tasks]]
 name = "tempo-v1/set-fee-token"
-digest = "sha256:05353a30f7a19102ed7dd93d3db5c683dd18153928925414738c1a13ed7eb6ab"
+digest = "sha256:3187816dd0f44b1d5abc7ade6d124f45a47a3412d160c011199ecd07de3efe70"
 
 [[tasks]]
 name = "tempo-v1/stablecoin-dex-swap"
-digest = "sha256:b341a90df2b7b4ef86fbf8475b27d17023838053915a07587afb8e18a6dc5ba8"
+digest = "sha256:c8a19123f8b16543831cb7882f57fe8f72e149262c6e42af08d5f5be6415e389"
 
 [[tasks]]
 name = "tempo-v1/transfer-batched"
-digest = "sha256:4930665f5a249af26248f55ec749d44aaaff382379de883dbd7f7818e431d371"
+digest = "sha256:02896870edff001c5e77722e95fdd2ec55cd35263a8d9c2d06c058851f5eba2a"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo"
-digest = "sha256:f5cdd73140f6fcd6e002c8b82ef611d1d44cdbdeb741aab6555fe75bf9fdaf08"
+digest = "sha256:e5aa9850517181c7a010cebaef7122b40973bde30d4b2062f0cc154dfe8a10e0"
 
 [[tasks]]
 name = "tempo-v1/transfer-with-memo-fee-payer"
-digest = "sha256:919dda1cb50960c7d43b93285f4de1b22ddd228e3a3abbf87c4998d0cd8a09bf"
+digest = "sha256:66b49675c5921c55fb445e6d205e6f8c16fa2b0b1c2566ee99aad55b8ac082a7"
 

--- a/tasks/tempo-v1/faucet-funded-transfer/README.md
+++ b/tasks/tempo-v1/faucet-funded-transfer/README.md
@@ -14,5 +14,5 @@ send a stablecoin transfer from that funded wallet.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including onchain evidence that the faucet funded the reported payer before its configured transfer.

--- a/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/faucet-funded-transfer/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/receive-policy-held-transfer/README.md
+++ b/tasks/tempo-v1/receive-policy-held-transfer/README.md
@@ -14,6 +14,6 @@ receive policy and send a stablecoin transfer that the policy blocks and holds.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including the required policy, transaction order,
   blocked transfer, and exact balance held by the receive-policy guard.

--- a/tasks/tempo-v1/receive-policy-held-transfer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/receive-policy-held-transfer/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and provided task values, creates fresh payer and recipient accounts, and funds them without hard-coding secrets or account addresses."
+description = "The submission uses the Tempo testnet and environment-provided values, creates and funds fresh payer and recipient accounts, and does not hard-code private keys or account addresses. Prompt-documented defaults are allowed."
 
 [[criterion]]
 name = "uses_receive_policy_primitives_correctly"

--- a/tasks/tempo-v1/set-fee-token/README.md
+++ b/tasks/tempo-v1/set-fee-token/README.md
@@ -14,5 +14,5 @@ through the Fee Manager.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including onchain confirmation that the reported payer's default fee token matches the configured token.

--- a/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
+++ b/tasks/tempo-v1/set-fee-token/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/stablecoin-dex-swap/README.md
+++ b/tasks/tempo-v1/stablecoin-dex-swap/README.md
@@ -14,5 +14,5 @@ on testnet.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including an onchain DEX fill for the reported taker and configured input amount, with the configured input token spent in that transaction.

--- a/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
+++ b/tasks/tempo-v1/stablecoin-dex-swap/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/transfer-batched/README.md
+++ b/tasks/tempo-v1/transfer-batched/README.md
@@ -13,7 +13,7 @@ Build a TypeScript integration that pays every recipient in a supplied list the 
 ## Verification
 
 - General file structure: `/app/package.json` and `/app/src/index.ts` are checked.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including:
   - Every configured recipient receives the configured stablecoin amount.
   - All transfers originate from the reported payer.

--- a/tasks/tempo-v1/transfer-batched/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-batched/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/README.md
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/README.md
@@ -14,5 +14,5 @@ delegating transaction fees to a separate fee payer.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including a memo transfer with the configured amount and a sponsored Tempo envelope for the reported fee payer and configured fee token.

--- a/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo-fee-payer/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"

--- a/tasks/tempo-v1/transfer-with-memo/README.md
+++ b/tasks/tempo-v1/transfer-with-memo/README.md
@@ -14,5 +14,5 @@ the required memo attached.
 ## Verification
 
 - General file structure: a runnable `/app` TypeScript project with `src/index.ts` and an `npm run eval` entry point.
-- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
+- Usage of proper Tempo libraries: the project must depend on `viem` and import `viem/tempo`, `viem/tempo/actions`, `viem/tempo/chains`, or `viem/tempo/zones`; other blockchain SDKs such as Solana, Sui, `ethers`, and `web3` are rejected.
 - Correctness of the script, including a TransferWithMemo event with the reported payer, recipient, amount, and memo.

--- a/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
+++ b/tasks/tempo-v1/transfer-with-memo/tests/quality/reward.toml
@@ -8,7 +8,7 @@ timeout = 300
 name = "uses_tempo_testnet_appropriately"
 type = "likert"
 points = 5
-description = "The submission uses the Tempo testnet and the provided task values without hard-coding task-specific secrets, recipients, amounts, or token addresses."
+description = "The submission uses the Tempo testnet and reads task values from the environment when provided. Prompt-documented defaults are allowed; private keys and unspecified task values must not be hard-coded."
 
 [[criterion]]
 name = "uses_tempo_primitives_correctly"


### PR DESCRIPTION
## What

- Accept the supported `viem/tempo` entry points: the root module plus `/actions`, `/chains`, and `/zones`.
- Apply the same exact allowlist to static imports, dynamic imports, and `require()`, without accepting prefix collisions or unknown subpaths.
- Clarify the nine Tempo v1 quality rubrics: environment values take precedence when supplied, prompt-documented defaults are valid, and private keys or unspecified task values must not be hard-coded.
- Keep the verifier documentation aligned with the accepted import paths.

This revision does not add task-specific Action parsing or enforcement.

## Checks

- `uv run python -m unittest scripts.rewardkit_criteria_test`
- `npm run check`
- `npm run check:generated`
- `npm run check:dataset`
