### PR TITLE
fix: simplify benchmark validation and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,17 @@ and documentation.
 
 ## Setup
 
-Requirements: Docker, Node.js with `npm`, and
-[`uv`](https://docs.astral.sh/uv/).
+Requirements: Docker, Node.js 22 with `npm`, and
+[`uv`](https://docs.astral.sh/uv/). `uv` installs the Python 3.13 CI runtime.
 
 ```bash
-uv sync
-npm run docs:prepare
+uv sync --python 3.13 --locked
+npm ci
+npm run task:lint
 ```
 
-For remote runs, install Harbor with Daytona support:
-
-```bash
-uv tool install 'harbor[daytona]'
-```
+The last command is credential-free and prints `Task lint passed.` Harbor,
+including Daytona support, is installed by `uv sync`.
 
 ## Run Benchmarks
 

--- a/ci_checks/check-compose-host-binds.sh
+++ b/ci_checks/check-compose-host-binds.sh
@@ -28,10 +28,13 @@
 # style sources.
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d | sort)
-else
-    TASK_DIRS="$*"
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 FAILED=0
 for task_dir in $TASK_DIRS; do

--- a/ci_checks/check-instruction-suffix.sh
+++ b/ci_checks/check-instruction-suffix.sh
@@ -12,10 +12,13 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d)
-else
-    TASK_DIRS="$*"
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/ci_checks/check-nproc.sh
+++ b/ci_checks/check-nproc.sh
@@ -14,10 +14,13 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d)
-else
-    TASK_DIRS="$*"
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/ci_checks/check-pip-pinning.sh
+++ b/ci_checks/check-pip-pinning.sh
@@ -22,10 +22,13 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d)
-else
-    TASK_DIRS="$*"
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/ci_checks/check-pytest-version.sh
+++ b/ci_checks/check-pytest-version.sh
@@ -16,10 +16,13 @@ CANONICAL_CTRF="0.5.2"
 set -e
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d)
-else
-    TASK_DIRS="$*"
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/ci_checks/check-task-absolute-path.sh
+++ b/ci_checks/check-task-absolute-path.sh
@@ -4,8 +4,7 @@
 # This ensures tasks don't have implicit assumptions about working directory
 #
 # Usage:
-#   ./check-task-absolute-path.sh                    # Check all tasks
-#   ./check-task-absolute-path.sh tasks/task1/       # Check specific tasks
+#   ./check-task-absolute-path.sh tasks/tempo-v1/set-fee-token
 #
 # This script checks for:
 # 1. File paths in task instructions that should be absolute (starting with /)
@@ -115,19 +114,14 @@ $subdir_paths"
     echo -e "$issues"
 }
 
-# Get list of task directories to check (either from arguments or check all tasks)
 if [ $# -eq 0 ]; then
-    # If no arguments, check all task directories
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d | sort)
-else
-    # If arguments provided, use those directories
-    TASK_DIRS=""
-    for arg in "$@"; do
-        if [ -d "$arg" ]; then
-            TASK_DIRS="$TASK_DIRS $arg"
-        fi
-    done
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/ci_checks/check-trial-network-fetch.sh
+++ b/ci_checks/check-trial-network-fetch.sh
@@ -31,15 +31,13 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d)
-else
-    TASK_DIRS=""
-    for task_dir in "$@"; do
-        if [ -d "$task_dir" ]; then
-            TASK_DIRS="$TASK_DIRS $task_dir"
-        fi
-    done
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/ci_checks/check-verifier-tooling-baked.sh
+++ b/ci_checks/check-verifier-tooling-baked.sh
@@ -24,13 +24,13 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    TASK_DIRS=$(find tasks -mindepth 1 -maxdepth 1 -type d)
-else
-    TASK_DIRS=""
-    for task_dir in "$@"; do
-        [ -d "$task_dir" ] && TASK_DIRS="$TASK_DIRS $task_dir"
-    done
+    echo "Usage: $0 TASK_DIR [TASK_DIR ...]" >&2
+    exit 2
 fi
+for task_dir in "$@"; do
+    [ -f "$task_dir/task.toml" ] || { echo "Not a task directory: $task_dir" >&2; exit 2; }
+done
+TASK_DIRS="$*"
 
 if [ -z "$TASK_DIRS" ]; then
     echo "No task directories to check"

--- a/config/variants.yaml
+++ b/config/variants.yaml
@@ -83,7 +83,6 @@ variants:
   model:
     benchmark: tempo
     prefix: model-local
-    path: tasks/tempo-v1
     default_agent: claude-code
     default_model: haiku
     needs_agent_auth: true

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -60,6 +60,12 @@ MCP_ORACLE_DOCS_TOOLS = {
     MCP_DIRECT_PROFILE["id"]: "docs_search",
     MCP_CODE_PROFILE["id"]: "docs_code",
 }
+SUITE_PROFILES = {
+    "tempo": (DOCS_PROFILE["id"], MCP_PROFILE["id"], "all"),
+    "tempo-mcp": (MCP_DIRECT_PROFILE["id"], MCP_CODE_PROFILE["id"], "mcp-both"),
+    "mpp": (DOCS_PROFILE["id"],),
+    "all": (DOCS_PROFILE["id"],),
+}
 _IMAGE_BUILD_LOCK = Lock()
 _images_built = False
 
@@ -320,6 +326,35 @@ def task_paths(options: dict[str, Any]) -> list[str]:
     }
     suite = options.get("task_suite") or "tempo"
     return list(paths.values()) if suite == "all" else [paths[suite]]
+
+
+def validate_run_options(variant_name: str, options: dict[str, Any]) -> dict[str, Any]:
+    variant = VARIANTS.get(variant_name)
+    if not variant:
+        raise RuntimeError(f"Unknown variant: {variant_name}")
+
+    suite = options.get("task_suite") or "tempo"
+    profile = options["profile"]
+    profiles = SUITE_PROFILES[suite]
+    if profile not in profiles:
+        choices = ", ".join(profiles)
+        raise RuntimeError(
+            f"--profile {profile} is not valid for --task-suite {suite}; use {choices}"
+        )
+
+    job_agents = variant.get("job", {}).get("agents", [])
+    if suite == "all" and (
+        not job_agents or any(agent.get("name") != "oracle" for agent in job_agents)
+    ):
+        raise RuntimeError("--task-suite all requires an oracle variant")
+
+    if (
+        not variant.get("job")
+        and not variant.get("production")
+        and profile != DOCS_PROFILE["id"]
+    ):
+        raise RuntimeError("Non-Docs profiles require a job-backed variant")
+    return variant
 
 
 def sync_generated() -> None:
@@ -619,6 +654,17 @@ def production_job(
     }
 
 
+def harbor_flags(options: dict[str, Any]) -> list[str]:
+    names = (
+        "no_force_build",
+        "no_delete",
+        "disable_verification",
+        "install_only",
+        "debug",
+    )
+    return [f"--{name.replace('_', '-')}" for name in names if options.get(name)]
+
+
 def run_production_variant(
     run_id: str,
     options: dict[str, Any],
@@ -637,6 +683,7 @@ def run_production_variant(
     args = ["run", "harbor", "run", "-c", config]
     if options.get("env_file"):
         args.extend(["--env-file", options["env_file"]])
+    args.extend(harbor_flags(options))
     args.extend(["--max-retries", max_retries])
     os.environ["TEMPO_DOCS_BUNDLE_PATH"] = ""
     args.append("-y")
@@ -1095,14 +1142,7 @@ def main(argv: list[str]) -> None:
         return
 
     if options["profile"] in {"all", "mcp-both"}:
-        variant = VARIANTS.get(variant_name)
-        if not variant:
-            usage()
-            raise RuntimeError(f"Unknown variant: {variant_name}")
-        if not variant.get("job") and not variant.get("production"):
-            raise RuntimeError(
-                "The all profile requires a job-backed or production benchmark variant."
-            )
+        variant = validate_run_options(variant_name, options)
         if variant.get("production"):
             prepare_production_profiles(variant, options)
         elif options["sync"]:
@@ -1153,26 +1193,7 @@ def main(argv: list[str]) -> None:
 
 
 def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
-
-    variant = VARIANTS.get(variant_name)
-    if not variant:
-        usage()
-        msg = f"Unknown variant: {variant_name}"
-        raise RuntimeError(msg)
-
-    if (
-        options["profile"]
-        in {
-            MCP_PROFILE["id"],
-            MCP_DIRECT_PROFILE["id"],
-            MCP_CODE_PROFILE["id"],
-        }
-        and not variant.get("job")
-        and not variant.get("production")
-    ):
-        raise RuntimeError(
-            "The MCP profile requires a job-backed or production benchmark variant."
-        )
+    variant = validate_run_options(variant_name, options)
 
     source = {"mode": "live"} if uses_live_mcp_eval(options) else docs_source(options)
     load_env_file(options.get("env_file"))
@@ -1210,7 +1231,7 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
         args.extend(
             [
                 "--path",
-                options.get("tasks") or variant.get("path") or "tasks/tempo-v1",
+                task_paths(options)[0],
             ]
         )
         args.extend(
@@ -1233,16 +1254,7 @@ def run_benchmark_variant(variant_name: str, options: dict[str, Any]) -> None:
         args.extend(["--n-concurrent", options["concurrency"]])
     if options.get("agent_concurrency"):
         args.extend(["--n-concurrent-agents", options["agent_concurrency"]])
-    if options.get("no_force_build"):
-        args.append("--no-force-build")
-    if options.get("no_delete"):
-        args.append("--no-delete")
-    if options.get("disable_verification"):
-        args.append("--disable-verification")
-    if options.get("install_only"):
-        args.append("--install-only")
-    if options.get("debug"):
-        args.append("--debug")
+    args.extend(harbor_flags(options))
     max_retries = options.get("max_retries") or (
         "2" if variant.get("needs_daytona_auth") else None
     )

--- a/scripts/run_benchmark_test.py
+++ b/scripts/run_benchmark_test.py
@@ -33,6 +33,7 @@ from scripts.run_benchmark import (
     stage_pinned_docs_task,
     sync_dataset,
     uses_live_mcp_eval,
+    validate_run_options,
     versioned_name,
 )
 
@@ -402,6 +403,58 @@ class RunBenchmarkTest(unittest.TestCase):
 
         self.assertEqual(options["n_attempts"], "1")
 
+    def test_model_uses_the_requested_task_suite(self) -> None:
+        options = {
+            "env_file": None,
+            "job_name": "mpp-model-test",
+            "profile": "docs",
+            "sync": False,
+            "task_suite": "mpp",
+        }
+        with (
+            patch("scripts.run_benchmark.preflight"),
+            patch("scripts.run_benchmark.build_images"),
+            patch("scripts.run_benchmark.docs_source", return_value={"mode": "public"}),
+            patch("scripts.run_benchmark.ensure_docs_bundle", return_value=None),
+            patch("scripts.run_benchmark.run") as run,
+        ):
+            run_benchmark_variant("model", options)
+
+        self.assertEqual(
+            run.call_args.args[1][3:5],
+            ["--path", "tasks/mpp"],
+        )
+
+    def test_suite_profiles_are_validated_before_running(self) -> None:
+        for suite, profile in (
+            ("tempo", "mcp-direct"),
+            ("tempo-mcp", "mcp"),
+            ("mpp", "mcp"),
+            ("all", "all"),
+        ):
+            with (
+                self.subTest(suite=suite, profile=profile),
+                self.assertRaisesRegex(RuntimeError, "is not valid"),
+            ):
+                validate_run_options(
+                    "local-agent", {"task_suite": suite, "profile": profile}
+                )
+
+    def test_model_rejects_the_all_suite(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "requires an oracle variant"):
+            validate_run_options("model", {"task_suite": "all", "profile": "docs"})
+
+    def test_all_suite_rejects_agent_runs_before_work(self) -> None:
+        with patch("scripts.run_benchmark.preflight") as preflight:
+            for variant in ("local-agent", "production-daytona"):
+                with (
+                    self.subTest(variant=variant),
+                    self.assertRaisesRegex(RuntimeError, "requires an oracle variant"),
+                ):
+                    main([variant, "--task-suite", "all"])
+
+        preflight.assert_not_called()
+
     def test_production_job_uses_native_name_and_requested_attempts(self) -> None:
         run_id = "mpp-bench-v1-production-20260714T202823Z-docs"
         job = production_job(
@@ -447,7 +500,17 @@ class RunBenchmarkTest(unittest.TestCase):
             ) as stage,
             patch("scripts.run_benchmark.run_status", return_value=0) as run_status,
         ):
-            run_production_variant(run_id, {"task_suite": "mpp"}, None)
+            run_production_variant(
+                run_id,
+                {
+                    "task_suite": "mpp",
+                    "no_delete": True,
+                    "disable_verification": True,
+                    "install_only": True,
+                    "debug": True,
+                },
+                None,
+            )
 
         self.assertEqual(stage.call_args.args[0]["job_name"], run_id)
         self.assertEqual(
@@ -467,6 +530,10 @@ class RunBenchmarkTest(unittest.TestCase):
                 "run",
                 "-c",
                 "job.yaml",
+                "--no-delete",
+                "--disable-verification",
+                "--install-only",
+                "--debug",
                 "--max-retries",
                 "4",
                 "-y",


### PR DESCRIPTION
## Motivation

Benchmark commands currently accept incompatible suite/profile combinations, silently ignore several production flags, and can run the wrong suite through `bench:model`. The local static-check fallback and setup path also promise behavior they do not provide.

## Summary

- validate suite/profile/variant combinations before any run setup
- share Harbor flag forwarding and select direct model task paths from `--task-suite`
- require explicit leaf task directories for static checks instead of broken auto-discovery
- use the locked project toolchain for setup and remove redundant install steps

## Key design considerations

- reuse existing suite, variant, and task-path data rather than adding a new command layer
- keep exception handling centralized in CI
- preserve the existing npm entry points