### PR TITLE
chore: update production model matrix defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ per-profile model caps.
 
 Production model configs pin the candidate and judge model IDs. The runner also
 requires a clean checkout and a full docs SHA, then records `TEMPO_EVALS_SHA`
-and `TEMPO_DOCS_SHA` in Harbor's generated `lock.json`.
+and `TEMPO_DOCS_SHA` in Harbor's generated `lock.json`. Production runs retry
+transient trial and setup failures up to four times by default; use
+`--max-retries` to override that limit.
 
 Jobs are written under `jobs/` and are not uploaded automatically:
 

--- a/config/models.production.yaml
+++ b/config/models.production.yaml
@@ -40,11 +40,6 @@ models:
     concurrency_group: openai
 
   - agent: codex
-    model_name: gpt-5.5-pro-2026-04-23
-    n_concurrent: 4
-    concurrency_group: openai
-
-  - agent: codex
     model_name: gpt-5.6-terra
     n_concurrent: 4
     concurrency_group: openai

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -100,7 +100,7 @@ Options:
                           (default: model config value, otherwise 16)
   --agent-concurrency N   Override per-profile agent concurrency pools
   --max-retries N         Retry transient trial/setup failures
-                          (default: 2 for Daytona runs)
+                          (default: 4 for production, 2 for other Daytona runs)
   --agent NAME            Agent for the model variant (default: claude-code)
   --model NAME            Model for the model variant (default: haiku)
   --task-filter GLOB      Include matching task names for model and config variants
@@ -633,7 +633,7 @@ def run_production_variant(
     rendered = render_job_config(job, benchmark=None)
     rendered["verifier"]["env"].update(production_revision_env(options))
     config = stage_daytona_config(rendered, run_id, docs_bundle, options)
-    max_retries = options.get("max_retries") or "2"
+    max_retries = options.get("max_retries") or "4"
     args = ["run", "harbor", "run", "-c", config]
     if options.get("env_file"):
         args.extend(["--env-file", options["env_file"]])

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -293,7 +293,6 @@ class RunBenchmarkTest(unittest.TestCase):
                 "claude-sonnet-5",
                 "gpt-5.4-mini-2026-03-17",
                 "gpt-5.6-sol",
-                "gpt-5.5-pro-2026-04-23",
                 "gpt-5.6-terra",
                 "gpt-5.6-luna",
             ],
@@ -301,7 +300,7 @@ class RunBenchmarkTest(unittest.TestCase):
         self.assertEqual([model["n_concurrent"] for model in dev["models"]], ["16"])
         self.assertEqual(
             [model["n_concurrent"] for model in production["models"]],
-            ["4"] * 9,
+            ["4"] * 8,
         )
         self.assertEqual(
             production_job("test-run", production, {})["n_concurrent_trials"], 8
@@ -311,7 +310,7 @@ class RunBenchmarkTest(unittest.TestCase):
                 (model["agent"], model["concurrency_group"])
                 for model in production["models"]
             ],
-            [("claude-code", "anthropic")] * 4 + [("codex", "openai")] * 5,
+            [("claude-code", "anthropic")] * 4 + [("codex", "openai")] * 4,
         )
 
     def test_production_profiles_prepare_shared_inputs_once(self) -> None:
@@ -446,7 +445,7 @@ class RunBenchmarkTest(unittest.TestCase):
             patch(
                 "scripts.run_benchmark.stage_daytona_config", return_value="job.yaml"
             ) as stage,
-            patch("scripts.run_benchmark.run_status", return_value=0),
+            patch("scripts.run_benchmark.run_status", return_value=0) as run_status,
         ):
             run_production_variant(run_id, {"task_suite": "mpp"}, None)
 
@@ -459,6 +458,19 @@ class RunBenchmarkTest(unittest.TestCase):
                 "TEMPO_EVALS_SHA": "a" * 40,
                 "TEMPO_DOCS_SHA": "b" * 40,
             },
+        )
+        run_status.assert_called_once_with(
+            "uv",
+            [
+                "run",
+                "harbor",
+                "run",
+                "-c",
+                "job.yaml",
+                "--max-retries",
+                "4",
+                "-y",
+            ],
         )
 
     def test_production_revision_env_requires_clean_full_shas(self) -> None:

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -69,8 +69,8 @@ independent Harbor job that can be retried and published separately.
 `bench:matrix:dev` reads `config/models.dev.yaml` and runs Haiku 4.5 once over
 every matching task. `bench:matrix:production` reads
 `config/models.production.yaml` and runs Fable 5, Opus 4.8, Haiku 4.5,
-Sonnet 5, GPT-5.4 mini, GPT-5.6 Sol, GPT-5.5 Pro, GPT-5.6 Terra, and GPT-5.6
-Luna three times per task. Both commands run the full Tempo suite unless
+Sonnet 5, GPT-5.4 mini, GPT-5.6 Sol, GPT-5.6 Terra, and GPT-5.6 Luna three
+times per task. Both commands run the full Tempo suite unless
 `--task-filter` is provided. `--concurrency` applies independently to each
 profile job. Because `--profile all` runs the two profile jobs in parallel, the
 production default of 8 allows up to 8 trials in each job, or 16 across the
@@ -105,7 +105,7 @@ npm run bench:matrix:dev -- --task-suite tempo --profile mcp \
   --task-filter transfer-with-memo \
   --agent-image "$AGENT_IMAGE" --verifier-image "$VERIFIER_IMAGE"
 
-# Full nine-model, three-attempt production suite with both profiles.
+# Full eight-model, three-attempt production suite with both profiles.
 npm run bench:matrix:production -- --task-suite tempo --profile all \
   --agent-image "$AGENT_IMAGE" --verifier-image "$VERIFIER_IMAGE"
 


### PR DESCRIPTION
## Motivation

Keep the production matrix aligned with the desired model set and make production runs more resilient to transient failures.

## Summary

- Remove GPT-5.5 Pro from the production model matrix and suite runbook.
- Default production trial and setup retries to four.

## Key design considerations

- The retry change is scoped to production Daytona runs; other Daytona variants continue to default to two retries.
- `--max-retries` remains available as an explicit override.