### PR TITLE
fix: scope pinned docs proxy

### DIFF
--- a/scripts/prepare_docs_bundle.py
+++ b/scripts/prepare_docs_bundle.py
@@ -22,6 +22,8 @@ LLMS_FEEDBACK_NOTICE = (
     "or `client`.\n"
 )
 
+BUNDLE_SCHEMA_VERSION = 2
+
 # Rewrite only rendered documentation links; root-host APIs such as the faucet
 # must continue to resolve to Tempo rather than the pinned docs sidecar.
 CANONICAL_DOCS_URL_PATTERN = re.compile(
@@ -90,7 +92,8 @@ def is_prepared(lock: dict[str, Any]) -> bool:
     try:
         manifest = json.loads(manifest_path(lock).read_text())
         return (
-            manifest.get("repo") == lock["repo"]
+            manifest.get("schemaVersion") == BUNDLE_SCHEMA_VERSION
+            and manifest.get("repo") == lock["repo"]
             and manifest.get("sha") == lock["sha"]
             and manifest.get("docCount", 0) > 0
             and (public_dir(lock) / "developers" / "llms.txt").exists()
@@ -275,7 +278,7 @@ def write_manifest(
     output_root: Path,
 ) -> None:
     manifest = {
-        "schemaVersion": 1,
+        "schemaVersion": BUNDLE_SCHEMA_VERSION,
         "repo": lock["repo"],
         "sha": lock["sha"],
         "docCount": len(docs),

--- a/scripts/prepare_docs_bundle.py
+++ b/scripts/prepare_docs_bundle.py
@@ -22,6 +22,15 @@ LLMS_FEEDBACK_NOTICE = (
     "or `client`.\n"
 )
 
+# Rewrite only rendered documentation links; root-host APIs such as the faucet
+# must continue to resolve to Tempo rather than the pinned docs sidecar.
+CANONICAL_DOCS_URL_PATTERN = re.compile(
+    r"https://tempo\.xyz/developers/(?:"
+    r"docs(?=[/?#\"'<\s)\]}]|$)|"
+    r"llms(?:-full)?\.txt(?=[/?#\"'<\s)\]}]|$)"
+    r")"
+)
+
 
 def read_lock() -> dict[str, Any]:
     lock = json.loads(LOCK_PATH.read_text())
@@ -164,6 +173,15 @@ def description_from(content: str) -> str:
     return parse_frontmatter(content).get("description", "").strip()
 
 
+def rewrite_canonical_docs_urls(content: str) -> str:
+    return CANONICAL_DOCS_URL_PATTERN.sub(
+        lambda match: match.group().replace(
+            "https://tempo.xyz", "https://docs.tempo.xyz"
+        ),
+        content,
+    )
+
+
 def clean_markdown(content: str, doc: dict[str, str]) -> str:
     without_frontmatter = re.sub(r"^---\n[\s\S]*?\n---\n*", "", content)
     cleaned_lines: list[str] = []
@@ -175,6 +193,7 @@ def clean_markdown(content: str, doc: dict[str, str]) -> str:
         cleaned_lines.append(line)
 
     markdown = re.sub(r"\n{3,}", "\n\n", "\n".join(cleaned_lines)).strip()
+    markdown = rewrite_canonical_docs_urls(markdown)
     if not markdown.startswith("# "):
         parts = [f"# {doc['title']}", "", doc.get("description", ""), "", markdown]
         markdown = "\n".join(part for part in parts if part)

--- a/scripts/prepare_docs_bundle_test.py
+++ b/scripts/prepare_docs_bundle_test.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.prepare_docs_bundle import rewrite_canonical_docs_urls
+
+
+class PrepareDocsBundleTest(unittest.TestCase):
+    def test_rewrites_only_canonical_documentation_urls(self) -> None:
+        cases = {
+            "https://tempo.xyz/developers/docs/quickstart/faucet": (
+                "https://docs.tempo.xyz/developers/docs/quickstart/faucet"
+            ),
+            "https://tempo.xyz/developers/llms.txt": (
+                "https://docs.tempo.xyz/developers/llms.txt"
+            ),
+            "https://tempo.xyz/developers/llms-full.txt": (
+                "https://docs.tempo.xyz/developers/llms-full.txt"
+            ),
+            "https://tempo.xyz/developers/api/faucet": (
+                "https://tempo.xyz/developers/api/faucet"
+            ),
+            "https://tempo.xyz/developers/docs-preview": (
+                "https://tempo.xyz/developers/docs-preview"
+            ),
+            "https://tempo.xyz/SKILL.md": "https://tempo.xyz/SKILL.md",
+        }
+
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                self.assertEqual(rewrite_canonical_docs_urls(source), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/prepare_docs_bundle_test.py
+++ b/scripts/prepare_docs_bundle_test.py
@@ -1,11 +1,45 @@
 from __future__ import annotations
 
+import json
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
+from scripts import prepare_docs_bundle
 from scripts.prepare_docs_bundle import rewrite_canonical_docs_urls
 
 
 class PrepareDocsBundleTest(unittest.TestCase):
+    def test_prepared_bundle_requires_current_schema(self) -> None:
+        lock = {"repo": "https://example.test/docs.git", "sha": "docs123"}
+
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.object(prepare_docs_bundle, "CACHE_ROOT", Path(directory)),
+        ):
+            public_dir = prepare_docs_bundle.public_dir(lock)
+            public_dir.joinpath("developers").mkdir(parents=True)
+            for name in ("llms.txt", "llms-full.txt", "index.html"):
+                public_dir.joinpath("developers", name).write_text("docs\n")
+
+            for schema_version, expected in (
+                (prepare_docs_bundle.BUNDLE_SCHEMA_VERSION - 1, False),
+                (prepare_docs_bundle.BUNDLE_SCHEMA_VERSION, True),
+            ):
+                with self.subTest(schema_version=schema_version):
+                    prepare_docs_bundle.manifest_path(lock).write_text(
+                        json.dumps(
+                            {
+                                "schemaVersion": schema_version,
+                                "repo": lock["repo"],
+                                "sha": lock["sha"],
+                                "docCount": 1,
+                            }
+                        )
+                    )
+                    self.assertEqual(prepare_docs_bundle.is_prepared(lock), expected)
+
     def test_rewrites_only_canonical_documentation_urls(self) -> None:
         cases = {
             "https://tempo.xyz/developers/docs/quickstart/faucet": (

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -821,14 +821,14 @@ def generate_docs_tls_assets(environment_dir: Path) -> Path:
             "-out",
             str(leaf_csr),
             "-subj",
-            "/CN=tempo.xyz",
+            "/CN=docs.tempo.xyz",
         ]
     )
     extensions.write_text(
         "basicConstraints=critical,CA:FALSE\n"
         "keyUsage=critical,digitalSignature,keyEncipherment\n"
         "extendedKeyUsage=serverAuth\n"
-        "subjectAltName=DNS:docs.tempo.xyz,DNS:tempo.xyz\n"
+        "subjectAltName=DNS:docs.tempo.xyz\n"
     )
     run_openssl(
         [

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -338,7 +338,7 @@ class RunBenchmarkTest(unittest.TestCase):
         stage_tasks.assert_called_once()
         redirect.assert_called_once()
 
-    def test_staged_pinned_docs_keep_the_public_hostname(self) -> None:
+    def test_staged_pinned_docs_proxy_only_docs_hostname(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             task_dir = Path(directory) / "transfer-with-memo"
             environment_dir = task_dir / "environment"
@@ -403,12 +403,12 @@ class RunBenchmarkTest(unittest.TestCase):
                 text=True,
             )
             self.assertIn("DNS:docs.tempo.xyz", certificate.stdout)
-            self.assertIn("DNS:tempo.xyz", certificate.stdout)
+            self.assertNotIn("DNS:tempo.xyz", certificate.stdout)
             self.assertIn(
                 "- docs.tempo.xyz",
                 (environment_dir / "docker-compose.yaml").read_text(),
             )
-            self.assertIn(
+            self.assertNotIn(
                 "- tempo.xyz",
                 (environment_dir / "docker-compose.yaml").read_text(),
             )

--- a/shared/tempo/docker/compose/tempo-docs.yaml
+++ b/shared/tempo/docker/compose/tempo-docs.yaml
@@ -44,7 +44,6 @@ services:
       default:
         aliases:
           - docs.tempo.xyz
-          - tempo.xyz
     expose:
       - "80"
       - "443"


### PR DESCRIPTION
## Motivation

Keep Tempo documentation pinned without intercepting root-domain endpoints such as the faucet.

## Summary

- Proxy only docs.tempo.xyz in pinned docs task containers.
- Rewrite canonical documentation and llms links to the pinned docs hostname.
- Rebuild cached docs bundles when bundle routing behavior changes.
- Cover scoped URL rewriting, cache invalidation, and generated proxy TLS configuration.

## Key design considerations

- tempo.xyz remains unproxied, so its homepage and API routes resolve to Tempo.
- A path-aware root-domain gateway is intentionally not added: Docker DNS aliases are host-scoped, and safely proxying only docs paths would require a separate upstream route to avoid a DNS loop.