### PR TITLE
chore: lower production trial concurrency

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -90,7 +90,7 @@ Options:
   --n-attempts N          Override production attempts per task and model
                           (default: 3)
   --concurrency N         Override n_concurrent_trials per profile job
-                          (default: 32 for production runs)
+                          (default: 16 for production runs)
   --agent-concurrency N   Override per-profile agent concurrency pools
   --max-retries N         Retry transient trial/setup failures
                           (default: 2 for Daytona runs)
@@ -528,7 +528,7 @@ def production_job(
         "job_name": job_dir.name,
         "jobs_dir": str(job_dir.parent),
         "n_attempts": int(options.get("n_attempts") or "3"),
-        "n_concurrent_trials": int(options.get("concurrency") or "32"),
+        "n_concurrent_trials": int(options.get("concurrency") or "16"),
         "environment_type": "daytona",
         "force_build": False,
         "agents": [production_agent(model) for model in model_config["models"]],

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -307,9 +307,16 @@ class RunBenchmarkTest(unittest.TestCase):
             Path(config["jobs_dir"]) / config["job_name"], Path("jobs") / run_id
         )
         self.assertEqual(job["n_attempts"], 1)
+        self.assertEqual(job["n_concurrent_trials"], 16)
         self.assertEqual(
             production_job("test-run", production_model_config(), {})["n_attempts"],
             3,
+        )
+        self.assertEqual(
+            production_job("test-run", production_model_config(), {"concurrency": "8"})[
+                "n_concurrent_trials"
+            ],
+            8,
         )
         with (
             patch(

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -69,7 +69,8 @@ every matching task. `bench:matrix:production` reads
 GPT-5.4 three times per task. Both commands run the full Tempo suite unless
 `--task-filter` is provided. `--concurrency` applies independently to each
 profile job. Because `--profile all` runs the two profile jobs in parallel,
-`--concurrency 32` allows up to 32 trials in each job, or 64 across the pair.
+the default `--concurrency 16` allows up to 16 trials in each job, or 32 across
+the pair.
 The model configs use a per-provider, per-profile agent concurrency cap of 16.
 
 ```bash


### PR DESCRIPTION
## Motivation

Paired production profiles can currently schedule up to 64 trial setup phases at once, which increases transient environment failures.

## Summary

- Lower the production default from 32 to 16 trials per profile.
- Preserve the existing CLI override and per-provider agent caps.

## Key design considerations

- Keep non-production Daytona defaults unchanged.
