### PR TITLE
fix: retain verifier install errors

### DIFF
--- a/shared/tempo/verifier/src/index.js
+++ b/shared/tempo/verifier/src/index.js
@@ -59,14 +59,14 @@ async function main() {
 
     context = {
       phase: "submission-npm-install",
-      expected: "npm install --silent exits 0",
+      expected: "npm install --loglevel=error exits 0",
       logs: [
         "submission-npm-install.stdout.txt",
         "submission-npm-install.stderr.txt",
         "submission-npm-install.status.json",
       ],
     };
-    runStep(config, "submission-npm-install", "npm", ["install", "--silent"]);
+    runStep(config, "submission-npm-install", "npm", ["install", "--loglevel=error"]);
     context = {
       phase: "submission-eval",
       expected: "npm run eval exits 0",

--- a/shared/tempo/verifier/test/install-logging.test.js
+++ b/shared/tempo/verifier/test/install-logging.test.js
@@ -1,0 +1,9 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const test = require("node:test");
+
+test("npm install retains error output", () => {
+  const source = fs.readFileSync(require.resolve("../src/index"), "utf8");
+  assert.match(source, /\["install", "--loglevel=error"\]/);
+  assert.doesNotMatch(source, /--silent/);
+});


### PR DESCRIPTION
## Motivation

Failed submission dependency installs can produce empty verifier logs because npm is invoked in silent mode.

## Summary

- Run submission installs with npm's error log level.
- Keep using the existing captured stdout and stderr artifacts.

## Key design considerations

- Leave verifier control flow and log collection unchanged.
