### PR TITLE
docs: clarify OpenAI live documentation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,236 +1,158 @@
 # Tempo Evals
 
-Monorepo for tooling and evaluation harnesses targeting Tempo and related protocols.
-
-Powered by [Harbor](https://harborframework.com).
+Evaluation harnesses for agents building on Tempo and related protocols,
+powered by [Harbor](https://harborframework.com).
 
 ## Suites
 
-| Suite | Dataset | Version | What it measures | Suite guide |
-| --- | --- | --- | --- | --- |
-| Tempo integration | `tempo/tempo-bench-v1` | `v1` | TypeScript integrations that submit and verify Tempo testnet transactions | [tasks/tempo-v1](tasks/tempo-v1/README.md) |
-| Tempo MCP efficiency | `tempo/tempo-mcp-bench-v1` | `v1` | Live Tempo data investigations using direct documentation tools or `docs_code` | [tasks/tempo-mcp-v1](tasks/tempo-mcp-v1/README.md) |
-| MPP integration | `tempo/mpp-bench-v1` | `v1` | Paid HTTP and MCP services and clients on Tempo testnet | [tasks/mpp](tasks/mpp/README.md) |
+| Suite | Dataset | What it measures | Guide |
+| --- | --- | --- | --- |
+| Tempo integration | `tempo/tempo-bench-v1` | TypeScript integrations that submit and verify Tempo testnet transactions | [tasks/tempo-v1](tasks/tempo-v1/README.md) |
+| Tempo MCP efficiency | `tempo/tempo-mcp-bench-v1` | Live Tempo investigations using direct documentation tools or `docs_code` | [tasks/tempo-mcp-v1](tasks/tempo-mcp-v1/README.md) |
+| MPP integration | `tempo/mpp-bench-v1` | Paid HTTP and MCP services and clients on Tempo testnet | [tasks/mpp](tasks/mpp/README.md) |
 
-Each suite README owns its task model, harness behavior, run commands, and
-implementation notes. Task-level `README.md` files are concise Harbor Hub
-descriptions; `instruction.md` files are the agent-facing contracts.
+Suite guides own suite-specific behavior and commands. Task `README.md` files
+are short Harbor Hub descriptions; `instruction.md` files are the agent-facing
+contracts.
+
+## How It Works
+
+- A **task** contains an instruction, environment, oracle solution, and
+  independent verifier.
+- The **oracle** proves that the task is solvable. It is never shown to agents.
+- The **verifier** deterministically checks the submission and writes the
+  Harbor reward. RewardKit quality signals are reported separately and cannot
+  replace functional correctness.
+- A **dataset** is a versioned task collection. Its task set, prompts, fixtures,
+  verifier behavior, and scoring are fixed within a benchmark major.
+- A **job** runs one or more agent trials against a dataset. Job configs are
+  compiled from `config/` rather than edited by hand.
+
+### Access Profiles
+
+Tempo integration tasks use the same task artifacts under two access profiles:
+
+| Profile | Agent access |
+| --- | --- |
+| `docs` | Tempo documentation pinned by `config/tempo-docs.lock.json` |
+| `mcp` | The same pinned documentation plus the Tempo API MCP server |
+
+The Tempo MCP efficiency suite instead uses `mcp-direct` and `mcp-code` to
+compare direct documentation tools with `docs_code`; both query live Tempo data
+and documentation.
+
+> [!IMPORTANT]
+> **OpenAI documentation exception:** OpenAI models run through Codex's hosted
+> web fetch, which resolves `docs.tempo.xyz` outside the task sandbox. They
+> therefore use the live public docs and do not honor
+> `config/tempo-docs.lock.json` or `--docs-sha`. The pin only controls
+> documentation requests routed from within the sandbox.
 
 ## Repository Layout
 
 | Path | Purpose |
 | --- | --- |
 | `tasks/` | Authored, versioned Harbor task suites |
-| `shared/` | Reusable base image, verifiers, and suite harness assets |
-| `config/` | Dataset identities, access profiles, run variants, and generated jobs |
-| `scripts/` | Task synchronization, benchmark execution, validation, and result tools |
-
-## Key Concepts
-
-Harbor terms used throughout this repository:
-
-- **Task** — a single instruction, container environment, and test script,
-  authored as a directory (`instruction.md`, `task.toml`, `environment/`,
-  `solution/`, `tests/`). The instruction and verifier behavior form the
-  evaluation contract.
-- **Oracle** — the minimal reference solution checked in under `solution/`.
-  Oracle runs execute it in place of an agent to prove the task is solvable
-  and the verifier accepts a correct submission. It is not shown to agents.
-- **Verifier** — the independent test script under `tests/` that checks the
-  submission programmatically and writes the Harbor reward. Correctness must
-  be deterministic. Where RewardKit quality contributes to a reward, it is
-  gated by correctness and remains a separately reported score.
-- **Dataset** — a versioned collection of tasks; each suite here is one
-  dataset (e.g. `tempo/tempo-bench-v1`) with a checked-in generated manifest
-  (`dataset.toml`). A dataset major is an immutable evaluation contract.
-- **Trial and job** — a trial is one agent attempt at a task producing a
-  reward; a job is a batch of trials. Jobs here are compiled from `config/`
-  into `config/generated/` rather than written by hand.
-- **Access profile** — run-time injection of pinned documentation alone or
-  pinned documentation plus MCP access into a job, configured in
-  `config/tasks.yaml`, so the same task artifact can be evaluated under
-  different capabilities.
+| `shared/` | Shared base image, verifiers, and suite harnesses |
+| `config/` | Benchmark identities, access profiles, model matrices, and job sources |
+| `scripts/` | Synchronization, execution, validation, and result tooling |
 
 ## Setup
 
-### Requirements
-
-* Docker
-* Node.js with `npm`
-* [uv](https://docs.astral.sh/uv/).
-
-### Instructions
+Requirements: Docker, Node.js with `npm`, and
+[`uv`](https://docs.astral.sh/uv/).
 
 ```bash
 uv sync
 npm run docs:prepare
 ```
 
-Install Harbor with Daytona support when you need remote runs:
+For remote runs, install Harbor with Daytona support:
 
 ```bash
 uv tool install 'harbor[daytona]'
 ```
 
-## Global Workflows
+## Run Benchmarks
 
 ```bash
-# Synchronize shared assets and generated job configurations.
-npm run sync
-
-# Validate task conventions, generated assets, scripts, tests, formatting, and lint.
-npm run check
-
-# Create a task scaffold in a named suite.
-npm run task:new -- --suite tempo --name example-task
-
-# Remove local job output and staging caches.
-npm run clean
-```
-
-Run the dataset refresh command after changing task files. Dataset manifests are checked-in generated artifacts and must stay in sync with their suite.
-
-## Shared Architecture
-
-Three shared layers keep the suites consistent:
-
-- **One base image.** Every task environment extends the base image configured
-  in `config/tasks.yaml`, which bundles the RewardKit environment and the
-  shared Tempo verifier.
-- **Injected access profiles.** Benchmark jobs grant pinned documentation
-  alone or pinned documentation plus MCP access at run time instead of baking
-  it into task source, so the same task artifact can be evaluated under
-  different profiles. Profiles are configured centrally in
-  `config/tasks.yaml`; see the suite guides for profile-specific behavior.
-- **Immutable benchmark majors.** A dataset version fixes its task set,
-  prompts, verifier behavior, and scoring. Changes that make results
-  incomparable require a new dataset version rather than an in-place rewrite.
-
-## Running Tasks
-
-Every run is a Harbor job compiled from `config/`; the npm scripts select the
-variant. Suite READMEs cover suite-specific filters and workflows.
-
-### Locally
-
-Local runs use Docker and build the shared base image from the checkout, so
-they only need the API keys listed under Environment.
-
-```bash
-# Oracle validation for one suite.
+# Validate a suite with its oracle.
 npm run bench:local:oracle -- --task-suite tempo
 
-# Fast iteration on a single task.
+# Iterate on one task.
 npm run bench:local:one -- --task-filter tempo-v1/transfer-with-memo
 
-# Agent smoke run with the MCP profile.
-npm run bench:local:agent:dev -- --task-suite tempo --profile mcp
+# Run an agent against one Tempo task with Docs plus MCP.
+npm run bench:local:agent:dev -- \
+  --task-suite tempo --profile mcp --task-filter transfer-with-memo
 ```
 
-### On Daytona
-
-Daytona runs execute the same jobs on remote sandboxes. They require Daytona
-credentials and an explicit CI-published base image passed with `--base-image`;
-`npm run base-image:ref` prints the immutable reference for the current
-checkout.
+Daytona runs require credentials and an explicit CI-published base image:
 
 ```bash
-# Oracle validation on Daytona.
-npm run bench:daytona:oracle -- --base-image "$(npm run -s base-image:ref)"
-
-# Full Claude Code matrix on Daytona.
-npm run bench:daytona:agent -- --base-image "$(npm run -s base-image:ref)"
-
 BASE_IMAGE="$(npm run -s base-image:ref)"
 
-# Development smoke: Haiku, one attempt, both Tempo profiles.
+# Development model matrix: one attempt per task.
 npm run bench:matrix:dev -- \
   --task-suite tempo --profile all --base-image "$BASE_IMAGE"
 
-# Production: configured models, three attempts, both Tempo profiles.
+# Production model matrix: three attempts per task.
 npm run bench:matrix:production -- \
   --task-suite tempo --profile all --base-image "$BASE_IMAGE"
 ```
 
-`bench:matrix:dev` reads `config/models.dev.yaml`; the production command reads
-`config/models.production.yaml`. Both commands include every matching task
-unless `--task-filter` is provided. For Tempo, `docs` uses pinned Docs and `mcp`
-adds the Tempo MCP server.
+The matrix commands read `config/models.dev.yaml` and
+`config/models.production.yaml`. `--profile all` runs the `docs` and `mcp` jobs
+in parallel. `--concurrency` limits trials per profile job, so a value of 32 can
+run 64 trials across the pair. `--agent-concurrency` overrides the per-provider,
+per-profile model caps.
 
-`--concurrency` is the concurrent-trial limit for each profile job, not a
-combined limit. `--profile all` runs the Docs and Docs-plus-MCP jobs in
-parallel, so `--concurrency 32` permits up to 32 trials in each job, or 64
-across the pair. The model configs cap agent phases at 16 per provider and
-profile; `--agent-concurrency` overrides those caps.
-
-## Production Jobs
-
-Production writes local Harbor jobs under `jobs/<job-name>` and does not upload
-them automatically:
-
-| Suite | Production profile | Job names |
-| --- | --- | --- |
-| `tempo` | `all` | `tempo-bench-v1-production-<YYYYMMDDTHHMMSSZ>-{docs,mcp}` |
-| `mpp` | `docs` | `mpp-bench-v1-production-<YYYYMMDDTHHMMSSZ>-docs` |
-| `tempo-mcp` | `mcp-both` | `tempo-mcp-bench-v1-production-<YYYYMMDDTHHMMSSZ>-{mcp-direct,mcp-code}` |
-
-`--job-name` sets the shared run group, and the profile suffix is always added.
+Jobs are written under `jobs/` and are not uploaded automatically:
 
 ```bash
 npm run harbor:view
-uv run harbor auth login # Skip when already authenticated
+uv run harbor auth login # Skip when already authenticated.
 uv run harbor upload --public "jobs/<job-name>"
-uv run harbor job download "<job-id>" --output-dir jobs
 ```
 
-The upload prints a public Harbor Hub URL. Downloaded jobs can be viewed
-locally; resuming them requires the original staged task cache.
+## Develop Tasks
 
-## Authoring a New Task
+Read the relevant suite guide before editing a task. The usual workflow is:
 
-Read the suite README first; each suite has its own task model and shared
-files. The general flow:
+1. Scaffold with `npm run task:new -- --suite <suite> --name <task>`.
+2. Define the prompt and metadata in `instruction.md` and `task.toml`.
+3. Add the minimal environment, independent verifier, and oracle solution.
+4. Run a clean local oracle for the affected suite.
+5. Refresh generated artifacts with `npm run dataset`, then run
+   `npm run check`.
 
-1. **Scaffold.** `npm run task:new -- --suite <suite> --name <task>` creates
-   the task directory with the suite's conventions in place.
-2. **Write the contract.** `instruction.md` is the agent-facing prompt: keep
-   it concise and unambiguous, and prefer observable outputs (files, logs,
-   onchain effects) that a verifier can check. `task.toml` declares metadata,
-   resources, and verifier configuration.
-3. **Build the environment.** `environment/Dockerfile` extends the shared
-   base image; add only what the task needs.
-4. **Write the verifier.** `tests/` must establish correctness independently
-   and deterministically — it defines what "solved" means. Follow existing
-   verifier patterns and use the smallest check set that proves the
-   integration works. RewardKit quality checks go in `tests/quality/` as
-   diagnostics on top.
-5. **Write the oracle.** `solution/` is the minimal solution that satisfies
-   the instruction. If the oracle cannot pass the verifier, the task is
-   broken; if it passes trivially without doing the work, the verifier is too
-   weak.
-6. **Validate and refresh artifacts.** Run `npm run task:lint`, then a clean
-   local oracle run (`npm run bench:local:oracle -- --task-suite <suite>`),
-   then refresh the suite's dataset manifest with `npm run dataset`. Commit
-   the manifest and any generated artifacts with the task. `npm run check`
-   runs the full repository validation.
+Useful repository-wide commands:
 
-Adding a task to a released benchmark major changes the evaluation contract;
-see [AGENTS.md](AGENTS.md) for versioning and contribution rules.
+```bash
+npm run sync             # Refresh shared assets and generated job configs.
+npm run task:lint        # Validate task structure, metadata, and canaries.
+npm run check:generated  # Check generated artifacts are current.
+npm run check            # Run the full repository check.
+npm run clean            # Remove local job output and staging caches.
+```
+
+Do not hand-edit generated configs or synchronized MPP harness files. See
+[AGENTS.md](AGENTS.md) for source ownership, benchmark versioning, validation,
+and contribution rules.
 
 ## Environment
 
 | Variable | Purpose |
 | --- | --- |
-| `ANTHROPIC_API_KEY` | Claude Code runs and RewardKit LLM evaluation |
-| `OPENAI_API_KEY` | Codex production runs |
-| `DAYTONA_API_KEY` | Daytona authentication; JWT variables are an alternative |
-| `DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID` | Daytona JWT authentication |
-| `DAYTONA_TARGET` | Optional Daytona target |
+| `ANTHROPIC_API_KEY` | Claude Code runs and RewardKit evaluation |
+| `OPENAI_API_KEY` | Codex runs |
+| `DAYTONA_API_KEY` | Daytona authentication |
+| `DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID` | Alternative Daytona authentication |
 | `HARBOR_API_KEY` | Optional noninteractive Harbor Hub authentication |
-| `TEMPO_MCP_EVAL_URL` | Optional upstream endpoint for the MCP efficiency bridge |
+| `TEMPO_MCP_EVAL_URL` | Optional MCP efficiency suite upstream override |
 
 ## References
 
-* [Harbor concepts](https://www.harborframework.com/docs/core-concepts)
-* [Tempo documentation](https://docs.tempo.xyz/)
-* [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+- [Harbor concepts](https://www.harborframework.com/docs/core-concepts)
+- [Tempo documentation](https://docs.tempo.xyz/)
+- [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -47,10 +47,15 @@ plus 50% of RewardKit's aggregate `quality` score, which includes the LLM rubric
 and trajectory diagnostics. Missing quality configuration or a RewardKit
 execution/configuration error produces no reward.
 
-The benchmark job injects access rather than changing task source:
+The benchmark job injects access rather than changing task source. For requests
+made from within the task sandbox:
 
 - `docs` serves the revision pinned in `config/tempo-docs.lock.json`.
 - `mcp` serves the same pinned revision and also adds the Tempo API MCP server.
+
+OpenAI models are an exception: Codex's hosted web fetch reads the live public
+docs outside the sandbox and therefore does not honor the pinned docs SHA. See
+[Access Profiles](../../README.md#access-profiles) for details.
 
 Use `--profile all` to launch paired Docs and MCP jobs. Use `--profile docs` or
 `--profile mcp` when only one access profile is needed; each profile remains an


### PR DESCRIPTION
## Motivation

OpenAI models use Codex's hosted web fetch outside the task sandbox, so the pinned Tempo docs SHA does not control the documentation they read. The root README also duplicated suite-level detail and had become harder to scan.

## Summary

- document the OpenAI live-docs exception in the root and Tempo suite READMEs
- condense the root README around the current suites, access profiles, workflows, and configuration

## Key design considerations

- preserve pinned-docs semantics for requests made within the task sandbox while making the Codex exception explicit