### PR TITLE
chore: lock production run revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ in parallel. `--concurrency` limits trials per profile job, so a value of 32 can
 run 64 trials across the pair. `--agent-concurrency` overrides the per-provider,
 per-profile model caps.
 
+Production model configs pin the candidate and judge model IDs. The runner also
+requires a clean checkout and a full docs SHA, then records `TEMPO_EVALS_SHA`
+and `TEMPO_DOCS_SHA` in Harbor's generated `lock.json`.
+
 Jobs are written under `jobs/` and are not uploaded automatically:
 
 ```bash

--- a/config/generated/job.daytona-agent-dev.yaml
+++ b/config/generated/job.daytona-agent-dev.yaml
@@ -22,7 +22,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: claude-code
   model_name: claude-haiku-4-5

--- a/config/generated/job.daytona-agent.yaml
+++ b/config/generated/job.daytona-agent.yaml
@@ -22,7 +22,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: claude-code
   model_name: claude-haiku-4-5

--- a/config/generated/job.daytona-oracle.yaml
+++ b/config/generated/job.daytona-oracle.yaml
@@ -22,7 +22,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: oracle
 datasets:

--- a/config/generated/job.local-agent-dev.yaml
+++ b/config/generated/job.local-agent-dev.yaml
@@ -17,7 +17,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: claude-code
   model_name: claude-haiku-4-5

--- a/config/generated/job.local-agent.yaml
+++ b/config/generated/job.local-agent.yaml
@@ -17,7 +17,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: claude-code
   model_name: claude-haiku-4-5

--- a/config/generated/job.local-oracle-dev.yaml
+++ b/config/generated/job.local-oracle-dev.yaml
@@ -17,7 +17,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: oracle
 datasets:

--- a/config/generated/job.local-oracle.yaml
+++ b/config/generated/job.local-oracle.yaml
@@ -17,7 +17,7 @@ verifier:
   - '*.txt'
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5-20251001}
 agents:
 - name: oracle
 datasets:

--- a/config/job.yaml.j2
+++ b/config/job.yaml.j2
@@ -26,7 +26,7 @@ verifier:
     - "*.txt"
   env:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    REWARDKIT_JUDGE: ${REWARDKIT_JUDGE:-anthropic/claude-haiku-4-5}
+    REWARDKIT_JUDGE: {{ judge_model | tojson }}
 agents:
 {% for agent in agents %}
   - name: {{ agent.name | tojson }}

--- a/config/models.dev.yaml
+++ b/config/models.dev.yaml
@@ -1,5 +1,7 @@
 # Development model matrix for the `bench:matrix:dev` script.
 # `n_concurrent` is a per-profile agent cap; `--agent-concurrency` overrides it.
+judge_model: anthropic/claude-haiku-4-5-20251001
+
 models:
   - agent: claude-code
     model_name: claude-haiku-4-5-20251001

--- a/config/models.production.yaml
+++ b/config/models.production.yaml
@@ -2,6 +2,8 @@
 #
 # Models from one provider share a per-profile `n_concurrent` pool.
 # `--agent-concurrency N` overrides these limits for the run.
+judge_model: anthropic/claude-haiku-4-5-20251001
+
 models:
   - agent: claude-code
     model_name: claude-haiku-4-5-20251001
@@ -9,6 +11,7 @@ models:
     concurrency_group: anthropic
 
   - agent: claude-code
+    # Sonnet 5 uses an immutable canonical ID without a snapshot date.
     model_name: claude-sonnet-5
     n_concurrent: 16
     concurrency_group: anthropic

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -211,6 +211,9 @@ def run_python(script: str, args: list[str] | None = None) -> None:
 
 
 DOCS_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{7,40}")
+FULL_GIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+PINNED_JUDGE_MODEL = "anthropic/claude-haiku-4-5-20251001"
+DEFAULT_JUDGE_MODEL = f"${{REWARDKIT_JUDGE:-{PINNED_JUDGE_MODEL}}}"
 DOCS_ACCESS_LOG = "/var/log/tempo-docs/access.log"
 DOCS_TLS_DIR = "docs-tls"
 DOCS_CA_FILE = "ca.crt"
@@ -359,7 +362,10 @@ def parse_model_config(file_path: str, agent_concurrency: str | None) -> dict[st
     if not models:
         msg = f"No models configured in {file_path}"
         raise RuntimeError(msg)
-    return {"models": models}
+    judge_model = parsed.get("judge_model", PINNED_JUDGE_MODEL)
+    if not isinstance(judge_model, str) or not judge_model:
+        raise RuntimeError(f"Invalid judge_model in {file_path}")
+    return {"judge_model": judge_model, "models": models}
 
 
 def normalize_production_model(
@@ -406,6 +412,30 @@ def production_job_dir(job_name: str) -> Path:
     if job_name in {"", ".", ".."} or Path(job_name).name != job_name:
         raise RuntimeError("Production job name must be one path component")
     return Path("jobs") / job_name
+
+
+def git_output(args: list[str]) -> str:
+    result = subprocess.run(["git", *args], check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def production_revision_env(options: dict[str, Any]) -> dict[str, str]:
+    if git_output(["status", "--porcelain", "--untracked-files=all"]):
+        raise RuntimeError("Production runs require a clean tempo-evals checkout")
+    repository_sha = git_output(["rev-parse", "HEAD"]).lower()
+    if not FULL_GIT_SHA_PATTERN.fullmatch(repository_sha):
+        raise RuntimeError(f"Invalid tempo-evals Git SHA: {repository_sha!r}")
+
+    revisions = {"TEMPO_EVALS_SHA": repository_sha}
+    if options.get("task_suite") in {None, "tempo", "all"}:
+        source = docs_source(options)
+        docs_sha = source.get("sha", "").lower()
+        if source["mode"] != "pinned" or not FULL_GIT_SHA_PATTERN.fullmatch(docs_sha):
+            raise RuntimeError("Production Tempo runs require a full docs Git SHA")
+        revisions["TEMPO_DOCS_SHA"] = docs_sha
+    return revisions
 
 
 def benchmark_key(value: str | BenchmarkKey | None) -> BenchmarkKey:
@@ -494,6 +524,7 @@ def render_job_config(
         environment_type=job["environment_type"],
         force_build=job["force_build"],
         agents=job["agents"],
+        judge_model=job.get("judge_model", DEFAULT_JUDGE_MODEL),
         dind_image=RUN_CONFIG["daytona"]["dind_image"],
     )
     config = yaml.safe_load(rendered)
@@ -531,6 +562,7 @@ def production_job(
         "n_concurrent_trials": int(options.get("concurrency") or "32"),
         "environment_type": "daytona",
         "force_build": False,
+        "judge_model": model_config["judge_model"],
         "agents": [production_agent(model) for model in model_config["models"]],
         "datasets": datasets_for_suite(options.get("task_suite") or "tempo"),
     }
@@ -547,9 +579,9 @@ def run_production_variant(
     )
     preflight_production_agents(model_config)
     job = production_job(run_id, model_config, options)
-    config = stage_daytona_config(
-        render_job_config(job, benchmark=None), run_id, docs_bundle, options
-    )
+    rendered = render_job_config(job, benchmark=None)
+    rendered["verifier"]["env"].update(production_revision_env(options))
+    config = stage_daytona_config(rendered, run_id, docs_bundle, options)
     max_retries = options.get("max_retries") or "2"
     args = ["run", "harbor", "run", "-c", config]
     if options.get("env_file"):

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -22,6 +22,7 @@ from scripts.run_benchmark import (
     parse_model_config,
     prepare_production_profiles,
     production_job,
+    production_revision_env,
     render_job_config,
     run_benchmark_key,
     run_benchmark_variant,
@@ -38,7 +39,10 @@ def base_config() -> dict[str, Any]:
 
 
 def production_model_config() -> dict[str, Any]:
-    return {"models": [{"agent": "claude-code", "model_name": "claude-haiku-4-5"}]}
+    return {
+        "judge_model": "anthropic/claude-haiku-4-5-20251001",
+        "models": [{"agent": "claude-code", "model_name": "claude-haiku-4-5"}],
+    }
 
 
 class RunBenchmarkTest(unittest.TestCase):
@@ -187,6 +191,10 @@ class RunBenchmarkTest(unittest.TestCase):
             [model["model_name"] for model in dev["models"]],
             ["claude-haiku-4-5-20251001"],
         )
+        self.assertEqual(dev["judge_model"], "anthropic/claude-haiku-4-5-20251001")
+        self.assertEqual(
+            production["judge_model"], "anthropic/claude-haiku-4-5-20251001"
+        )
         self.assertEqual(
             [model["model_name"] for model in production["models"]],
             [
@@ -318,6 +326,13 @@ class RunBenchmarkTest(unittest.TestCase):
             ),
             patch("scripts.run_benchmark.preflight_production_agents"),
             patch(
+                "scripts.run_benchmark.production_revision_env",
+                return_value={
+                    "TEMPO_EVALS_SHA": "a" * 40,
+                    "TEMPO_DOCS_SHA": "b" * 40,
+                },
+            ),
+            patch(
                 "scripts.run_benchmark.stage_daytona_config", return_value="job.yaml"
             ) as stage,
             patch("scripts.run_benchmark.run_status", return_value=0),
@@ -325,6 +340,37 @@ class RunBenchmarkTest(unittest.TestCase):
             run_production_variant(run_id, {"task_suite": "mpp"}, None)
 
         self.assertEqual(stage.call_args.args[0]["job_name"], run_id)
+        self.assertEqual(
+            stage.call_args.args[0]["verifier"]["env"],
+            {
+                "ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY:-}",
+                "REWARDKIT_JUDGE": "anthropic/claude-haiku-4-5-20251001",
+                "TEMPO_EVALS_SHA": "a" * 40,
+                "TEMPO_DOCS_SHA": "b" * 40,
+            },
+        )
+
+    def test_production_revision_env_requires_clean_full_shas(self) -> None:
+        with (
+            patch(
+                "scripts.run_benchmark.git_output",
+                side_effect=["", "a" * 40],
+            ),
+            patch(
+                "scripts.run_benchmark.docs_source",
+                return_value={"mode": "pinned", "repo": "tempo/docs", "sha": "b" * 40},
+            ),
+        ):
+            self.assertEqual(
+                production_revision_env({"task_suite": "tempo"}),
+                {"TEMPO_EVALS_SHA": "a" * 40, "TEMPO_DOCS_SHA": "b" * 40},
+            )
+
+        with (
+            patch("scripts.run_benchmark.git_output", return_value="M dirty.py"),
+            self.assertRaisesRegex(RuntimeError, "clean tempo-evals checkout"),
+        ):
+            production_revision_env({"task_suite": "tempo"})
 
     def test_production_job_rejects_run_id_paths(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "one path component"):


### PR DESCRIPTION
## Motivation

Downloaded production results should identify the exact model and source revisions used by the run.

## Summary

- Pin the production judge alongside the candidate model matrix.
- Require a clean checkout and full docs SHA for production Tempo runs.
- Record the Tempo Evals and docs SHAs in Harbor's generated lock.

## Key design considerations

- Reuse Harbor's existing `lock.json` instead of introducing a second manifest format.
