### PR TITLE
docs: label benchmark stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ powered by [Harbor](https://harborframework.com).
 
 ## Suites
 
-| Suite | Dataset | What it measures | Guide |
-| --- | --- | --- | --- |
-| Tempo integration | `tempo/tempo-bench-v1` | TypeScript integrations that submit and verify Tempo testnet transactions | [tasks/tempo-v1](tasks/tempo-v1/README.md) |
-| Tempo MCP efficiency | `tempo/tempo-mcp-bench-v1` | Live Tempo investigations using direct documentation tools or `docs_code` | [tasks/tempo-mcp-v1](tasks/tempo-mcp-v1/README.md) |
-| MPP integration | `tempo/mpp-bench-v1` | Paid HTTP and MCP services and clients on Tempo testnet | [tasks/mpp](tasks/mpp/README.md) |
+| Suite | Status | Dataset | What it measures | Guide |
+| --- | --- | --- | --- | --- |
+| Tempo integration | v1 | `tempo/tempo-bench-v1` | TypeScript integrations that submit and verify Tempo testnet transactions | [tasks/tempo-v1](tasks/tempo-v1/README.md) |
+| Tempo MCP efficiency | v1 | `tempo/tempo-mcp-bench-v1` | Live Tempo investigations using direct documentation tools or `docs_code` | [tasks/tempo-mcp-v1](tasks/tempo-mcp-v1/README.md) |
+| MPP integration | Unstable | `tempo/mpp-bench-v1` | Paid HTTP and MCP services and clients on Tempo testnet | [tasks/mpp](tasks/mpp/README.md) |
 
 Suite guides own suite-specific behavior and commands. Task `README.md` files
 are short Harbor Hub descriptions; `instruction.md` files are the agent-facing


### PR DESCRIPTION
## Motivation

Make benchmark maturity visible in the suite overview.

## Summary

- Add a status label for every benchmark
- Mark the Tempo benchmarks as v1 and MPP as unstable

## Key design considerations

- Retains the existing dataset identifiers while exposing their maturity separately