### PR TITLE
fix(results): classify Tempo passes by correctness

### DIFF
--- a/scripts/export_results.py
+++ b/scripts/export_results.py
@@ -357,6 +357,18 @@ def primary_reward(rewards: dict[str, float | int]) -> Numeric:
     return values[0] if len(values) == 1 else ""
 
 
+def pass_reward(
+    task_family: str,
+    rewards: dict[str, float | int],
+    reward: Numeric,
+) -> Numeric:
+    if task_family.startswith("tempo-v1/"):
+        correctness = as_number(rewards.get("correctness"))
+        if correctness is not None:
+            return correctness
+    return reward
+
+
 def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | None:
     result = read_json(file_path)
     if not result or not isinstance(result.get("task_name"), str):
@@ -378,7 +390,8 @@ def parse_trial_result(file_path: Path, context: JsonObject) -> JsonObject | Non
         judge_available := as_number(rewards.get("quality_judge_available"))
     ) is not None:
         validation["quality_judge_available"] = judge_available
-    passed = isinstance(reward, int | float) and reward >= 1
+    passing_reward = pass_reward(task["task_family"], rewards, reward)
+    passed = isinstance(passing_reward, int | float) and passing_reward >= 1
     used_mcp = isinstance(trace["calls"], int | float) and trace["calls"] > 0
     trace_clean = (
         isinstance(trace["denied"], int | float)

--- a/scripts/export_results_test.py
+++ b/scripts/export_results_test.py
@@ -193,6 +193,64 @@ class ExportResultsTest(unittest.TestCase):
             )
             self.assertEqual({row["docs_source"] for row in rows}, {"live"})
 
+    def test_tempo_passes_use_correctness_instead_of_composite_reward(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tempo-bench-export-") as root:
+            job_dir = Path(root) / "job"
+            write_json(
+                job_dir / "trial" / "result.json",
+                trial(
+                    {
+                        "task_name": "tempo-v1/transfer-with-memo",
+                        "config": {
+                            "agent": {"mcp_servers": [{"name": "tempo"}]},
+                        },
+                        "verifier_result": {
+                            "rewards": {
+                                "correctness": 1,
+                                "quality": 0.85,
+                                "reward": 0.925,
+                            }
+                        },
+                    }
+                ),
+            )
+            trace = job_dir / "trial" / "artifacts" / "tempo" / "trace.jsonl"
+            trace.parent.mkdir(parents=True)
+            trace.write_text(
+                json.dumps({"method": "tools/call", "allowed": True}) + "\n"
+            )
+
+            result = export_results(job_dir)
+
+            self.assertTrue(result["trials"][0]["passed"])
+            self.assertTrue(result["trials"][0]["eligible"])
+            self.assertEqual(result["trials"][0]["outcome"], "passed")
+            self.assertEqual(result["summary"][0]["n_passed"], 1)
+            self.assertEqual(result["summary"][0]["pass_rate"], 1)
+
+    def test_non_tempo_suites_keep_primary_reward_pass_semantics(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tempo-bench-export-") as root:
+            job_dir = Path(root) / "job"
+            write_json(
+                job_dir / "trial" / "result.json",
+                trial(
+                    {
+                        "task_name": "mpp/server-charge-pathusd",
+                        "verifier_result": {
+                            "rewards": {
+                                "correctness": 0.75,
+                                "quality": 0.6,
+                                "reward": 1,
+                            }
+                        },
+                    }
+                ),
+            )
+
+            result = export_results(job_dir)
+
+            self.assertTrue(result["trials"][0]["passed"])
+
     def test_export_marks_only_clean_mcp_trials_eligible(self) -> None:
         with tempfile.TemporaryDirectory(prefix="tempo-bench-export-") as root:
             job_dir = Path(root) / "job"


### PR DESCRIPTION
## Summary

- classify Tempo v1 passes from binary `correctness`
- preserve primary-reward pass semantics for other suites

Tempo's composite reward blends correctness and quality, so correct trials with quality below 1 were exported as failures.

## Validation

- `uv run python -m unittest scripts.export_results_test`
- `npm run test:results` (97 tests)
- replayed the affected jobs: Docs 79/108, MCP 96/108