### PR TITLE
ci: annotate static check violations

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -15,14 +15,13 @@ concurrency:
 
 env:
   STATIC_CHECKS_MODE: error
-  UPSTREAM_STATIC_CHECKS_URL: https://github.com/harbor-framework/benchmark-template/blob/main/.github/workflows/static-checks.yml
 
 jobs:
   static-checks:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     steps:
       - name: Check out trusted static checks
         uses: actions/checkout@v4
@@ -73,34 +72,12 @@ jobs:
           echo "Detected task directories:"
           echo "$VALID_TASK_DIRS"
 
-      - name: Write placeholder comment
-        if: steps.detect.outputs.has_tasks == 'true'
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          SHORT_SHA="${HEAD_SHA:0:7}"
-          SHA_LINK="${{ github.server_url }}/${{ github.repository }}/commit/${HEAD_SHA}"
-          printf '### Static Checks ⏳\nRunning in %s mode...\n\n<sub><a href="%s">Ran</a> on <a href="%s"><code>%s</code></a>. Source: <a href="%s">upstream workflow</a>.</sub>\n' \
-            "$STATIC_CHECKS_MODE" "$RUN_URL" "$SHA_LINK" "$SHORT_SHA" "$UPSTREAM_STATIC_CHECKS_URL" \
-            > /tmp/static-checks-comment.md
-
-      - name: Post placeholder sticky comment
-        if: steps.detect.outputs.has_tasks == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: static-checks
-          number: ${{ github.event.pull_request.number }}
-          path: /tmp/static-checks-comment.md
-
       - name: Run all static checks
         if: steps.detect.outputs.has_tasks == 'true'
         id: checks
         working-directory: pr
         env:
           TASK_DIRS: ${{ steps.detect.outputs.task_dirs }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           case "$STATIC_CHECKS_MODE" in
             warning|error) ;;
@@ -139,10 +116,24 @@ jobs:
           EXCEPTIONS_PATH="$GITHUB_WORKSPACE/base/ci_checks/exceptions.yml"
           EXEMPTION_CHECK="$GITHUB_WORKSPACE/base/ci_checks/is-exempt.py"
 
-          FAILED_ROWS=""
-          PASSED_ROWS=""
           FAILED_COUNT=0
-          PASSED_COUNT=0
+
+          emit_failure_annotations() {
+            local check_name="$1"
+            local output="$2"
+            local failure path message
+
+            while IFS= read -r failure; do
+              [ -n "$failure" ] || continue
+              failure="${failure#FAIL }"
+              path="${failure%%:*}"
+              message="${failure#*: }"
+              message="${message//%/%25}"
+              message="${message//$'\r'/%0D}"
+              message="${message//$'\n'/%0A}"
+              printf '::error file=%s,line=1,title=%s::%s\n' "$path" "$check_name" "$message"
+            done < <(printf '%s\n' "$output" | grep '^FAIL ' || true)
+          }
 
           for entry in "${CHECKS[@]}"; do
             NAME="${entry%%|*}"
@@ -175,11 +166,8 @@ jobs:
                 if ! OUT=$(bash "$SCRIPT_PATH" "$task_dir" 2>&1); then
                   echo "$OUT"
                   CLEAN=$(printf '%s\n' "$OUT" | sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g')
-                  MSG=$(printf '%s\n' "$CLEAN" | grep '^FAIL ' | sed 's/^FAIL //' | sed 's/|/\\|/g')
-                  [ -z "$MSG" ] && MSG="(see workflow log)"
-                  while IFS= read -r line; do
-                    [ -n "$line" ] && FAIL_DETAILS="${FAIL_DETAILS}${FAIL_DETAILS:+<br>}${line}"
-                  done <<< "$MSG"
+                  emit_failure_annotations "$NAME" "$CLEAN"
+                  FAIL_DETAILS="failed"
                 else
                   echo "$OUT"
                 fi
@@ -189,66 +177,14 @@ jobs:
 
             if [ -n "$FAIL_DETAILS" ]; then
               FAILED_COUNT=$((FAILED_COUNT + 1))
-              FAILED_ROWS="${FAILED_ROWS}| ${NAME} | ${FAIL_DETAILS} |"$'\n'
-            else
-              PASSED_COUNT=$((PASSED_COUNT + 1))
-              PASSED_ROWS="${PASSED_ROWS}| ${NAME} |"$'\n'
             fi
           done
 
-          SHORT_SHA="${HEAD_SHA:0:7}"
-          SHA_LINK="${{ github.server_url }}/${{ github.repository }}/commit/${HEAD_SHA}"
-          {
-            if [ "$FAILED_COUNT" -eq 0 ]; then
-              echo "### Static Checks ✅"
-            elif [ "$STATIC_CHECKS_MODE" = "warning" ]; then
-              echo "### Static Checks ⚠️"
-            else
-              echo "### Static Checks ❌"
-            fi
-            echo
-            echo "Mode: \`$STATIC_CHECKS_MODE\`"
-            echo
-            if [ "$FAILED_COUNT" -gt 0 ]; then
-              echo "<details open>"
-              echo "<summary><b>${FAILED_COUNT} failed</b></summary>"
-              echo
-              echo "| Check | Details |"
-              echo "|-------|---------|"
-              printf '%s' "$FAILED_ROWS"
-              echo
-              echo "</details>"
-              echo
-            fi
-            if [ "$PASSED_COUNT" -gt 0 ]; then
-              echo "<details>"
-              echo "<summary><b>${PASSED_COUNT} passed</b></summary>"
-              echo
-              echo "| Check |"
-              echo "|-------|"
-              printf '%s' "$PASSED_ROWS"
-              echo
-              echo "</details>"
-              echo
-            fi
-            printf '<sub><a href="%s">Ran</a> on <a href="%s"><code>%s</code></a>. Source: <a href="%s">upstream workflow</a>.</sub>\n' \
-              "$RUN_URL" "$SHA_LINK" "$SHORT_SHA" "$UPSTREAM_STATIC_CHECKS_URL"
-          } > /tmp/static-checks-comment.md
-
-          cat /tmp/static-checks-comment.md >> "$GITHUB_STEP_SUMMARY"
           echo "all_passed=$([ "$FAILED_COUNT" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
           if [ "$FAILED_COUNT" -gt 0 ] && [ "$STATIC_CHECKS_MODE" = "warning" ]; then
             echo "::warning::${FAILED_COUNT} static checks failed in warning mode"
           fi
-
-      - name: Post sticky comment
-        if: steps.detect.outputs.has_tasks == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: static-checks
-          number: ${{ github.event.pull_request.number }}
-          path: /tmp/static-checks-comment.md
 
       - name: Fail if static checks failed
         if: steps.detect.outputs.has_tasks == 'true' && env.STATIC_CHECKS_MODE == 'error' && steps.checks.outputs.all_passed != 'true'


### PR DESCRIPTION
## Motivation

Show static-check failures where they occur without maintaining a pull request summary comment.

## Summary

- Emit GitHub Actions error annotations for each violating file
- Remove sticky static-check comments and unneeded write permission

## Key design considerations

- The existing static-check job remains the single pass/fail status check