### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -65,11 +65,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
-      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      - uses: tempoxyz/gh-actions/vendor/docker/login-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build and push agent image
         if: steps.images.outputs.agent_exists != 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: .
           file: shared/global/docker/agent/Dockerfile
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build and push verifier image
         if: steps.images.outputs.verifier_exists != 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: .
           file: shared/global/docker/verifier/Dockerfile

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -65,11 +65,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      - uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
 
-      - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
 
-      - uses: tempoxyz/gh-actions/vendor/docker/login-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      - uses: tempoxyz/gh-actions/vendor/docker/login-action@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build and push agent image
         if: steps.images.outputs.agent_exists != 'true'
-        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           context: .
           file: shared/global/docker/agent/Dockerfile
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build and push verifier image
         if: steps.images.outputs.verifier_exists != 'true'
-        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           context: .
           file: shared/global/docker/verifier/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: npm
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: npm
 
       - name: Set up uv
-        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `astral-sh/setup-uv` | [`tempoxyz/gh-actions/vendor/astral-sh/setup-uv`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/astral-sh/setup-uv) |
| `docker/build-push-action` | [`tempoxyz/gh-actions/vendor/docker/build-push-action`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/docker/build-push-action) |
| `docker/login-action` | [`tempoxyz/gh-actions/vendor/docker/login-action`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/docker/login-action) |
| `docker/setup-buildx-action` | [`tempoxyz/gh-actions/vendor/docker/setup-buildx-action`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/docker/setup-buildx-action) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 0 -> 0, zizmor 18 -> 17).
