### PR TITLE
chore: expand production model matrix

### DIFF
--- a/config/models.production.yaml
+++ b/config/models.production.yaml
@@ -3,25 +3,53 @@
 # Models from one provider share a per-profile `n_concurrent` pool.
 # `--agent-concurrency N` overrides these limits for the run.
 judge_model: anthropic/claude-haiku-4-5-20251001
+n_concurrent_trials: 8
 
 models:
   - agent: claude-code
+    # Fable 5 uses a canonical ID without a snapshot date.
+    model_name: claude-fable-5
+    n_concurrent: 4
+    concurrency_group: anthropic
+
+  - agent: claude-code
+    # Opus 4.8 uses a canonical ID without a snapshot date.
+    model_name: claude-opus-4-8
+    n_concurrent: 4
+    concurrency_group: anthropic
+
+  - agent: claude-code
     model_name: claude-haiku-4-5-20251001
-    n_concurrent: 16
+    n_concurrent: 4
     concurrency_group: anthropic
 
   - agent: claude-code
     # Sonnet 5 uses an immutable canonical ID without a snapshot date.
     model_name: claude-sonnet-5
-    n_concurrent: 16
+    n_concurrent: 4
     concurrency_group: anthropic
 
   - agent: codex
     model_name: gpt-5.4-mini-2026-03-17
-    n_concurrent: 16
+    n_concurrent: 4
     concurrency_group: openai
 
   - agent: codex
-    model_name: gpt-5.4-2026-03-05
-    n_concurrent: 16
+    model_name: gpt-5.6-sol
+    n_concurrent: 4
+    concurrency_group: openai
+
+  - agent: codex
+    model_name: gpt-5.5-pro-2026-04-23
+    n_concurrent: 4
+    concurrency_group: openai
+
+  - agent: codex
+    model_name: gpt-5.6-terra
+    n_concurrent: 4
+    concurrency_group: openai
+
+  - agent: codex
+    model_name: gpt-5.6-luna
+    n_concurrent: 4
     concurrency_group: openai

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -97,7 +97,7 @@ Options:
   --n-attempts N          Override production attempts per task and model
                           (default: 3)
   --concurrency N         Override n_concurrent_trials per profile job
-                          (default: 16 for production runs)
+                          (default: model config value, otherwise 16)
   --agent-concurrency N   Override per-profile agent concurrency pools
   --max-retries N         Retry transient trial/setup failures
                           (default: 2 for Daytona runs)
@@ -405,7 +405,14 @@ def parse_model_config(file_path: str, agent_concurrency: str | None) -> dict[st
     judge_model = parsed.get("judge_model", PINNED_JUDGE_MODEL)
     if not isinstance(judge_model, str) or not judge_model:
         raise RuntimeError(f"Invalid judge_model in {file_path}")
-    return {"judge_model": judge_model, "models": models}
+    n_concurrent_trials = validate_optional_positive_integer(
+        string_field(parsed, "n_concurrent_trials"), "n_concurrent_trials"
+    )
+    return {
+        "judge_model": judge_model,
+        "n_concurrent_trials": n_concurrent_trials,
+        "models": models,
+    }
 
 
 def normalize_production_model(
@@ -599,7 +606,11 @@ def production_job(
         "job_name": job_dir.name,
         "jobs_dir": str(job_dir.parent),
         "n_attempts": int(options.get("n_attempts") or "3"),
-        "n_concurrent_trials": int(options.get("concurrency") or "16"),
+        "n_concurrent_trials": int(
+            options.get("concurrency")
+            or model_config.get("n_concurrent_trials")
+            or "16"
+        ),
         "environment_type": "daytona",
         "force_build": False,
         "judge_model": model_config["judge_model"],

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -282,19 +282,36 @@ class RunBenchmarkTest(unittest.TestCase):
         self.assertEqual(
             production["judge_model"], "anthropic/claude-haiku-4-5-20251001"
         )
+        self.assertIsNone(dev["n_concurrent_trials"])
+        self.assertEqual(production["n_concurrent_trials"], "8")
         self.assertEqual(
             [model["model_name"] for model in production["models"]],
             [
+                "claude-fable-5",
+                "claude-opus-4-8",
                 "claude-haiku-4-5-20251001",
                 "claude-sonnet-5",
                 "gpt-5.4-mini-2026-03-17",
-                "gpt-5.4-2026-03-05",
+                "gpt-5.6-sol",
+                "gpt-5.5-pro-2026-04-23",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
             ],
         )
         self.assertEqual([model["n_concurrent"] for model in dev["models"]], ["16"])
         self.assertEqual(
             [model["n_concurrent"] for model in production["models"]],
-            ["16", "16", "16", "16"],
+            ["4"] * 9,
+        )
+        self.assertEqual(
+            production_job("test-run", production, {})["n_concurrent_trials"], 8
+        )
+        self.assertEqual(
+            [
+                (model["agent"], model["concurrency_group"])
+                for model in production["models"]
+            ],
+            [("claude-code", "anthropic")] * 4 + [("codex", "openai")] * 5,
         )
 
     def test_production_profiles_prepare_shared_inputs_once(self) -> None:

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -68,13 +68,14 @@ independent Harbor job that can be retried and published separately.
 
 `bench:matrix:dev` reads `config/models.dev.yaml` and runs Haiku 4.5 once over
 every matching task. `bench:matrix:production` reads
-`config/models.production.yaml` and runs Haiku 4.5, Sonnet 5, GPT-5.4 mini, and
-GPT-5.4 three times per task. Both commands run the full Tempo suite unless
+`config/models.production.yaml` and runs Fable 5, Opus 4.8, Haiku 4.5,
+Sonnet 5, GPT-5.4 mini, GPT-5.6 Sol, GPT-5.5 Pro, GPT-5.6 Terra, and GPT-5.6
+Luna three times per task. Both commands run the full Tempo suite unless
 `--task-filter` is provided. `--concurrency` applies independently to each
-profile job. Because `--profile all` runs the two profile jobs in parallel,
-the default `--concurrency 16` allows up to 16 trials in each job, or 32 across
-the pair.
-The model configs use a per-provider, per-profile agent concurrency cap of 16.
+profile job. Because `--profile all` runs the two profile jobs in parallel, the
+production default of 8 allows up to 8 trials in each job, or 16 across the
+pair. The production model config uses a per-provider, per-profile agent
+concurrency cap of 4.
 
 ```bash
 # Clean local oracle validation for the suite.
@@ -104,7 +105,7 @@ npm run bench:matrix:dev -- --task-suite tempo --profile mcp \
   --task-filter transfer-with-memo \
   --agent-image "$AGENT_IMAGE" --verifier-image "$VERIFIER_IMAGE"
 
-# Full four-model, three-attempt production suite with both profiles.
+# Full nine-model, three-attempt production suite with both profiles.
 npm run bench:matrix:production -- --task-suite tempo --profile all \
   --agent-image "$AGENT_IMAGE" --verifier-image "$VERIFIER_IMAGE"
 


### PR DESCRIPTION
## Motivation

Broaden the production benchmark across current Claude and OpenAI capability and cost tiers while keeping provider pressure conservative.

## Summary

- add Claude Fable 5 and Opus 4.8 to the production matrix
- add GPT-5.6 Sol, Terra, and Luna plus GPT-5.5 Pro while retaining GPT-5.4 Mini
- keep all models on Harbor-native Claude Code and Codex agents with shared provider concurrency pools
- set production to 8 trials per profile and 4 agent phases per provider pool
- document and test the exact nine-model production lineup

## Key design considerations

- use dated provider snapshots where available and canonical model IDs otherwise
- keep the development matrix unchanged
- keep CLI concurrency overrides available for individual runs