### PR TITLE
chore: restore production concurrency

### DIFF
--- a/config/models.production.yaml
+++ b/config/models.production.yaml
@@ -3,48 +3,48 @@
 # Models from one provider share a per-profile `n_concurrent` pool.
 # `--agent-concurrency N` overrides these limits for the run.
 judge_model: anthropic/claude-haiku-4-5-20251001
-n_concurrent_trials: 8
+n_concurrent_trials: 16
 
 models:
   - agent: claude-code
     # Fable 5 uses a canonical ID without a snapshot date.
     model_name: claude-fable-5
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: anthropic
 
   - agent: claude-code
     # Opus 4.8 uses a canonical ID without a snapshot date.
     model_name: claude-opus-4-8
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: anthropic
 
   - agent: claude-code
     model_name: claude-haiku-4-5-20251001
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: anthropic
 
   - agent: claude-code
     # Sonnet 5 uses an immutable canonical ID without a snapshot date.
     model_name: claude-sonnet-5
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: anthropic
 
   - agent: codex
     model_name: gpt-5.4-mini-2026-03-17
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: openai
 
   - agent: codex
     model_name: gpt-5.6-sol
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: openai
 
   - agent: codex
     model_name: gpt-5.6-terra
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: openai
 
   - agent: codex
     model_name: gpt-5.6-luna
-    n_concurrent: 4
+    n_concurrent: 16
     concurrency_group: openai

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -283,7 +283,7 @@ class RunBenchmarkTest(unittest.TestCase):
             production["judge_model"], "anthropic/claude-haiku-4-5-20251001"
         )
         self.assertIsNone(dev["n_concurrent_trials"])
-        self.assertEqual(production["n_concurrent_trials"], "8")
+        self.assertEqual(production["n_concurrent_trials"], "16")
         self.assertEqual(
             [model["model_name"] for model in production["models"]],
             [
@@ -300,10 +300,10 @@ class RunBenchmarkTest(unittest.TestCase):
         self.assertEqual([model["n_concurrent"] for model in dev["models"]], ["16"])
         self.assertEqual(
             [model["n_concurrent"] for model in production["models"]],
-            ["4"] * 8,
+            ["16"] * 8,
         )
         self.assertEqual(
-            production_job("test-run", production, {})["n_concurrent_trials"], 8
+            production_job("test-run", production, {})["n_concurrent_trials"], 16
         )
         self.assertEqual(
             [

--- a/tasks/tempo-v1/README.md
+++ b/tasks/tempo-v1/README.md
@@ -73,9 +73,9 @@ Sonnet 5, GPT-5.4 mini, GPT-5.6 Sol, GPT-5.6 Terra, and GPT-5.6 Luna three
 times per task. Both commands run the full Tempo suite unless
 `--task-filter` is provided. `--concurrency` applies independently to each
 profile job. Because `--profile all` runs the two profile jobs in parallel, the
-production default of 8 allows up to 8 trials in each job, or 16 across the
+production default of 16 allows up to 16 trials in each job, or 32 across the
 pair. The production model config uses a per-provider, per-profile agent
-concurrency cap of 4.
+concurrency cap of 16.
 
 ```bash
 # Clean local oracle validation for the suite.


### PR DESCRIPTION
## Motivation

PR #146 reduced both production trial concurrency and per-provider agent concurrency, which made full production matrix runs too slow.

## Summary

- Restore the production trial limit from 8 to 16 per profile.
- Restore each production provider pool from 4 to 16 concurrent agent phases.
- Align the production runbook and model-matrix assertions with the restored defaults.

## Key design considerations

- With `--profile all`, Docs and MCP remain separate parallel jobs, so the defaults allow up to 32 concurrent trials across the pair.
- `--concurrency` and `--agent-concurrency` remain available as explicit overrides.