### PR TITLE
chore: update pinned Tempo docs revision

### DIFF
--- a/config/tempo-docs.lock.json
+++ b/config/tempo-docs.lock.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "repo": "https://github.com/tempoxyz/docs.git",
-  "sha": "9aa9de6399970f31a688a08de3287f8f18415d42"
+  "sha": "24479d5336b6c55ae299b3b5bead4b9d7f096ae5"
 }


### PR DESCRIPTION
## Summary

- update the pinned Tempo docs revision from `9aa9de6399970f31a688a08de3287f8f18415d42` to `24479d5336b6c55ae299b3b5bead4b9d7f096ae5`
- align pinned Docs and MCP profile bundles with the latest `tempoxyz/docs` `main` revision

## Validation

- `npm run check`
- `npm run check:generated`
- pinned docs bundle preparation and validation