### PR TITLE
feat: align Tempo reward weighting

### DIFF
--- a/scripts/tempo_reward_schema_test.py
+++ b/scripts/tempo_reward_schema_test.py
@@ -26,18 +26,26 @@ class RewardSchemaTest(unittest.TestCase):
         self.assertLessEqual(len(wrapper.splitlines()), 9)
         self.assertIn("tempo_bench_rewardkit.tempo.verifier", wrapper)
 
-    def test_tempo_reward_is_correctness_gated_and_evenly_weighted(self) -> None:
-        for quality, expected in ((0, 0.5), (0.6, 0.8), (1, 1)):
-            with self.subTest(quality=quality):
+    def test_tempo_reward_combines_code_and_aggregate_quality(self) -> None:
+        for code_score, aggregate_quality, quality, reward in (
+            (0, 0, 0, 0.5),
+            (0, 1, 0.5, 0.75),
+            (0.6, 0.8, 0.7, 0.85),
+            (1, 1, 1, 1),
+        ):
+            with self.subTest(
+                code_score=code_score, aggregate_quality=aggregate_quality
+            ):
                 self.assertEqual(
                     compose_reward(
-                        {"correctness": 1, "quality": quality, "reward": 0.123}
+                        {
+                            "correctness": code_score,
+                            "quality": aggregate_quality,
+                            "reward": 0.123,
+                        }
                     ),
-                    {"correctness": 1, "quality": quality, "reward": expected},
+                    {"correctness": 1, "quality": quality, "reward": reward},
                 )
-        self.assertEqual(
-            compose_reward({"correctness": 0.75, "quality": 1}), ZERO_REWARD
-        )
         with self.assertRaises(ValueError):
             compose_reward({"correctness": 1, "reward": 1})
 
@@ -54,7 +62,7 @@ class RewardSchemaTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIsNone(reward)
 
-    def test_tempo_static_failure_skips_quality(self) -> None:
+    def test_tempo_static_failure_contributes_to_quality(self) -> None:
         quality_check = (
             "import os\nfrom pathlib import Path\nimport rewardkit as rk\n"
             "@rk.criterion\ndef quality(workspace: Path) -> float:\n"
@@ -62,11 +70,14 @@ class RewardSchemaTest(unittest.TestCase):
             "    return 1\n"
         )
         result, reward, quality_ran = self._run_tempo(
-            "exit 0\n", correctness=0, quality_check=quality_check
+            "exit 0\n",
+            correctness=0,
+            quality_config='[scoring]\naggregation = "weighted_mean"\n',
+            quality_check=quality_check,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(reward, ZERO_REWARD)
-        self.assertFalse(quality_ran)
+        self.assertEqual(reward, {"correctness": 1, "quality": 0.5, "reward": 0.75})
+        self.assertTrue(quality_ran)
 
     def test_tempo_missing_quality_config_is_a_verifier_error(self) -> None:
         result, reward, _ = self._run_tempo(

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/common/tempo_reward.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/common/tempo_reward.py
@@ -23,17 +23,16 @@ def _score(output: dict[str, Any], key: str) -> float:
 def compose_reward(
     rewardkit_output: dict[str, Any],
 ) -> dict[str, float | int]:
-    correctness = _score(rewardkit_output, "correctness")
-    if correctness != 1:
-        return dict(ZERO_REWARD)
-
-    # RewardKit's aggregate `reward` is intentionally ignored because it also
-    # includes the correctness dimension and would count it twice here.
-    quality = _score(rewardkit_output, "quality")
+    # The onchain verifier already passed. Harbor correctness is therefore 1,
+    # while RewardKit's code and aggregate scores together form Harbor quality.
+    correctness = 1
+    code_score = _score(rewardkit_output, "correctness")
+    aggregate_quality = _score(rewardkit_output, "quality")
+    quality = round((code_score + aggregate_quality) / 2, 4)
     return {
-        "correctness": 1,
+        "correctness": correctness,
         "quality": quality,
-        "reward": round(0.5 + 0.5 * quality, 4),
+        "reward": round((correctness + quality) / 2, 4),
     }
 
 
@@ -45,12 +44,3 @@ def write_reward(
     if not isinstance(rewardkit_output, dict):
         raise ValueError("RewardKit output must be a JSON object")
     output_path.write_text(f"{json.dumps(compose_reward(rewardkit_output))}\n")
-
-
-def write_correctness_gate(rewardkit_path: Path, output_path: Path) -> None:
-    rewardkit_output = json.loads(rewardkit_path.read_text())
-    if not isinstance(rewardkit_output, dict):
-        raise ValueError("RewardKit output must be a JSON object")
-    output_path.unlink(missing_ok=True)
-    if _score(rewardkit_output, "correctness") != 1:
-        output_path.write_text(f"{json.dumps(ZERO_REWARD)}\n")

--- a/shared/global/rewardkit-lib/tempo_bench_rewardkit/tempo/verifier.py
+++ b/shared/global/rewardkit-lib/tempo_bench_rewardkit/tempo/verifier.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from tempo_bench_rewardkit.common.tempo_reward import (
     ZERO_REWARD,
-    write_correctness_gate,
     write_reward,
 )
 
@@ -40,23 +39,19 @@ def run() -> int:
     tests = Path(os.environ.get("TEMPO_BENCH_TESTS_DIR", "/tests"))
     reward = log_dir / "reward.json"
     details = log_dir / "reward-details.json"
-    correctness_output = log_dir / "correctness-reward.json"
     rewardkit_output = log_dir / "rewardkit-output.json"
 
     log_dir.mkdir(parents=True, exist_ok=True)
-    for path in (reward, details, correctness_output, rewardkit_output):
+    for path in (reward, details, rewardkit_output):
         path.unlink(missing_ok=True)
 
     def verifier_error(message: str) -> int:
         print(message, file=sys.stderr)
-        for path in (reward, details, correctness_output, rewardkit_output):
+        for path in (reward, details, rewardkit_output):
             path.unlink(missing_ok=True)
         return 1
 
-    with (
-        tempfile.TemporaryDirectory() as workspace_dir,
-        tempfile.TemporaryDirectory() as correctness_dir,
-    ):
+    with tempfile.TemporaryDirectory() as workspace_dir:
         rewardkit_workspace = Path(workspace_dir)
         try:
             shutil.copytree(workspace, rewardkit_workspace, dirs_exist_ok=True)
@@ -71,23 +66,6 @@ def run() -> int:
                 reward.write_text(f"{json.dumps(ZERO_REWARD)}\n")
                 return 0
             return verifier_result.returncode or 1
-
-        correctness_tests = Path(correctness_dir) / "correctness"
-        try:
-            shutil.copytree(tests / "correctness", correctness_tests)
-        except OSError as error:
-            return verifier_error(f"Could not stage correctness tests: {error}")
-        if not _run_rewardkit(
-            Path(correctness_dir), rewardkit_workspace, correctness_output
-        ):
-            return verifier_error("RewardKit correctness checks failed to run.")
-        try:
-            write_correctness_gate(correctness_output, reward)
-        except (OSError, ValueError, json.JSONDecodeError) as error:
-            return verifier_error(f"Invalid RewardKit correctness output: {error}")
-        correctness_output.unlink(missing_ok=True)
-        if reward.is_file():
-            return 0
 
         quality_config = tests / "quality" / "reward.toml"
         if not quality_config.is_file():

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -38,14 +38,14 @@ tasks/tempo-v1/<task>/
     └── quality/             # RewardKit quality checks and weights
 ```
 
-The task test script first runs the independent onchain verifier. A scored
-onchain failure writes a zero Harbor reward and skips RewardKit. On success,
-RewardKit's static correctness criteria run first and must all pass or the
-complete reward is zero without invoking the quality judge. The published
-`correctness` is therefore binary. Passing submissions receive 50% correctness
-plus 50% of RewardKit's aggregate `quality` score, which includes the LLM rubric
-and trajectory diagnostics. Missing quality configuration or a RewardKit
-execution/configuration error produces no reward.
+The task first runs the independent onchain verifier. A scored onchain failure
+publishes `correctness = 0`, `quality = 0`, and `reward = 0`, then skips
+RewardKit. On success, Harbor receives `correctness = 1`. Published `quality`
+is the mean of RewardKit's static code score and its aggregate LLM and
+trajectory quality score. Harbor then publishes
+`reward = (correctness + quality) / 2`, which is equivalent to
+`0.5 * correctness + 0.25 * code + 0.25 * aggregate quality`. Missing quality
+configuration or a RewardKit execution/configuration error produces no reward.
 
 The benchmark job injects access rather than changing task source. For requests
 made from within the task sandbox:


### PR DESCRIPTION
## Motivation

Tempo rewards should expose Harbor's binary correctness and continuous quality dimensions directly, with each contributing half of the final reward.

## Summary

- Keep onchain verification as the only zero-reward gate.
- Publish the mean of RewardKit's static code score and aggregate quality score as Harbor's `quality`.
- Keep the existing `tempo-bench-v1` benchmark identity.

## Key design considerations

- Onchain failure publishes zero and skips RewardKit.
- Onchain success publishes `quality = (code + aggregate quality) / 2`, so Harbor's 50/50 correctness-quality reward is equivalent to `0.5C + 0.25K + 0.25Q`.
- Run RewardKit once after onchain verification instead of maintaining a separate static-check gate.
